### PR TITLE
docs: name the product ChatChart

### DIFF
--- a/.ai/mission.md
+++ b/.ai/mission.md
@@ -11,7 +11,7 @@ read_when: [onboarding, planning, architecture]
 
 ## What this project is
 
-{{PROJECT_NAME}} — {{ONE_SENTENCE_DESCRIPTION}}
+ChatChart — {{ONE_SENTENCE_DESCRIPTION}}
 
 | Field | Value |
 |-------|-------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ conflict, follow the authority order in [.ai/README.md](.ai/README.md)
 
 | Field | Value |
 |-------|-------|
-| Project | {{PROJECT_NAME}} — see [.ai/mission.md](.ai/mission.md) |
+| Project | ChatChart — see [.ai/mission.md](.ai/mission.md) |
 | Stack | {{STACK}} |
 | Architecture | Modular monolith, Clean Architecture, DDD — [.ai/architecture.md](.ai/architecture.md) |
 | Branching | GitHub Flow; `main` always releasable |

--- a/docs/discovery-log.md
+++ b/docs/discovery-log.md
@@ -1,6 +1,6 @@
 ---
 id: discovery-log
-title: Discovery Log — マルチテナント型 AI-BI SaaS（Evidence × MCP）
+title: Discovery Log — ChatChart（マルチテナント型 AI-BI SaaS / Evidence × MCP）
 updated: 2026-07-16
 ---
 
@@ -11,7 +11,7 @@ updated: 2026-07-16
   product-discovery record; translation deferred, tracked alongside ADR-0005's.
 -->
 
-# 【検討サマリ 統合版】マルチテナント型 AI-BI SaaS（Evidence × MCP）
+# 【検討サマリ 統合版】ChatChart — マルチテナント型 AI-BI SaaS（Evidence × MCP）
 
 > 本書は、これまでの対話で決まったこと・設計・数字・評価を1本に統合したもの。
 > 末尾 §8 に「**まだ答えが出ていない問い（Claude側の疑問点）**」を正直に列挙している。ここが次に埋めるべき穴。

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,6 +1,6 @@
 ---
 id: requirements
-title: 要件定義書 — マルチテナント型 AI-BI SaaS（Evidence × MCP）
+title: 要件定義書 — ChatChart（マルチテナント型 AI-BI SaaS / Evidence × MCP）
 status: draft
 updated: 2026-07-16
 ---
@@ -14,7 +14,7 @@ updated: 2026-07-16
   the session narrative and open questions behind these decisions.
 -->
 
-# 【要件定義書 v1】マルチテナント型 AI-BI SaaS（Evidence × MCP）
+# 【要件定義書 v1】ChatChart — マルチテナント型 AI-BI SaaS（Evidence × MCP）
 
 > **v1の立ち位置**：v0（統合要件定義書）で見えた3つの楽観——①静的SSGとアクセス制御の矛盾、②サポート原価とCACの欠落、③工数の過小——を「設計判断」として潰したバージョン。数字は"守り"で引き直し、獲得とセキュリティ証明を工程に組み込む。**動くデモではなく、売れる最小プロダクトを定義する**ことを目的とする。
 


### PR DESCRIPTION
## What

Names the product **ChatChart** in-repo, ahead of the GitHub repo rename to `chat-chart`.

- Fills the never-instantiated `{{PROJECT_NAME}}` placeholder in `CLAUDE.md` and `.ai/mission.md`.
- Adds "ChatChart" to the title/H1 of `docs/requirements.md` and `docs/discovery-log.md`, which previously only carried a generic description ("マルチテナント型 AI-BI SaaS（Evidence × MCP）") with no proper noun.

## Explicitly left unchanged (and why)

| Location | Reason |
|---|---|
| `README.md` title ("ai-dev-foundation") | Describes the template scaffold itself, not the product being built inside it |
| ADR-0005 title | Names the architectural decision, not the product |
| `kotonoha-bi-dev` in `spikes/nl2sql-thelook/run_thelook.py` | A real GCP project ID (external resource), not a product-name reference — renaming the string wouldn't rename the actual GCP project |

## Related

The repo itself is being renamed `kotonoha-bi` → `chat-chart` on GitHub (owner's side). This PR is the documentation half of that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)