### PR TITLE
chore: wire the TypeScript/Node toolchain (Makefile profile + CI runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # TEMPLATE: add your runtime setup action here (setup-node / setup-python / setup-go)
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
       - run: make setup
       - run: make lint
 
@@ -27,6 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
       - run: make setup
       - run: make coverage
       - name: Upload coverage artifact
@@ -40,6 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
       - run: make setup
       - run: make build
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,10 @@
+# Prettier owns only the product source (src/, tests/) and root JSON configs.
+# Docs/spikes/templates keep their existing formatting; mdformat (pre-commit)
+# owns Markdown.
+/*
+!/src/
+!/tests/
+!/package.json
+!/tsconfig.json
+!/.prettierrc.json
+*.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "printWidth": 100,
+  "singleQuote": true
+}

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-# Canonical command interface (CLAUDE.md §11).
-# Every agent, hook, and CI job calls ONLY these targets, so automation stays stable
-# across stacks. TEMPLATE: replace each no-op with your project's real commands and
-# delete the placeholder echo — or start from a reference implementation in profiles/
-# (contract semantics: profiles/README.md). Optional FILE=<path> narrows format/lint
-# to one file.
+# Canonical command interface (CLAUDE.md §11) — TypeScript/Node implementation.
+# Adapted from profiles/typescript-node (contract semantics: profiles/README.md).
+# Deliberate deviations, to keep the dependency tree (and its committed lockfile)
+# within GR-020: npm instead of pnpm; node:test instead of Vitest; lint =
+# prettier --check + tsc --noEmit (ESLint added when a rule earns its place).
+# Tests run .ts directly via Node >=24 type stripping (tsconfig erasableSyntaxOnly).
 
 .PHONY: setup format lint test test-unit test-integration coverage build run \
         security-scan sbom clean help doctor
@@ -13,43 +13,56 @@ FILE ?=
 help: ## List available targets
 	@grep -E '^[a-z-]+:.*##' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  make %-18s %s\n", $$1, $$2}'
 
-setup: ## Install toolchain and dependencies
-	@echo "[template] setup: not wired yet — add your install commands here"
+setup: ## Install toolchain: node deps (from lockfile) + git hooks
+	npm ci --no-fund --no-audit
+	@if command -v pre-commit >/dev/null 2>&1; then \
+		pre-commit install --hook-type pre-commit --hook-type pre-push; \
+	else echo "pre-commit not installed — local gates skipped (CI still enforces)"; fi
 
 format: ## Auto-format code (all, or FILE=<path>)
-	@echo "[template] format: not wired yet (e.g. ruff format / prettier --write / gofmt)"
+ifneq ($(FILE),)
+	npx prettier --write --ignore-unknown "$(FILE)"
+else
+	npx prettier --write .
+endif
 
 lint: ## Lint code, zero warnings allowed — COD-001 (all, or FILE=<path>)
-	@echo "[template] lint: not wired yet (e.g. ruff check / eslint / golangci-lint)"
+ifneq ($(FILE),)
+	npx prettier --check --ignore-unknown "$(FILE)"
+else
+	npx prettier --check .
+	npx tsc --noEmit
+endif
 
 test: ## Full test suite (unit + integration) — TST-001
-	@echo "[template] test: not wired yet (e.g. pytest / npm test / go test ./...)"
+	node --test "tests/**/*.test.ts"
 
 test-unit: ## Fast unit suite only, used by pre-commit — TST-001
-	@echo "[template] test-unit: not wired yet"
+	node --test --test-skip-pattern "integration|e2e" "tests/**/*.test.ts"
 
 test-integration: ## Integration suite (may use containers)
-	@echo "[template] test-integration: not wired yet"
+	node --test --test-name-pattern "integration|e2e" "tests/**/*.test.ts"
 
 coverage: ## Test with coverage report — TST-003 ratchet
-	@echo "[template] coverage: not wired yet"
+	node --test --experimental-test-coverage "tests/**/*.test.ts"
 
-build: ## Produce deployable artifact
-	@echo "[template] build: not wired yet"
+build: ## Produce deployable artifact (typecheck-only until the Workers adapter lands)
+	npm run build
 
 run: ## Run the application locally
-	@echo "[template] run: not wired yet"
+	npm run dev
 
 security-scan: ## Local security sweep (secrets + deps + config)
 	@if command -v gitleaks >/dev/null 2>&1; then gitleaks detect --no-banner; else echo "[template] gitleaks not installed — CI still enforces SEC-002"; fi
 	@if command -v trivy >/dev/null 2>&1; then trivy fs --scanners vuln,misconfig,secret --exit-code 1 .; else echo "[template] trivy not installed — CI still enforces SEC-030"; fi
+	npm audit --audit-level=high
 
 sbom: ## Generate SBOM (SPDX + CycloneDX) into ./dist — REL-020
 	@mkdir -p dist
 	@if command -v syft >/dev/null 2>&1; then syft . -o spdx-json=dist/sbom.spdx.json -o cyclonedx-json=dist/sbom.cdx.json && echo "SBOM written to dist/"; else echo "[template] syft not installed — release workflow generates the authoritative SBOM"; fi
 
 clean: ## Remove build artifacts
-	@rm -rf dist
+	@rm -rf dist coverage node_modules/.cache
 
 doctor: ## Self-check the template: metadata invariants + guard-hook tests (foundation-level, stack-independent)
 	@bash scripts/template-check.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "app",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "app",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/node": "^26.1.1",
+        "prettier": "^3.6.0",
+        "typescript": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "dev": "echo 'nothing runnable yet — the gate Workers adapter PR adds a dev server' && exit 1"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "prettier": "^3.6.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/tests/toolchain.test.ts
+++ b/tests/toolchain.test.ts
@@ -1,0 +1,9 @@
+// Smoke test proving the toolchain runs TypeScript through node:test.
+// Replaced by the gate module's acceptance suite (#23) as soon as it lands.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('node runs TypeScript tests with types stripped', () => {
+  const sum = (xs: readonly number[]): number => xs.reduce((a, b) => a + b, 0);
+  assert.equal(sum([1, 2, 3]), 6);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Step 0 of the gate implementation (#23, gated on merged ADR-0006): the repo root still had the template's no-op Makefile and no toolchain. This wires the canonical `make` contract to a real TypeScript/Node stack so the gate module PR can land with tests and lint enforced.

**Deliberate deviations from `profiles/typescript-node`** (documented in the Makefile header) — all chosen to keep the dependency tree and its **committed 67-line lockfile** inside GR-020:

| Profile | Here | Why |
|---|---|---|
| pnpm | npm | no workspace needs; setup-node caching built-in; no corepack friction |
| Vitest | node:test | zero deps; `.ts` runs directly via Node ≥24 type stripping (`erasableSyntaxOnly`) |
| ESLint+prettier+tsc | prettier + tsc --noEmit | ESLint added when a rule earns its place; lockfile stays tiny |

devDependencies: `typescript`, `prettier`, `@types/node` — nothing else.

- Prettier scoped to `src/`, `tests/`, root configs (`.prettierignore`); docs/spikes untouched, mdformat stays the Markdown owner.
- CI: `actions/setup-node` (Node 24 + npm cache) replaces the TEMPLATE placeholder in lint/test/build jobs. `doctor` unchanged (71 guard tests pass).
- Smoke test proves TS-through-node:test; the gate acceptance suite replaces it in the next PR.
- `package.json` name is `app` (COD-005: product name never in identifiers).

## Verification

`make lint` / `make test` / `make coverage` (100%) / `make build` / `make doctor` all green locally.

170 added / 19 removed lines, 8 files — within GR-020 soft limit.

Refs: #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)