### PR TITLE
feat(gate): in-memory + WebCrypto adapters and the ported acceptance suite

### DIFF
--- a/src/modules/gate/infrastructure/memory.ts
+++ b/src/modules/gate/infrastructure/memory.ts
@@ -1,0 +1,167 @@
+// In-memory adapters — the ARC-005 "current second adapter" mandated by
+// ADR-0006 rule 1. They back the acceptance suite (and any local run) and
+// keep the core portable off Cloudflare. TTL semantics mirror Workers KV
+// minus its propagation delay (that delta is covered by design: ADR-0006
+// consequences, revocation ≤60s).
+import type { AuthzContext, RoleGrant, TenantId } from '../domain/types.ts';
+import type {
+  AuditSink,
+  Clock,
+  ControlPlaneReader,
+  KeyValueStore,
+  QueryExecutor,
+} from '../application/ports.ts';
+
+export class MemoryKv<T> implements KeyValueStore<T> {
+  readonly #clock: Clock;
+  readonly #entries = new Map<string, { value: T; expiresAt: number | null }>();
+
+  constructor(clock: Clock) {
+    this.#clock = clock;
+  }
+
+  async get(key: string): Promise<T | undefined> {
+    const e = this.#entries.get(key);
+    if (!e) return undefined;
+    if (e.expiresAt !== null && e.expiresAt <= this.#clock.nowMs()) {
+      this.#entries.delete(key);
+      return undefined;
+    }
+    return e.value;
+  }
+
+  async set(key: string, value: T, ttlMs?: number): Promise<void> {
+    this.#entries.set(key, {
+      value,
+      expiresAt: ttlMs === undefined ? null : this.#clock.nowMs() + ttlMs,
+    });
+  }
+
+  /** Test/ops introspection — not part of the KeyValueStore port. */
+  get size(): number {
+    return this.#entries.size;
+  }
+  keys(): readonly string[] {
+    return [...this.#entries.keys()];
+  }
+  delete(key: string): void {
+    this.#entries.delete(key);
+  }
+}
+
+export interface MemoryUser {
+  readonly tenantId: TenantId;
+  authEpoch: number;
+  readonly roles: readonly string[];
+}
+
+/** Fixture-backed control plane (stand-in for Postgres — 原則D). */
+export class MemoryControlPlane implements ControlPlaneReader {
+  readonly tenants: Map<TenantId, { authEpoch: number }>;
+  readonly users: Map<string, MemoryUser>;
+  readonly roles: Map<TenantId, Map<string, RoleGrant>>;
+  readonly reports: Map<TenantId, Map<string, { reportVersion: number }>>;
+  readonly dataVersions: Map<TenantId, number>;
+
+  constructor(seed: {
+    tenants: Record<TenantId, { authEpoch: number }>;
+    users: Record<string, MemoryUser>;
+    roles: Record<TenantId, Record<string, RoleGrant>>;
+    reports: Record<TenantId, Record<string, { reportVersion: number }>>;
+    dataVersions: Record<TenantId, number>;
+  }) {
+    this.tenants = new Map(Object.entries(seed.tenants));
+    this.users = new Map(Object.entries(seed.users));
+    this.roles = new Map(
+      Object.entries(seed.roles).map(([t, r]) => [t, new Map(Object.entries(r))]),
+    );
+    this.reports = new Map(
+      Object.entries(seed.reports).map(([t, r]) => [t, new Map(Object.entries(r))]),
+    );
+    this.dataVersions = new Map(Object.entries(seed.dataVersions));
+  }
+
+  async getTenantEpoch(tenantId: TenantId): Promise<number | null> {
+    return this.tenants.get(tenantId)?.authEpoch ?? null;
+  }
+
+  async getUser(tenantId: TenantId, userId: string) {
+    const user = this.users.get(userId);
+    if (!user) return null;
+    const grants = user.roles
+      .map((r) => this.roles.get(user.tenantId)?.get(r))
+      .filter((g): g is RoleGrant => g !== undefined);
+    return { tenantId: user.tenantId, authEpoch: user.authEpoch, grants };
+  }
+
+  async getReportVersion(tenantId: TenantId, reportId: string): Promise<number | null> {
+    return this.reports.get(tenantId)?.get(reportId)?.reportVersion ?? null;
+  }
+
+  async getDataVersion(tenantId: TenantId): Promise<number> {
+    return this.dataVersions.get(tenantId) ?? 0;
+  }
+
+  // -- write-side helpers (the future control-plane module's job; used by
+  // -- tests and local admin flows) ------------------------------------------
+
+  bumpDataVersion(tenantId: TenantId): void {
+    this.dataVersions.set(tenantId, (this.dataVersions.get(tenantId) ?? 0) + 1);
+  }
+
+  bumpReportVersion(tenantId: TenantId, reportId: string): void {
+    const report = this.reports.get(tenantId)?.get(reportId);
+    if (report) report.reportVersion += 1;
+  }
+
+  /** Epoch bump — the SoR side of revocation (denylist write is the caller's). */
+  revokeUser(userId: string): void {
+    const user = this.users.get(userId);
+    if (user) user.authEpoch += 1;
+  }
+}
+
+/** Executor stand-in for the MCP gateway, over per-tenant datasets (原則C-3). */
+export class MemoryExecutor implements QueryExecutor {
+  readonly #data: ReadonlyMap<
+    TenantId,
+    readonly { store_id: string; category: string; amount: number }[]
+  >;
+  executorCalls = 0;
+
+  constructor(
+    data: Record<TenantId, readonly { store_id: string; category: string; amount: number }[]>,
+  ) {
+    this.#data = new Map(Object.entries(data));
+  }
+
+  async execute(ctx: AuthzContext, queryId: string) {
+    this.executorCalls += 1;
+    if (queryId !== 'q_sales_by_category')
+      return { ok: false as const, status: 404 as const, reason: 'unknown-query' };
+    let rows = this.#data.get(ctx.tenantId) ?? [];
+    if (ctx.scope.kind === 'stores') {
+      const ids = ctx.scope.storeIds;
+      rows = rows.filter((r) => ids.includes(r.store_id));
+    }
+    const byCategory = new Map<string, number>();
+    for (const r of rows) byCategory.set(r.category, (byCategory.get(r.category) ?? 0) + r.amount);
+    return {
+      ok: true as const,
+      rows: [...byCategory]
+        .map(([category, total]) => ({ category, total }))
+        .sort((a, b) => a.category.localeCompare(b.category)),
+    };
+  }
+}
+
+export class MemoryAuditSink implements AuditSink {
+  readonly events: { tenantId: TenantId; action: string; detail: Record<string, string> }[] = [];
+  async record(event: {
+    tenantId: TenantId;
+    action: string;
+    detail: Readonly<Record<string, string>>;
+  }): Promise<void> {
+    this.events.push({ ...event, detail: { ...event.detail } });
+  }
+}

--- a/src/modules/gate/infrastructure/webcrypto.ts
+++ b/src/modules/gate/infrastructure/webcrypto.ts
@@ -1,0 +1,131 @@
+// WebCrypto-backed adapters — the runtime-portable implementations of the
+// crypto ports (globalThis.crypto exists in both Node >=20 and Cloudflare
+// Workers, per ADR-0006). Verification only: signing belongs to the vendor's
+// backend (ADR-0005 §7) and to test helpers.
+import type { TokenClaims } from '../domain/types.ts';
+import type { Clock, Hasher, TokenVerifier } from '../application/ports.ts';
+
+/**
+ * Public JWK (EC P-256) as stored in the control plane's `vendor_keys`.
+ * Structural type so this file stays free of platform type-lib dependencies.
+ */
+export interface PublicJwk {
+  readonly kty: string;
+  readonly crv: string;
+  readonly x: string;
+  readonly y: string;
+}
+
+export class SystemClock implements Clock {
+  nowMs(): number {
+    return Date.now();
+  }
+}
+
+export class WebCryptoHasher implements Hasher {
+  async sha256hex(input: string): Promise<string> {
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+    return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+  }
+}
+
+function b64urlToBytes(s: string): Uint8Array<ArrayBuffer> {
+  const bin = atob(s.replaceAll('-', '+').replaceAll('_', '/'));
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+interface WireClaims {
+  readonly sub?: unknown;
+  readonly tenant_id?: unknown;
+  readonly sid?: unknown;
+  readonly epoch?: unknown;
+  readonly exp?: unknown;
+  readonly aud?: unknown;
+}
+
+/**
+ * ES256 JWT verifier keyed by `kid` — one public JWK per vendor signing key
+ * (control-plane `vendor_keys`; public keys only, GR-001).
+ */
+export class Es256TokenVerifier implements TokenVerifier {
+  readonly #keys: ReadonlyMap<string, PublicJwk>;
+  readonly #aud: string;
+  readonly #imported = new Map<string, CryptoKey>();
+
+  constructor(keysByKid: ReadonlyMap<string, PublicJwk>, aud: string) {
+    this.#keys = keysByKid;
+    this.#aud = aud;
+  }
+
+  async #key(kid: string): Promise<CryptoKey | null> {
+    const cached = this.#imported.get(kid);
+    if (cached) return cached;
+    const jwk = this.#keys.get(kid);
+    if (!jwk) return null;
+    const key = await crypto.subtle.importKey(
+      'jwk',
+      jwk,
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      false,
+      ['verify'],
+    );
+    this.#imported.set(kid, key);
+    return key;
+  }
+
+  async verify(
+    token: string,
+    nowMs: number,
+  ): Promise<{ ok: true; claims: TokenClaims } | { ok: false; reason: string }> {
+    const parts = token.split('.');
+    if (parts.length !== 3) return { ok: false, reason: 'malformed' };
+    const [h, p, s] = parts as [string, string, string];
+    let kid: string;
+    let wire: WireClaims;
+    try {
+      const header = JSON.parse(new TextDecoder().decode(b64urlToBytes(h))) as {
+        alg?: unknown;
+        kid?: unknown;
+      };
+      if (header.alg !== 'ES256' || typeof header.kid !== 'string')
+        return { ok: false, reason: 'bad-header' };
+      kid = header.kid;
+      wire = JSON.parse(new TextDecoder().decode(b64urlToBytes(p))) as WireClaims;
+    } catch {
+      return { ok: false, reason: 'malformed' };
+    }
+    const key = await this.#key(kid);
+    if (!key) return { ok: false, reason: 'unknown-kid' };
+    const valid = await crypto.subtle.verify(
+      { name: 'ECDSA', hash: 'SHA-256' },
+      key,
+      b64urlToBytes(s),
+      new TextEncoder().encode(`${h}.${p}`),
+    );
+    if (!valid) return { ok: false, reason: 'bad-signature' };
+    if (
+      typeof wire.sub !== 'string' ||
+      typeof wire.tenant_id !== 'string' ||
+      typeof wire.sid !== 'string' ||
+      typeof wire.epoch !== 'number' ||
+      typeof wire.exp !== 'number' ||
+      typeof wire.aud !== 'string'
+    )
+      return { ok: false, reason: 'bad-claims' };
+    if (wire.exp * 1000 <= nowMs) return { ok: false, reason: 'expired' };
+    if (wire.aud !== this.#aud) return { ok: false, reason: 'bad-aud' };
+    return {
+      ok: true,
+      claims: {
+        sub: wire.sub,
+        tenantId: wire.tenant_id,
+        sessionId: wire.sid,
+        epoch: wire.epoch,
+        exp: wire.exp,
+        aud: wire.aud,
+      },
+    };
+  }
+}

--- a/tests/modules/gate/acceptance.test.ts
+++ b/tests/modules/gate/acceptance.test.ts
@@ -1,0 +1,184 @@
+// Acceptance suite — the vertical-slice spike's 12 proofs (LOG-0031) ported
+// onto the real module, per ADR-0006 rule 2. Runs on Node only (in-memory +
+// WebCrypto adapters); the Workers adapter must pass the same suite.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { denyKey, resultKey } from '../../../src/modules/gate/domain/cache-key.ts';
+import { canonicalScope } from '../../../src/modules/gate/domain/scope.ts';
+import { WebCryptoHasher } from '../../../src/modules/gate/infrastructure/webcrypto.ts';
+import { makeHarness } from './helpers.ts';
+
+const REQ = { reportId: 'r_sales', queryId: 'q_sales_by_category' };
+const total = (rows: readonly unknown[]): number =>
+  rows.reduce((sum: number, r) => sum + (r as { total: number }).total, 0);
+
+test('happy path: miss then hit, identical rows', async () => {
+  const h = await makeHarness();
+  const token = await h.mint('alice');
+  const first = await h.gate.requestData(token, REQ);
+  assert.ok(first.ok);
+  assert.equal(first.cached, false);
+  assert.equal(total(first.rows), 157_900);
+  const second = await h.gate.requestData(token, REQ);
+  assert.ok(second.ok);
+  assert.equal(second.cached, true);
+  assert.deepEqual(second.rows, first.rows);
+  assert.equal(h.executor.executorCalls, 1);
+});
+
+test('原則B: forged client tenant_id has zero effect on the key or the data', async () => {
+  const h = await makeHarness();
+  await h.gate.requestData(await h.mint('alice'), REQ); // warm t_alpha's entry
+  const res = await h.gate.requestData(await h.mint('boris'), {
+    ...REQ,
+    clientTenantId: 't_alpha', // attack: bravo user addresses alpha's cache
+  });
+  assert.ok(res.ok);
+  assert.equal(res.cached, false); // key came from ctx → different namespace
+  assert.equal(total(res.rows), 39_500); // bravo's own data only
+  for (const k of h.resultCache.keys()) assert.match(k, /^v1:t_(alpha|bravo):/);
+});
+
+test('JWT tenant claim must match the SoR: bravo user claiming t_alpha is rejected', async () => {
+  const h = await makeHarness();
+  const forged = await h.mint('boris', { tenant_id: 't_alpha' });
+  const res = await h.gate.requestData(forged, REQ);
+  assert.ok(!res.ok);
+  assert.equal(res.status, 401);
+  assert.equal(res.reason, 'unknown-principal');
+});
+
+test('bad signature / expiry / audience are rejected', async () => {
+  const h = await makeHarness();
+  const token = await h.mint('alice');
+  const [hd, pl] = token.split('.') as [string, string, string];
+  const badSig = await h.gate.requestData(`${hd}.${pl}.${'A'.repeat(86)}`, REQ);
+  assert.ok(!badSig.ok && badSig.status === 401);
+  const expired = await h.gate.requestData(await h.mint('alice', { exp: 1 }), REQ);
+  assert.ok(!expired.ok && expired.reason === 'expired');
+  const badAud = await h.gate.requestData(await h.mint('alice', { aud: 'other' }), REQ);
+  assert.ok(!badAud.ok && badAud.reason === 'bad-aud');
+});
+
+test('ADR-0005 §6: different scope → different key; same effective scope → shared cache', async () => {
+  const h = await makeHarness();
+  const manager = await h.gate.requestData(await h.mint('alice'), REQ);
+  const store1 = await h.gate.requestData(await h.mint('bob'), REQ);
+  assert.ok(manager.ok && store1.ok);
+  assert.equal(total(manager.rows), 157_900);
+  assert.equal(total(store1.rows), 65_000); // s1 only
+  assert.equal(h.executor.executorCalls, 2); // scopes differ → no sharing
+  // bev holds a *different role* with the same effective scope as bob
+  const viewer = await h.gate.requestData(await h.mint('bev'), REQ);
+  assert.ok(viewer.ok);
+  assert.equal(viewer.cached, true); // role explosion contained
+  assert.deepEqual(viewer.rows, store1.rows);
+  assert.equal(h.executor.executorCalls, 2);
+});
+
+test('原則C-4: a poisoned entry under the requester-derived key is caught, nothing served', async () => {
+  const h = await makeHarness();
+  // Simulate the worst key-derivation bug: bravo's own key holds alpha's payload.
+  const hasher = new WebCryptoHasher();
+  const bravoKey = resultKey(
+    {
+      tenantId: 't_bravo',
+      allowedReports: ['r_sales'],
+      scope: { kind: 'all' },
+      scopeHash: await hasher.sha256hex(canonicalScope({ kind: 'all' })),
+    },
+    REQ.queryId,
+    await hasher.sha256hex(''),
+    1,
+  );
+  await h.resultCache.set(bravoKey, { tenantId: 't_alpha', rows: [{ category: 'A', total: 1 }] });
+  const res = await h.gate.requestData(await h.mint('boris'), REQ);
+  assert.ok(!res.ok);
+  assert.equal(res.status, 500);
+  assert.equal(res.reason, 'payload-tenant-mismatch');
+  assert.ok(!('rows' in res)); // nothing leaks alongside the error
+});
+
+test('ADR-0005 §5: data_version bump invalidates without purging', async () => {
+  const h = await makeHarness();
+  const token = await h.mint('alice');
+  await h.gate.requestData(token, REQ);
+  h.controlPlane.bumpDataVersion('t_alpha');
+  const res = await h.gate.requestData(token, REQ);
+  assert.ok(res.ok);
+  assert.equal(res.cached, false); // new key → automatic miss
+  assert.equal(h.executor.executorCalls, 2);
+  assert.equal(h.resultCache.size, 2); // old entry left to age out, never served
+});
+
+test('ADR-0005 §5: report edit bumps the shell key', async () => {
+  const h = await makeHarness();
+  const token = await h.mint('alice');
+  const v1 = await h.gate.requestShell(token, 'r_sales');
+  assert.ok(v1.ok && v1.shellKey === 'r_sales:1');
+  h.controlPlane.bumpReportVersion('t_alpha', 'r_sales');
+  const v2 = await h.gate.requestShell(token, 'r_sales');
+  assert.ok(v2.ok && v2.shellKey === 'r_sales:2');
+});
+
+test('revocation: denylist + epoch cut off an unexpired JWT immediately', async () => {
+  const h = await makeHarness();
+  const token = await h.mint('bob'); // valid for 5 minutes
+  const before = await h.gate.requestData(token, REQ);
+  assert.ok(before.ok);
+  // Revoke: epoch bump at the SoR + denylist entry (revocation_events → KV).
+  h.controlPlane.revokeUser('bob');
+  await h.denylist.set(denyKey('bob'), true, 300_000);
+  const denied = await h.gate.requestData(token, REQ);
+  assert.ok(!denied.ok && denied.reason === 'denylisted');
+  // Even once the denylist entry lapses, the epoch mismatch still rejects.
+  h.denylist.delete(denyKey('bob'));
+  const stale = await h.gate.requestData(token, REQ);
+  assert.ok(!stale.ok && stale.reason === 'stale-epoch');
+  // A token minted *after* revocation carries the new epoch and works again.
+  const fresh = await h.gate.requestData(await h.mint('bob'), REQ);
+  assert.ok(fresh.ok);
+});
+
+test('single-flight: concurrent misses on one key execute once', async () => {
+  const h = await makeHarness();
+  const token = await h.mint('alice');
+  const results = await Promise.all(
+    Array.from({ length: 10 }, () => h.gate.requestData(token, REQ)),
+  );
+  assert.ok(results.every((r) => r.ok));
+  assert.equal(h.executor.executorCalls, 1);
+});
+
+test('errors are never cached', async () => {
+  const h = await makeHarness();
+  const res = await h.gate.requestData(await h.mint('alice'), {
+    reportId: 'r_sales',
+    queryId: 'q_nope',
+  });
+  assert.ok(!res.ok);
+  assert.equal(res.status, 404);
+  assert.equal(h.resultCache.size, 0);
+});
+
+test('403 outside allowed_reports; zero grants deny instead of widening', async () => {
+  const h = await makeHarness();
+  const secret = await h.gate.requestData(await h.mint('alice'), {
+    reportId: 'r_secret',
+    queryId: 'q_sales_by_category',
+  });
+  assert.ok(!secret.ok && secret.status === 403);
+  h.controlPlane.users.set('greg', { tenantId: 't_alpha', authEpoch: 0, roles: [] });
+  const grantless = await h.gate.requestData(await h.mint('greg'), REQ);
+  assert.ok(!grantless.ok && grantless.status === 403 && grantless.reason === 'no-grants');
+});
+
+test('③ ctx cache expires by TTL and is rebuilt from the SoR', async () => {
+  const h = await makeHarness({ authzTtlMs: 60_000 });
+  const token = await h.mint('alice');
+  await h.gate.requestData(token, REQ);
+  h.clock.advance(61_000);
+  const res = await h.gate.requestData(token, REQ);
+  assert.ok(res.ok); // rebuilt ctx, same scope → still a ② hit
+  assert.equal(res.cached, true);
+});

--- a/tests/modules/gate/helpers.ts
+++ b/tests/modules/gate/helpers.ts
@@ -1,0 +1,147 @@
+// Test-side vendor simulation + gate wiring. Signing lives here (the vendor's
+// backend signs in production — ADR-0005 §7); the module under test only
+// verifies. Fixture mirrors spikes/vertical-slice (LOG-0031).
+import { GateService } from '../../../src/modules/gate/application/gate-service.ts';
+import type { AuthzEntry, ResultPayload } from '../../../src/modules/gate/application/ports.ts';
+import {
+  MemoryAuditSink,
+  MemoryControlPlane,
+  MemoryExecutor,
+  MemoryKv,
+} from '../../../src/modules/gate/infrastructure/memory.ts';
+import {
+  Es256TokenVerifier,
+  WebCryptoHasher,
+  type PublicJwk,
+} from '../../../src/modules/gate/infrastructure/webcrypto.ts';
+import type { Clock } from '../../../src/modules/gate/application/ports.ts';
+
+const bytesToB64url = (bytes: Uint8Array): string =>
+  btoa(String.fromCharCode(...bytes))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '');
+const jsonB64url = (obj: unknown): string =>
+  bytesToB64url(new TextEncoder().encode(JSON.stringify(obj)));
+
+export class TestClock implements Clock {
+  #now = 1_000_000;
+  nowMs(): number {
+    return this.#now;
+  }
+  advance(ms: number): void {
+    this.#now += ms;
+  }
+}
+
+export interface Vendor {
+  readonly kid: string;
+  readonly publicJwk: PublicJwk;
+  sign(payload: Record<string, unknown>): Promise<string>;
+}
+
+export async function makeVendor(kid = 'k1'): Promise<Vendor> {
+  const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ]);
+  const publicJwk = (await crypto.subtle.exportKey('jwk', pair.publicKey)) as PublicJwk;
+  return {
+    kid,
+    publicJwk,
+    async sign(payload) {
+      const input = `${jsonB64url({ alg: 'ES256', typ: 'JWT', kid })}.${jsonB64url(payload)}`;
+      const sig = await crypto.subtle.sign(
+        { name: 'ECDSA', hash: 'SHA-256' },
+        pair.privateKey,
+        new TextEncoder().encode(input),
+      );
+      return `${input}.${bytesToB64url(new Uint8Array(sig))}`;
+    },
+  };
+}
+
+export function seedControlPlane(): MemoryControlPlane {
+  const all = { kind: 'all' } as const;
+  const s1 = { kind: 'stores', storeIds: ['s1'] } as const;
+  return new MemoryControlPlane({
+    tenants: { t_alpha: { authEpoch: 0 }, t_bravo: { authEpoch: 0 } },
+    users: {
+      alice: { tenantId: 't_alpha', authEpoch: 0, roles: ['manager'] },
+      bob: { tenantId: 't_alpha', authEpoch: 0, roles: ['store1_staff'] },
+      bev: { tenantId: 't_alpha', authEpoch: 0, roles: ['store1_viewer'] },
+      boris: { tenantId: 't_bravo', authEpoch: 0, roles: ['manager'] },
+    },
+    roles: {
+      t_alpha: {
+        manager: { dataScope: all, reports: ['r_sales'] },
+        store1_staff: { dataScope: s1, reports: ['r_sales'] },
+        // Different role, same effective scope → must share cache (ADR-0005 §6)
+        store1_viewer: { dataScope: s1, reports: ['r_sales'] },
+      },
+      t_bravo: { manager: { dataScope: all, reports: ['r_sales'] } },
+    },
+    reports: {
+      t_alpha: { r_sales: { reportVersion: 1 } },
+      t_bravo: { r_sales: { reportVersion: 1 } },
+    },
+    dataVersions: { t_alpha: 1, t_bravo: 1 },
+  });
+}
+
+export const analyticsFixture = {
+  t_alpha: [
+    { store_id: 's1', category: 'A', amount: 40_000 },
+    { store_id: 's1', category: 'B', amount: 25_000 },
+    { store_id: 's2', category: 'A', amount: 52_900 },
+    { store_id: 's2', category: 'C', amount: 30_000 },
+    { store_id: 's2', category: 'D', amount: 10_000 },
+  ],
+  t_bravo: [
+    { store_id: 's9', category: 'X', amount: 20_000 },
+    { store_id: 's9', category: 'Y', amount: 12_000 },
+    { store_id: 's9', category: 'Z', amount: 7_500 },
+  ],
+};
+
+export async function makeHarness(overrides: { authzTtlMs?: number } = {}) {
+  const clock = new TestClock();
+  const vendor = await makeVendor();
+  const controlPlane = seedControlPlane();
+  const executor = new MemoryExecutor(analyticsFixture);
+  const audit = new MemoryAuditSink();
+  const authzCache = new MemoryKv<AuthzEntry>(clock);
+  const resultCache = new MemoryKv<ResultPayload>(clock);
+  const denylist = new MemoryKv<true>(clock);
+  const shellCache = new MemoryKv<string>(clock);
+  const gate = new GateService({
+    verifier: new Es256TokenVerifier(new Map([[vendor.kid, vendor.publicJwk]]), 'gate'),
+    controlPlane,
+    authzCache,
+    resultCache,
+    denylist,
+    shellCache,
+    executor,
+    hasher: new WebCryptoHasher(),
+    audit,
+    clock,
+    ...(overrides.authzTtlMs !== undefined && { authzTtlMs: overrides.authzTtlMs }),
+  });
+
+  async function mint(userId: string, tamper: Record<string, unknown> = {}): Promise<string> {
+    const user = controlPlane.users.get(userId);
+    if (!user) throw new Error(`unknown fixture user ${userId}`);
+    const tenant = controlPlane.tenants.get(user.tenantId);
+    return vendor.sign({
+      sub: userId,
+      tenant_id: user.tenantId,
+      sid: `sess_${userId}`,
+      aud: 'gate',
+      epoch: (tenant?.authEpoch ?? 0) + user.authEpoch,
+      exp: Math.floor(clock.nowMs() / 1000) + 300,
+      ...tamper,
+    });
+  }
+
+  return { gate, clock, vendor, controlPlane, executor, audit, resultCache, denylist, mint };
+}

--- a/tests/toolchain.test.ts
+++ b/tests/toolchain.test.ts
@@ -1,9 +1,0 @@
-// Smoke test proving the toolchain runs TypeScript through node:test.
-// Replaced by the gate module's acceptance suite (#23) as soon as it lands.
-import test from 'node:test';
-import assert from 'node:assert/strict';
-
-test('node runs TypeScript tests with types stripped', () => {
-  const sum = (xs: readonly number[]): number => xs.reduce((a, b) => a + b, 0);
-  assert.equal(sum([1, 2, 3]), 6);
-});


### PR DESCRIPTION
## Summary

Completes the runtime-agnostic half of #23 (follows merged #26):

- **`infrastructure/webcrypto.ts`** — `Es256TokenVerifier` (per-`kid` vendor JWKs, verification only — signing stays on the vendor's backend per ADR-0005 §7), `WebCryptoHasher`, `SystemClock`. `globalThis.crypto` only → identical code on Node and Workers. `PublicJwk` is structural so the file has no platform type-lib dependency.
- **`infrastructure/memory.ts`** — `MemoryKv` (TTL via injected clock), `MemoryControlPlane` (fixture SoR + write-side helpers), `MemoryExecutor` (MCP stand-in over per-tenant datasets), `MemoryAuditSink`. This is the **ARC-005 second adapter** ADR-0006 rule 1 mandates — lock-in insurance + fast Node-only tests.
- **Acceptance suite** (`tests/modules/gate/acceptance.test.ts`): the spike's 12 proofs (LOG-0031) ported per ADR-0006 rule 2, plus a ③ TTL-expiry test:

| Proof | Result |
|---|---|
| 原則B: forged client `tenant_id` param / forged JWT claim both inert | ✅ |
| 原則C-4: poisoned cache entry → 500, serves nothing | ✅ |
| §5: data/report version bumps invalidate with no purge | ✅ |
| §6: distinct roles with same effective scope share one entry | ✅ |
| Revocation: denylist kills an unexpired JWT; epoch keeps it dead; re-mint works | ✅ |
| Single-flight, errors-never-cached, 403 + no-grants deny | ✅ |

Suite total: **24 green** (13 acceptance + 11 domain). The toolchain smoke test is superseded and removed.

## Remaining for #23 (next PR)

`interface/` Workers fetch handler + wrangler config + `.ai/architecture.md` update — that PR needs the Cloudflare account (already created ✅).

## Notes

- GR-020: 629 added / 9 removed, 5 files — over the soft limit, under hard. Adapters and the acceptance suite that proves them belong in one PR (the suite is 200 of the lines); the Workers half is already split out.
- No new dependencies; lockfile untouched.

Refs: #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)