### PR TITLE
build: sync with ai-dev-foundation template

### DIFF
--- a/.ai/documentation.md
+++ b/.ai/documentation.md
@@ -21,14 +21,17 @@ and **optimized for AI readers** — explicit, structured, unambiguous.
 - Every doc starts with YAML frontmatter (`id`, `title`, plus `status`/`updated` where
   meaningful) and states its purpose in the first paragraph.
 - Concrete examples for every rule or API. Fake credentials only (GR-002).
-- English for all `.ai/` and `docs/` content (ADR-0002); user-facing docs may add
-  localized versions as siblings (`README.ja.md`).
+- Foundation-owned instructions and documentation remain English. After template
+  instantiation, AI agents MUST write new project-specific documents under `docs/` in
+  Japanese unless the repository owner or an external contract explicitly requires
+  another language. Do not create a translated sibling solely to duplicate the same
+  facts (ADR-0005).
 - Files use kebab-case names; headings form a strict hierarchy (one `#`, then `##`...).
 
 ## DOC-002: Objective, structured prose
 
 Governs all prose in `.ai/` and `docs/`. `.skills/requirements.skill.md` and
-`docs/templates/requirements.md` build on this rule.
+`docs/foundation/templates/requirements.md` build on this rule.
 
 - **Objective basis.** State each claim with its basis — a measurement, a cited source, a
   standard, or explicit reasoning. Separate established fact, inference, and open
@@ -53,6 +56,8 @@ Governs all prose in `.ai/` and `docs/`. `.skills/requirements.skill.md` and
 | `.ai/` | rules for agents | yes (authority table) |
 | `CLAUDE.md`, `AGENTS.md` | agent entry points | yes |
 | `docs/adr/` | decisions with context | yes (accepted ADRs) |
+| `docs/foundation/` | synchronized foundation-owned guidance and document templates | descriptive |
+| `docs/requirements.md`, `docs/requirements/` | whole-project and initiative requirements | contract |
 | `docs/architecture/` | diagrams, flows, C4 | descriptive |
 | `docs/domain/` | domain model, ubiquitous language | descriptive |
 | `docs/api/` | API contracts (OpenAPI etc.) | contract |
@@ -66,6 +71,7 @@ When a PR contains a change of type X, it MUST update the docs listed:
 
 | Change | Must update |
 |--------|-------------|
+| New/changed project or initiative requirements | `docs/requirements.md` or `docs/requirements/<initiative>.md` |
 | New/changed public API | `docs/api/`, MODULE.md, README if user-facing |
 | New module / boundary change | `docs/architecture/`, MODULE.md, ADR |
 | New env var / config | `.env.example`, `docs/deployment/` |

--- a/.skills/requirements.skill.md
+++ b/.skills/requirements.skill.md
@@ -2,7 +2,7 @@
 name: requirements
 description: Produce a requirements definition document — purpose-driven, zero-based, objective, complete
 triggers: [requirements definition, 要件定義, spec a feature, write requirements, scope a project, interrogate the plan, grill me]
-reads: [.ai/mission.md, .ai/documentation.md, docs/templates/requirements.md]
+reads: [.ai/mission.md, .ai/documentation.md, docs/foundation/templates/requirements.md]
 ---
 
 # Skill: Requirements Definition
@@ -17,7 +17,7 @@ that design and acceptance testing proceed without re-asking.
   or ambiguous enough that two reasonable implementations would diverge, drive it out by
   interrogation (Process step 2) — do not fill the gap with an assumption (CLAUDE.md §13).
 - The success definition: how the requester will judge the result as met.
-- The template: [docs/templates/requirements.md](../docs/templates/requirements.md) —
+- The template: [docs/foundation/templates/requirements.md](../docs/foundation/templates/requirements.md) —
   structure and required sections.
 - Scope boundaries: [.ai/mission.md](../.ai/mission.md). Read other existing docs and code
   only in Process step 4, not before.
@@ -47,6 +47,9 @@ that design and acceptance testing proceed without re-asking.
    a MoSCoW priority with a one-line basis per requirement.
 7. **Fill the template top to bottom.** Define terms, assumptions, and constraints once in
    their sections; reference them by name afterward (DOC-002). Do not restate a definition.
+   After template instantiation, write the completed project document in Japanese and
+   translate the template headings and table labels. Use another language only when the
+   repository owner or an external contract explicitly requires it (ADR-0005).
 8. **Complete the non-functional set** against the ISO/IEC 25010 characteristics that
    apply, and give each NFR a measurement method — a target with no way to verify it is
    not a requirement.
@@ -78,6 +81,8 @@ that design and acceptance testing proceed without re-asking.
 ## Outputs
 - A completed document from the template at `docs/requirements.md` (whole project) or
   `docs/requirements/<initiative>.md` (one initiative).
+- In an instantiated repository, the completed project document is written in Japanese,
+  including headings and table labels, unless an explicit language exception applies.
 - Every FR/NFR carries a unique ID, a priority, and a traced purpose.
 - Open questions listed separately; any §13 escalations raised.
 


### PR DESCRIPTION
## What & why

Apply the non-workflow portion of `ai-dev-foundation` commit `35daa9fc03246b50dbfcd282da754f1b446c094e` after PR #31 established the ADR-0007 ownership boundary. The sync run successfully created and pushed this branch, then stopped because the repository correctly forbids GitHub Actions from creating pull requests; this PR is therefore opened with the maintainer's existing authentication without changing that security setting.

The diff updates the inherited documentation policy and requirements skill so new project-specific documents are written in Japanese and completed requirements live at `docs/requirements.md` or `docs/requirements/` while foundation templates stay under `docs/foundation/`.

Refs: #30

## Change classification (ARC-020)

- [ ] Local (inside one module, contract unchanged)
- [x] Contract (AI documentation and requirements-authoring contract updated; consumers are agents using the inherited skill)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: `git diff --check` passed; `make doctor` passed (71 foundation tests, 4 downstream sync-boundary assertions, 71 guard tests); `make test` passed 36/36. The diff contains only `.ai/documentation.md` and `.skills/requirements.skill.md`, with no `.github/workflows/**` changes.
- Not verified (be honest — GR-042): local `make lint` retains the repository's undeclared-TypeScript baseline blocker described in PR #31; GitHub CI is required before merge.

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: inherited documentation policy and requirements skill are the purpose of this PR

## AI disclosure

- [x] Authored by AI agent: Template Sync bot and Codex review — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes (optional, helps reviewers): the repository variable was returned to `false` immediately after dispatch; GitHub Actions PR-creation permission remains disabled.

## Self-review checklist (WF-090)

- [ ] `make format && make lint && make test` green — doctor/test green; existing local TypeScript lint setup blocker disclosed above; CI required
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)
