### PR TITLE
fix(sync): authenticate foundation documentation propagation

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -25,10 +25,22 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+      - name: Resolve full foundation source commit
+        id: foundation-source
+        shell: bash
+        run: |
+          set -euo pipefail
+          read -r source_sha _ <<< "$(git ls-remote https://github.com/Yukihide-Mitsuoka/ai-dev-foundation.git refs/heads/main)"
+          if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Unable to resolve the full ai-dev-foundation main commit" >&2
+            exit 1
+          fi
+          echo "sha=$source_sha" >> "$GITHUB_OUTPUT"
       - uses: AndreasAugustin/actions-template-sync@v2
         with:
           source_repo_path: "Yukihide-Mitsuoka/ai-dev-foundation"
           upstream_branch: main
           pr_title: "build: sync with ai-dev-foundation template"
+          pr_body: "Foundation-source: https://github.com/Yukihide-Mitsuoka/ai-dev-foundation@${{ steps.foundation-source.outputs.sha }}"
           pr_labels: "type:ci,type:dependencies"
           pr_commit_msg: "build: sync with ai-dev-foundation template"

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -38,8 +38,8 @@ CLAUDE.md
 Makefile
 README.md
 docs/**
-!docs/foundation/
-!docs/foundation/**
+:!docs/foundation/
+:!docs/foundation/**
 profiles/**
 spikes/**
 src/**

--- a/scripts/tests/test_template_sync_ignore.py
+++ b/scripts/tests/test_template_sync_ignore.py
@@ -1,0 +1,25 @@
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+IGNORE_FILE = REPOSITORY_ROOT / ".templatesyncignore"
+
+
+class TemplateSyncIgnoreTest(unittest.TestCase):
+    def test_foundation_docs_use_git_pathspec_exclusions(self):
+        entries = {
+            line.strip()
+            for line in IGNORE_FILE.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        }
+
+        self.assertIn("docs/**", entries)
+        self.assertIn(":!docs/foundation/", entries)
+        self.assertIn(":!docs/foundation/**", entries)
+        self.assertNotIn("!docs/foundation/", entries)
+        self.assertNotIn("!docs/foundation/**", entries)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_template_sync_workflow.py
+++ b/scripts/tests/test_template_sync_workflow.py
@@ -1,0 +1,26 @@
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+WORKFLOW = REPOSITORY_ROOT / ".github" / "workflows" / "template-sync.yml"
+
+
+class TemplateSyncWorkflowTest(unittest.TestCase):
+    def test_pull_request_body_contains_full_foundation_source_commit(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "git ls-remote https://github.com/Yukihide-Mitsuoka/ai-dev-foundation.git",
+            workflow,
+        )
+        self.assertIn(
+            'pr_body: "Foundation-source: '
+            'https://github.com/Yukihide-Mitsuoka/ai-dev-foundation@'
+            '${{ steps.foundation-source.outputs.sha }}"',
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/template-sync-boundary.test.sh
+++ b/tests/template-sync-boundary.test.sh
@@ -18,8 +18,8 @@ expect_rule() {
 
 expect_rule '.github/workflows/**'
 expect_rule 'docs/**'
-expect_rule '!docs/foundation/'
-expect_rule '!docs/foundation/**'
+expect_rule ':!docs/foundation/'
+expect_rule ':!docs/foundation/**'
 
 echo "template-sync-boundary.test.sh: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## What & why

Correct the protected Template Sync boundary so actions-template-sync@v2 re-includes docs/foundation/** using Git pathspec exclusions. Resolve and validate the full direct-parent main commit for generated PR provenance. Update the repository-specific boundary test and add failing-first regression tests for both defects.

Refs: #37

## Change classification (ARC-020)

- [x] Local (protected transport configuration; product contracts unchanged)
- [ ] Contract
- [ ] Architectural

## Breaking change?

- [x] No
- [ ] Yes

## Testing (GR-021 / TST-002)

- Failing first: commit d9eb4b1; make doctor failed for both missing :! pathspecs and missing full-SHA workflow provenance.
- Root cause: actions-template-sync passes ignore entries to git reset --, while the target used .gitignore negation; the workflow also omitted an auditable full parent commit.
- How verified: make setup, make format, make lint, make test (36/36), make doctor (73 governance tests, 4 target boundary tests, 71 guard tests), and git diff --check passed.
- Sibling occurrence: corrected the existing target boundary test that encoded the invalid ! syntax.
- Not verified: generated PR contents until Template Sync is dispatched after merge.

## Documentation (DOC-030)

- [x] Existing accepted ADR-0008 already defines protected recurring sync; no product documentation change required.

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against .ai/review-checklist.md completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] make format && make lint && make test green
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (.ai/guardrails.md)