### PR TITLE
docs(foundation): add inherited decisions and glossary

### DIFF
--- a/docs/foundation/adr/0001-record-architecture-decisions.md
+++ b/docs/foundation/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,47 @@
+# ADR-0001: Record architecture decisions
+
+| Field | Value |
+|-------|-------|
+| Status | accepted |
+| Date | 2026-07-02 |
+| Deciders | repository owner |
+| Author | Claude (AI agent) |
+| Supersedes / Superseded by | — |
+
+## Context
+
+AI agents perform most implementation work in this repository. Agents (and humans)
+joining later cannot infer *why* the system is shaped as it is from code alone; without
+recorded reasoning, agents re-litigate settled decisions, or worse, silently reverse
+them. The project mandates that architectural changes be deliberate and reviewable
+(GR-022).
+
+## Options considered
+
+### Option 1: Do nothing (decisions live in PR discussions)
+Pros: zero process. Cons: reasoning scattered and unsearchable; agents cannot load it
+as context; decisions effectively lost after squash-merge.
+
+### Option 2: Single evolving architecture document
+Pros: one place. Cons: history of *why* is overwritten by each edit; conflicts with
+the append-only audit trail agents need.
+
+### Option 3: ADRs (Michael Nygard style) + lightweight decision log
+Pros: immutable, numbered, diff-reviewed like code, ideal AI context units; industry
+standard. Cons: small process overhead per decision.
+
+## Decision
+
+Adopt Option 3. Architectural decisions (ARC-020 "Architectural" scope) MUST be
+recorded as an ADR in `docs/adr/` using `0000-template.md`, approved by a human before
+implementation (GR-022), and indexed in `.ai/decision-log.md`.
+
+## Consequences
+
+**Positive:** durable reasoning; agents can check "was this already decided?" before
+proposing changes; supersession chain shows evolution.
+
+**Negative:** friction for large changes (intended); requires discipline to keep the
+index current (enforced by DOC-030 and review checklist REV-DOC).
+
+**Follow-ups:** template created; process wired into `.skills/architecture.skill.md`.

--- a/docs/foundation/adr/0002-ai-facing-docs-in-english.md
+++ b/docs/foundation/adr/0002-ai-facing-docs-in-english.md
@@ -1,0 +1,49 @@
+# ADR-0002: AI-facing docs are written in English
+
+| Field | Value |
+|-------|-------|
+| Status | accepted |
+| Date | 2026-07-02 |
+| Deciders | repository owner |
+| Author | Claude (AI agent) |
+| Supersedes / Superseded by | — |
+
+## Context
+
+The primary maintainers are Japanese speakers, but the primary *readers* of `.ai/`,
+`CLAUDE.md`, `.skills/`, and `docs/` are AI agents from multiple vendors. This template
+must work across 100+ repositories and any current or future agent. Rule documents
+demand minimal interpretation variance (mission constraint: "AI向けに最適化").
+
+## Options considered
+
+### Option 1: Do nothing / Japanese only
+Pros: most comfortable for the human owner. Cons: higher token cost (Japanese consumes
+roughly 1.5–2× tokens for equivalent content on common tokenizers); slightly higher
+interpretation variance across models trained predominantly on English technical text;
+harder reuse if repos gain non-Japanese collaborators.
+
+### Option 2: Bilingual (English + Japanese siblings)
+Pros: best of both. Cons: two sources drift apart — violates one-fact-one-place
+(DOC-001); doubles maintenance for 100+ repos.
+
+### Option 3: English for AI-facing docs; Japanese optional for human-facing docs
+Pros: lowest token cost and interpretation variance where it matters; single source of
+truth; localized `README.ja.md`-style siblings remain allowed for human-facing docs.
+Cons: the human owner reviews rules in a second language.
+
+## Decision
+
+Adopt Option 3. All content in `.ai/`, `CLAUDE.md`, `AGENTS.md`, `.skills/`, and
+`docs/` MUST be English (DOC-001). User-facing documents MAY add localized siblings
+(e.g. `README.ja.md`) that translate — never extend — the English source.
+
+## Consequences
+
+**Positive:** stable cross-vendor interpretation; lower context cost; one source of truth.
+
+**Negative:** review burden for the owner; mitigated because AI agents can translate
+any rule file on demand ("この規約を日本語で要約して" works at zero maintenance cost).
+
+**Follow-ups:** if review burden proves too high in practice, supersede with Option 2
+limited to `.ai/` only.

--- a/docs/foundation/adr/0003-reconcile-github-governance-from-inherited-policy.md
+++ b/docs/foundation/adr/0003-reconcile-github-governance-from-inherited-policy.md
@@ -1,0 +1,141 @@
+# ADR-0003: Reconcile GitHub governance from inherited policy
+
+| Field | Value |
+|-------|-------|
+| Status | accepted |
+| Date | 2026-07-15 |
+| Deciders | repository owner |
+| Author | Codex (AI agent) |
+| Supersedes / Superseded by | — (evolves LOG-0003) |
+
+## Context
+
+`scripts/setup-github.sh` implements LOG-0003 as a one-time, imperative bootstrap. It
+hard-codes required checks and one approving review, enables both Renovate-oriented
+configuration and Dependabot automated fixes, continues after mandatory API failures,
+and does not compare later GitHub settings with repository rules. A downstream can
+therefore contain the correct `.ai/` rules and bootstrap script while its live settings
+remain absent or drifted.
+
+The foundation needs an immediate administrator-operated apply path and a read-only
+continuous audit path. It must remain stack-agnostic, preserve explicit human control of
+repository-administration credentials, support solo and team repositories, and let
+Template Sync distribute stronger foundation defaults without overwriting downstream
+choices. Runtime AI interpretation of Markdown is prohibited because it would make
+enforcement nondeterministic.
+
+## Options considered
+
+### Option 1: Keep the one-time bootstrap
+
+Pros: no migration or added implementation. Cons: hard-coded choices continue to lock
+solo repositories or omit project-specific checks; failures and later drift remain
+undetected. Security posture depends on an undocumented manual rerun.
+
+### Option 2: Parameterize the existing shell script
+
+Pros: small change; preserves the Bash plus `gh` runtime contract. Cons: environment
+variables do not provide a versioned, validated inheritance model; shell parsing makes
+nested policy and safe field ownership difficult; dry-run would still tend to describe
+commands instead of a current-versus-desired diff.
+
+### Option 3: Add a layered policy and deterministic reconciler
+
+Pros: versioned intent, explicit foundation minimums and repository overrides,
+idempotent plan/audit/apply modes, testable merge semantics, and post-apply evidence.
+The existing setup command can remain as a compatibility wrapper. Cons: adds a policy
+schema, migration work, and a small local runtime; GitHub API capability differences
+must be modeled explicitly.
+
+### Option 4: Enforce centrally with an organization ruleset or GitHub App
+
+Pros: strongest fleet-wide convergence and no per-repository administrator command.
+Cons: personal repositories and plan capabilities differ; a GitHub App adds credential,
+deployment, permission, and incident-response scope. It exceeds the forcing problem and
+reverses LOG-0003's no-service decision without evidence that central scale is needed.
+
+## Decision
+
+Adopt Option 3. The foundation MUST ship a machine-readable foundation policy whose
+entries reference normative `.ai/` rule IDs, plus a downstream-owned repository policy.
+The machine policy is an enforcement projection, not a second normative source: `.ai/`
+retains authority, every referenced rule ID must exist, and a change to a projected MUST
+must update its projection and contract tests in the same reviewed PR. The runtime MUST
+NOT parse rule prose or invoke an AI model. It MUST apply field-specific merge rules:
+repository policy may set operational values such as approval count, required check
+names, supported enforcement backend, and exactly one dependency-update provider, but
+it may not disable minimums derived from GR-010, GR-011, GR-012, SEC-002, or another
+foundation MUST.
+
+The initial machine interface is versioned JSON data:
+
+- `.github/governance/foundation.json` is foundation-owned and Template Sync-managed.
+- `.github/governance/repository.json` is downstream-owned and excluded from sync.
+- Both declare `schema_version`; projected controls declare `rule_refs`.
+
+JSON is selected so configuration is data rather than executable shell and can be
+parsed without adding a YAML/TOML package. The schema must reject unknown fields and
+invalid combinations before any GitHub read or write. A future format change is a
+versioned migration, not permissive parsing.
+
+The reconciler MUST provide these modes:
+
+- `plan`: authenticate and read current state, validate target/capabilities/check names,
+  and print a redacted current-versus-desired diff without writes.
+- `audit`: perform the same read-only comparison with machine-readable output and a
+  nonzero drift result suitable for CI.
+- `apply`: require an explicit repository target confirmation, reject an invalid plan
+  before writes, change only owned fields through versioned `gh api` endpoints, and
+  verify every result by reading it back.
+
+The foundation-managed branch rule MUST have a stable name and MUST NOT replace or
+delete unrelated rulesets. Repository rulesets are preferred; a legacy branch-protection
+adapter is allowed only when the selected policy declares it and it enforces the same
+minimums. Plan and audit must inventory all effective branch rules and flag stricter or
+conflicting unmanaged controls; apply does not silently remove them. Unsupported
+mandatory controls are errors, not warnings. Administrator credentials remain in the
+human's local `gh` authentication; CI may run `audit` with read-only access but MUST NOT
+store a repository-administration token or run `apply`.
+When a normal `GITHUB_TOKEN` cannot read an administrator-only setting, audit MUST report
+that control as `unknown`, not compliant; a complete audit requires an administrator's
+local read access unless a future ADR approves a narrower central credential boundary.
+
+Foundation policy, schema, reconciler, and tests are distributed through Template Sync.
+The downstream policy is excluded from sync. Existing downstream repositories require a
+one-time reviewed migration because their `.templatesyncignore` files are themselves
+downstream-owned. `scripts/setup-github.sh` remains as a documented compatibility wrapper
+until migrated repositories use the reconciler directly.
+
+## Consequences
+
+**Positive:** live GitHub governance becomes auditable against repository-owned intent;
+security failures stop closed; solo/team differences are explicit; foundation changes
+arrive as reviewable PRs and do not mutate downstream settings until an administrator
+runs `apply`.
+
+**Negative:** a wrong required-check name or approval policy can block merges. Enabling
+secret scanning can create alerts and push protection can reject pushes. GitHub API or
+plan capability changes can make a mandatory control unsupported. Policy and external
+state can diverge between a sync merge and the next apply. A partial API failure can
+leave some settings strengthened and others unchanged.
+
+Mitigations are mandatory: preflight checks must use observed check runs where GitHub
+requires them; approval validation must reject solo lockout combinations; dependency
+updaters are mutually exclusive; future branch auto-deletion is optional and must be
+called out as destructive in the plan; applies emit before/after evidence and stop on
+the first failed verification. The reconciler does not automatically roll back security
+hardening after a partial failure because that could weaken protection. Recovery is an
+idempotent roll-forward rerun; any deliberate weakening requires a separate reviewed
+policy change and explicit administrator action.
+
+**Follow-ups:**
+
+1. Add the versioned policy schema, foundation defaults, repository example, and strict
+   merge/validation tests without any write-capable adapter.
+2. Add read-only GitHub discovery plus deterministic `plan` and `audit` output.
+3. Add `apply` adapters, explicit target confirmation, read-back verification, and a
+   compatibility wrapper; test all API calls at the process boundary.
+4. Update README/usage/Template Sync ownership and migrate one downstream repository as
+   a separate reviewed proof before broader rollout.
+5. Reconsider Option 4 only after multiple repositories require centralized unattended
+   convergence and an owner accepts the additional credential boundary.

--- a/docs/foundation/adr/0004-harden-multi-level-template-inheritance.md
+++ b/docs/foundation/adr/0004-harden-multi-level-template-inheritance.md
@@ -1,0 +1,148 @@
+# ADR-0004: Harden multi-level template inheritance
+
+| Field | Value |
+|-------|-------|
+| Status | accepted |
+| Date | 2026-07-16 |
+| Deciders | repository owner |
+| Author | Codex (AI agent) |
+| Supersedes / Superseded by | Evolves ADR-0003; supersedes LOG-0004 |
+
+## Context
+
+ADR-0003 makes live GitHub governance deterministic and fail-closed, but it assumes one
+inherited foundation policy plus one local repository policy. The actual template graph
+has both direct and multi-level inheritance:
+
+- `ai-dev-foundation -> terraform-gcp-template -> secure-ga4-bq-template`
+- `ai-dev-foundation -> nextjs-saas-template`
+
+The current transport uses a target-owned `.templatesyncignore` denylist and
+`actions-template-sync`. All three enabled downstream schedules fail when their standard
+`GITHUB_TOKEN` attempts to push a changed workflow file because that token has no
+workflow-write permission. A dry-run also shows that the denylist would overwrite each
+stack's `.gitignore`; for Next.js this removes `.env*.local`, and for Terraform it
+removes state and variable-file exclusions. Because `.templatesyncignore` cannot itself
+be synchronized, every newly protected path requires a manual fleet migration.
+
+The two policy layers also cannot express an inheritable Terraform-family requirement
+separately from a repository-local override. Copying the parent's `repository.json`
+overwrites the child; excluding it drops the family requirement. In addition,
+`required_checks` currently replaces the foundation list, so an override can remove a
+foundation check. A child that misses several upstream PRs receives one accumulated diff
+that may exceed GR-020's hard PR-size gate.
+
+Constraints are: solo maintenance is the normal case; every change remains a reviewed
+PR; no repository-administration credential is stored in Actions; workflow files still
+need to inherit; local files and secrets must never become trackable because of sync;
+and every hop must remain green and reversible.
+
+## Options considered
+
+### Option 1: Do nothing
+
+Keep direct-parent paths, denylist sync, and the two policy layers. This has no migration
+cost, but scheduled sync remains red, target-owned files can be overwritten, and the
+Terraform family cannot safely pass stack policy to its children. Rejected.
+
+### Option 2: Keep the denylist and add a privileged sync token
+
+Use a PAT or GitHub App with Contents, Workflows, and Pull Requests write permissions.
+This restores unattended workflow PRs and is operationally familiar. It does not fix
+denylist omissions, policy-layer ambiguity, accumulated oversized diffs, or the need to
+hand-update `.templatesyncignore`; it also adds a credential and rotation boundary.
+
+### Option 3: Split automated and manual sync
+
+Exclude workflows from the scheduled action and port workflow changes locally. This
+keeps the default token least-privileged and is a small change, but two transports can
+drift and still rely on a denylist. Reviewers cannot prove from one plan that all parent
+changes and only parent-owned paths were considered.
+
+### Option 4: Use a manifest-driven, local-first inheritance reconciler
+
+Each child declares its direct parent, accepted parent commit, inherited allowlist, and
+protected local paths in a local manifest. A deterministic tool plans one parent commit
+at a time, refuses ownership overlap, defaults to no deletion, and materializes an
+explicitly confirmed change into a non-main worktree for the normal reviewed PR flow.
+It can modify workflows because the eventual push uses the maintainer's local GitHub
+authentication. Inheritable template-policy fragments separate family requirements from
+the leaf repository policy. This adds a schema, tool, and migration work, and unattended
+sync is no longer the default.
+
+## Decision
+
+Adopt Option 4. Keep a **direct-parent-only** topology; a child MUST NOT bypass an
+intermediate template. Every path MUST have exactly one owner:
+
+- `.github/inheritance/manifest.json` is child-owned and declares the direct parent,
+  inherited allowlist, protected paths, and lock-file location.
+- `.github/inheritance/lock.json` records the exact accepted parent repository and
+  commit. The default plan advances only the next first-parent commit so upstream PR
+  review slices and GR-020 limits are preserved.
+- `.gitignore`, the manifest, `.templatesyncignore`, the local governance policy, the
+  sync workflow, and stack-specific files are protected by default. A path cannot be
+  both inherited and protected. Unknown new parent paths are not copied until reviewed
+  into the allowlist.
+- Plan is read-only and reports adds, modifications, candidate deletions, source commit,
+  and ownership. Apply requires exact child and parent-commit confirmation, refuses
+  `main`, and defaults to no deletion. Deletion requires a separately confirmed command
+  under GR-031. Commit, push, and PR creation remain the normal repository workflow.
+
+Extend ADR-0003's governance projection to ordered layers:
+
+1. the global `ai-dev-foundation` policy and minimums;
+2. zero or more inheritable template-family profiles, each with a unique ID and explicit
+   parent profile (for example, a Terraform profile);
+3. the leaf repository's non-inherited `repository.json`.
+
+Foundation-required checks are monotonic: profiles and repository policy may add unique,
+always-reported checks but MUST NOT remove foundation checks. A required check MUST have
+a unique context and MUST run for every pull request; a path-filtered workflow is invalid
+for a required context. A Terraform-family profile will add `iac-scan` only after its
+workflow always reports that uniquely named result.
+
+Use solo-friendly foundation defaults: zero approvals, no last-push approval, automatic
+merged-branch deletion, Discussions disabled, squash-only merge, no admin bypass, and
+Renovate as the sole dependency updater. Team repositories may raise approval counts,
+enable last-push approval when at least one approval is required, and enable Discussions;
+they may not weaken foundation minimums or required checks.
+
+The scheduled write-capable Template Sync path is disabled by default. Local owner
+authentication is the standard transport and no new secret is introduced. A dedicated
+GitHub App restricted to Contents, Workflows, and Pull Requests write permissions may be
+considered later only through a separate security decision when unattended convergence
+has demonstrated value.
+
+## Consequences
+
+**Positive:** inheritance becomes fail-closed and auditable; new parent files cannot
+silently overwrite local files; multi-level policy has explicit semantics; workflow
+updates remain possible without a CI admin credential; and missed updates are reviewed
+in bounded upstream slices. Next.js application/auth/payment files remain local, while
+shared rules and governance can still inherit.
+
+**Negative:** every template needs a manifest and lock; a new inherited path requires an
+explicit child review; local sync is a maintainer action; each additional parent hop adds
+merge latency; and schema/profile migration is larger than an ignore-file patch.
+
+Migration is expand-only until every child is validated: add the manifest validator and
+layered policy support in the foundation; migrate `terraform-gcp-template` and
+`nextjs-saas-template`; then migrate `secure-ga4-bq-template` through Terraform. The old
+scheduled workflow stays disabled during migration and is removed only after equivalent
+read-only drift visibility exists. No live governance setting changes during migration;
+each repository receives a separate read-only plan before an explicitly approved apply.
+
+Rollback is a normal PR reverting a manifest lock or implementation slice. Existing
+local files and GitHub settings remain unchanged unless a separately confirmed tool
+applies them.
+
+**Follow-ups:**
+
+1. Specify and test the inheritance manifest, lock, ownership validation, and one-commit
+   planning semantics.
+2. Extend the governance resolver to template profiles and monotonic required checks.
+3. Change the foundation solo defaults and update comparison/apply tests.
+4. Migrate direct children before any broad sync, then migrate the Terraform child.
+5. Disable the currently failing scheduled sync variables until a safe replacement is
+   accepted and deployed.

--- a/docs/foundation/adr/0005-separate-foundation-and-project-document-languages.md
+++ b/docs/foundation/adr/0005-separate-foundation-and-project-document-languages.md
@@ -1,0 +1,84 @@
+# ADR-0005: Separate foundation and project document languages
+
+| Field | Value |
+|-------|-------|
+| Status | accepted |
+| Date | 2026-07-18 |
+| Deciders | repository owner (approved 2026-07-18) |
+| Author | Codex (AI agent) |
+| Supersedes / Superseded by | Partially supersedes ADR-0002 |
+
+## Context
+
+ADR-0002 requires English for all AI-facing and `docs/` content. That rule is suitable
+for the reusable governance and instructions maintained in this foundation, but it also
+applies to project-specific documents created after the template is instantiated.
+
+The repository owner requires AI agents in instantiated repositories to write project
+documents, including requirements definitions, in Japanese. Without an explicit
+lifecycle boundary, agents cannot determine whether to follow the foundation's English
+maintenance policy or the instantiated project's Japanese documentation policy.
+
+The decision must preserve one source of truth (DOC-001), avoid maintaining bilingual
+copies, and keep foundation rules consistent across downstream repositories.
+
+## Options considered
+
+### Option 1: Keep English for all AI-facing and project documents
+
+This retains ADR-0002 unchanged. It has the smallest foundation change and keeps token
+cost low, but it does not meet the repository owner's language requirement for project
+documents.
+
+### Option 2: Make all foundation and downstream content Japanese
+
+This creates one language rule and is easy for the repository owner to review. It has a
+large blast radius, increases divergence from existing foundation documents, and removes
+the cross-vendor and token-cost benefits recorded in ADR-0002.
+
+### Option 3: Keep foundation instructions in English and require downstream project documents in Japanese
+
+The reusable foundation rules, agent instructions, skills, templates' maintenance
+instructions, and foundation-owned documentation remain English. After instantiation,
+AI agents write new project-specific content under `docs/` in Japanese unless an
+external contract requires another language. Existing inherited foundation guidance is
+not translated solely to satisfy this rule.
+
+This option adds a lifecycle distinction but limits the change to authoring policy. It
+is reversible by changing one binding documentation rule and does not affect runtime,
+security posture, dependencies, or vendors.
+
+### Option 4: Maintain English and Japanese siblings for every project document
+
+This serves both AI agents and Japanese readers, but duplicates facts, increases
+maintenance cost, and creates contradiction risk prohibited by DOC-001.
+
+## Decision
+
+Adopt Option 3. Foundation-owned normative content MUST remain English. In an
+instantiated repository, AI agents MUST write new project-specific documents under
+`docs/` in Japanese unless the repository owner or an external contract explicitly
+requires another language. Agents MUST NOT create an English sibling solely as a
+translation. This decision partially supersedes ADR-0002 only for project-specific
+documents authored after template instantiation.
+
+## Consequences
+
+**Positive:** downstream project documents use the repository owner's working language;
+the foundation retains a single cross-vendor governance source; bilingual drift is
+avoided; and agents receive an explicit rule instead of inferring language from nearby
+files.
+
+**Negative:** instantiated repositories contain inherited English guidance and newly
+authored Japanese project documents; agents must distinguish foundation-owned guidance
+from project-specific content; non-Japanese collaborators may require an explicitly
+approved language exception.
+
+**Migration and rollback:** existing downstream project documents are not translated
+automatically. A repository may migrate them in a separate documentation change. Rollback
+requires a superseding ADR and restoration of the ADR-0002 language rule.
+
+**Follow-ups:** update DOC-001 with the lifecycle boundary; add `docs/requirements/` and
+its placement rules; update the documentation inventory and update matrix; update the
+requirements skill and template guidance if necessary; and record the accepted decision
+in `.ai/decision-log.md`.

--- a/docs/foundation/adr/0006-reserve-a-foundation-documentation-namespace.md
+++ b/docs/foundation/adr/0006-reserve-a-foundation-documentation-namespace.md
@@ -1,0 +1,100 @@
+# ADR-0006: Reserve a foundation documentation namespace
+
+| Field | Value |
+|-------|-------|
+| Status | accepted |
+| Date | 2026-07-18 |
+| Deciders | repository owner (approved 2026-07-18) |
+| Author | Codex (AI agent) |
+| Supersedes / Superseded by | Refines ADR-0005 |
+
+## Context
+
+PR #39 added foundation-owned placement guidance at
+`docs/requirements/README.md` while reserving `docs/requirements/<initiative>.md` for
+downstream project documents. This mixes files with different owners in one directory.
+It also places downstream project content below inherited foundation content, although
+the downstream project is the primary subject of an instantiated repository.
+
+The current Template Sync configuration excludes `docs/**` to protect downstream
+content. Consequently, foundation-owned guidance and templates under `docs/` cannot
+propagate automatically unless each file is selectively exempted. Adding individual
+exceptions does not establish a durable ownership boundary for future foundation
+documents.
+
+The structure must keep binding agent rules in `.ai/`, task procedures in `.skills/`,
+and downstream project documentation at conventional paths under `docs/`. It must also
+make sync ownership understandable from the path alone and avoid overwriting downstream
+documents.
+
+## Options considered
+
+### Option 1: Keep the mixed requirements directory
+
+Retain foundation guidance at `docs/requirements/README.md`, downstream whole-project
+requirements at `docs/requirements.md`, and downstream initiative requirements below
+`docs/requirements/`. This requires no migration, but ownership remains ambiguous and
+every future synchronized foundation document needs another ignore-file exception.
+
+### Option 2: Put downstream project documents under `docs/project/`
+
+Keep inherited foundation documents at their current paths and move downstream content
+to `docs/project/requirements.md` and `docs/project/requirements/`. This separates
+ownership but makes the downstream repository's primary documents subordinate to the
+template implementation and changes conventional project paths.
+
+### Option 3: Reserve `docs/foundation/` for inherited foundation documents
+
+Move reusable foundation guidance and templates below `docs/foundation/`. Keep
+downstream project documents at `docs/requirements.md` and
+`docs/requirements/<initiative>.md`. Template Sync can protect `docs/**` by default and
+allow only `docs/foundation/**`, creating one stable synchronization boundary.
+
+This adds one directory level only to inherited support material. Binding rules and
+procedures remain at `.ai/` and `.skills/`, so the new directory does not become a second
+normative source.
+
+### Option 4: Synchronize all of `docs/`
+
+Remove `docs/**` from `.templatesyncignore`. This is operationally simple but permits
+foundation updates to overwrite downstream requirements, architecture, ADRs, and
+runbooks. The risk violates the ownership and local-first constraints accepted in
+ADR-0004.
+
+## Decision
+
+Adopt Option 3. `docs/foundation/` MUST contain descriptive guidance and document
+templates owned and synchronized by `ai-dev-foundation`. Downstream project documents
+MUST remain directly under `docs/` at task-oriented paths such as
+`docs/requirements.md` and `docs/requirements/<initiative>.md`.
+
+The binding source for AI behavior remains `.ai/`, and executable task procedures remain
+`.skills/`; documents under `docs/foundation/` MUST link to those sources instead of
+duplicating their rules. Template Sync MUST continue to exclude `docs/**` by default and
+MAY synchronize only the explicit `docs/foundation/**` namespace.
+
+## Consequences
+
+**Positive:** path ownership is visible without reading file contents; downstream
+project documents keep the shortest and most conventional paths; foundation documents
+gain one stable synchronization boundary; and future foundation templates do not require
+per-file sync exceptions.
+
+**Negative:** inherited guidance moves and all references must be updated; instantiated
+repositories contain a dedicated foundation subtree; existing downstream repositories
+must adopt the `.templatesyncignore` exception once because that file is protected from
+sync; and migrating every existing foundation-owned document may require multiple PRs to
+stay within GR-020.
+
+**Migration and rollback:** first add `docs/foundation/` and update references, then move
+the requirements placement guide and templates, then remove the old foundation-owned
+paths. Every intermediate commit must keep links valid. Existing downstream repositories
+adopt the new ignore exception in a reviewed migration PR before running Template Sync.
+Rollback restores the previous paths and removes the namespace exception; downstream
+project documents remain untouched in either direction.
+
+**Follow-ups:** document the ownership boundary in DOC-010; migrate requirements guidance
+to `docs/foundation/requirements.md`; migrate reusable templates to
+`docs/foundation/templates/`; update every reference and update trigger; add a selective
+Template Sync exception for `docs/foundation/**`; and define a phased plan for other
+foundation-owned documents that remain outside the namespace.

--- a/docs/foundation/adr/README.md
+++ b/docs/foundation/adr/README.md
@@ -1,0 +1,33 @@
+---
+id: adr-index
+title: Architecture Decision Records
+---
+
+# Foundation Architecture Decision Records (ADR)
+
+Immutable records of decisions owned by `ai-dev-foundation` and synchronized to
+downstream repositories. Project-specific decisions belong in `docs/adr/`. Both use the
+process in `.skills/architecture.skill.md`.
+
+## Rules
+
+- Numbered sequentially: `NNNN-kebab-case-title.md`. Copy the
+  [foundation ADR template](../templates/adr.md).
+- Status flow: `proposed → accepted | rejected`; later `deprecated` or
+  `superseded by ADR-NNNN`. **Accepted ADRs are never edited** — supersede them.
+- One decision per ADR. Keep it under ~2 pages.
+- The ADR PR is approved by a human before implementation starts (GR-022).
+- Every ADR gets a line in [.ai/decision-log.md](../../../.ai/decision-log.md).
+
+## Index
+
+| # | Title | Status | Date |
+|---|-------|--------|------|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | accepted | 2026-07-02 |
+| [0002](0002-ai-facing-docs-in-english.md) | AI-facing docs are written in English | accepted | 2026-07-02 |
+| [0003](0003-reconcile-github-governance-from-inherited-policy.md) | Reconcile GitHub governance from inherited policy | accepted | 2026-07-15 |
+| [0004](0004-harden-multi-level-template-inheritance.md) | Harden multi-level template inheritance | accepted | 2026-07-16 |
+| [0005](0005-separate-foundation-and-project-document-languages.md) | Separate foundation and project document languages | accepted | 2026-07-18 |
+| [0006](0006-reserve-a-foundation-documentation-namespace.md) | Reserve a foundation documentation namespace | accepted | 2026-07-18 |
+
+<!-- Append new ADRs to this table (newest last). -->

--- a/docs/foundation/glossary.md
+++ b/docs/foundation/glossary.md
@@ -1,0 +1,40 @@
+---
+id: foundation-glossary
+title: Foundation Glossary
+updated: 2026-07-18
+---
+
+# Foundation Glossary
+
+Reusable foundation terminology. Code identifiers, documentation, and conversation use
+these terms with the meanings defined here under COD-002. Project-specific ubiquitous
+language belongs in `docs/glossary.md` after a repository is instantiated.
+
+Format: term, one-sentence definition, context it belongs to, banned synonyms (*Avoid* —
+never use these for the concept; COD-002), and what it is NOT when confusable. Keep
+alphabetical.
+
+## Terms
+
+| Term | Definition | Context | Avoid | Not to be confused with |
+|------|------------|---------|-------|--------------------------|
+| ADR | Immutable record of an architectural decision in `docs/foundation/adr/` or project-owned `docs/adr/` | foundation | design doc | decision log (the index of all decisions) |
+| Agent | Any AI system working in this repo under CLAUDE.md rules | foundation | bot, assistant | — |
+| Audit | Read-only governance comparison whose exit code fails on drift or unknown state | governance | check | plan (which reports those states without failing) |
+| Bounded context | A domain boundary owning its model and language; maps 1:1 to `src/modules/<context>` | DDD | — | module (the code artifact implementing it) |
+| Canonical command | A `make` target that is the only entry point for a dev action | foundation | — | — |
+| Contract change | A change to a MODULE.md public API or event (ARC-020) | foundation | — | breaking change (a contract change affecting *external* consumers) |
+| Drift | A known difference between resolved governance policy and live GitHub state | governance | mismatch | unknown (state that could not be evaluated) |
+| Guardrail | An absolute prohibition (GR-xxx) that no instruction can override | foundation | — | rule (overridable with justification if SHOULD-level) |
+| Module | A directory under `src/modules/` implementing one bounded context | foundation | component, service | package/library |
+| Plan | Read-only governance comparison that reports drift or unknown state without failing on it | governance | preview | audit (which exposes those states through its exit code) |
+| Skill | A task playbook in `.skills/*.skill.md` | foundation | — | Claude Code native skill (optional wrapper) |
+| Unknown | A governance control that could not be evaluated because required state was not visible | governance | indeterminate | compliant or drift |
+
+## Resolved ambiguities
+
+Append-only log of naming collisions and their resolution — one word carrying two
+meanings, or two words carrying one meaning. Recording the resolution keeps the
+collision from returning; move the surviving term into the tables above.
+
+*None yet.*

--- a/docs/foundation/templates/adr.md
+++ b/docs/foundation/templates/adr.md
@@ -1,0 +1,57 @@
+---
+id: adr-{{NNNN}}
+title: ADR-{{NNNN}} — {{DECISION_TITLE}}
+status: proposed
+updated: {{YYYY-MM-DD}}
+---
+
+<!--
+  FOUNDATION TEMPLATE. In ai-dev-foundation, copy to
+  docs/foundation/adr/NNNN-kebab-case-title.md. After template instantiation, copy to
+  docs/adr/NNNN-kebab-case-title.md. Replace every placeholder and delete this guidance
+  comment. Write project-specific ADR content in Japanese unless the repository owner or
+  an external contract explicitly requires another language. Keep this template in
+  English (ADR-0005).
+-->
+
+# ADR-{{NNNN}}: {{decision as a short imperative statement}}
+
+| Field | Value |
+|-------|-------|
+| Status | proposed |
+| Date | {{YYYY-MM-DD}} |
+| Deciders | {{humans who approve}} |
+| Author | {{human or AI agent name}} |
+| Supersedes / Superseded by | — |
+
+## Context
+
+<!-- The forcing problem: what makes the current state insufficient? Constraints
+     (performance, cost, compliance, team). Facts only — no solution here yet.
+     An agent reading only this section should understand why change is needed. -->
+
+## Options considered
+
+<!-- 2-4 options INCLUDING "do nothing". One subsection each: description, pros, cons.
+     Evaluate against: simplicity, blast radius, reversibility, operational cost,
+     security posture (GR-030), vendor lock-in. -->
+
+### Option 1: Do nothing
+
+### Option 2: {{name}}
+
+## Decision
+
+<!-- The chosen option and the decisive reasons. One paragraph. Use MUST/SHOULD language
+     for any new rules this decision creates. -->
+
+## Consequences
+
+<!-- Honest, including negatives. What becomes easier; what becomes harder; new risks;
+     migration path; rollback path; what future decisions this constrains. -->
+
+**Positive:**
+
+**Negative:**
+
+**Follow-ups:** <!-- issues to open, docs to update (DOC-030), rules to change in .ai/ -->


### PR DESCRIPTION
## What & why

Port the first dependency-safe batch from authenticated Template Sync source a177d1f: accepted foundation ADRs, their index, the reusable foundation glossary, and the ADR template. ChatChart-specific ADRs under docs/adr/ remain unchanged.

Refs: #37

## Change classification (ARC-020)

- [x] Local (mechanical inherited documentation batch)
- [ ] Contract
- [ ] Architectural

## Breaking change?

- [x] No
- [ ] Yes

## Testing (GR-021 / TST-002)

- How verified: make format, make lint, make test (36/36), make doctor (73 governance tests, 4 target boundary tests, 71 guard tests), and git diff --check passed.
- Verified all nine files exactly match generated branch chore/template_sync_a177d1f.
- Docs-only/config-free batch; no runtime behavior changed.

## Documentation (DOC-030)

- [x] Foundation-owned content added only under docs/foundation/**; project ADRs retained.

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against .ai/review-checklist.md completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] make format && make lint && make test green
- [x] Mechanical batch is below GR-020 hard limits and justified above
- [x] No guardrail violated (.ai/guardrails.md)