### PR TITLE
docs(foundation): add inherited project templates

### DIFF
--- a/docs/foundation/requirements.md
+++ b/docs/foundation/requirements.md
@@ -1,0 +1,41 @@
+---
+id: foundation-requirements-guide
+title: Foundation Requirements Guide
+---
+
+# Requirements document placement
+
+This foundation-owned guide defines where an instantiated repository stores its
+requirements documents. Follow the binding requirements procedure in
+[`.skills/requirements.skill.md`](../../.skills/requirements.skill.md) and start from
+[`docs/foundation/templates/requirements.md`](templates/requirements.md).
+
+## Placement
+
+| Scope | Location | Example |
+|-------|----------|---------|
+| Whole project | `docs/requirements.md` | `docs/requirements.md` |
+| One initiative, feature, or major change | `docs/requirements/<initiative>.md` | `docs/requirements/account-recovery.md` |
+
+Use one initiative document when its scope, decisions, and acceptance criteria can be
+reviewed independently. Keep cross-initiative requirements in the whole-project document
+and link to them instead of copying them.
+
+## Naming and language
+
+- Use a stable kebab-case initiative name. Do not add dates or sequence numbers; Git
+  records history.
+- Include the required YAML frontmatter from the template.
+- After template instantiation, AI agents MUST write project-specific requirements in
+  Japanese. Translate the copied template's headings and table labels as part of filling
+  it. A repository-owner instruction or external contract may explicitly require another
+  language (ADR-0005).
+- Do not create English and Japanese siblings containing the same requirements
+  (DOC-001).
+
+## Update triggers
+
+Create or update the applicable requirements document when project scope, success
+metrics, functional or non-functional requirements, constraints, priorities, or
+acceptance criteria change. A design or implementation change that does not alter a
+requirement links to the existing requirement instead of rewriting it.

--- a/docs/foundation/templates/README.md
+++ b/docs/foundation/templates/README.md
@@ -1,0 +1,23 @@
+---
+id: docs-templates-index
+title: Document Templates
+---
+
+# docs/foundation/templates/ — Document Templates
+
+Reusable skeletons for standard project documents. Copy a template out of this directory,
+fill it, and delete the guidance comments. Each template names the skill that drives it.
+
+| Template | Produces | Driven by |
+|----------|----------|-----------|
+| [adr.md](adr.md) | A project architecture decision record under `docs/adr/` | [.skills/architecture.skill.md](../../../.skills/architecture.skill.md) |
+| [glossary.md](glossary.md) | `docs/glossary.md` with project-specific ubiquitous language | [.ai/coding-rules.md](../../../.ai/coding-rules.md) |
+| [requirements.md](requirements.md) | A requirements definition document | [.skills/requirements.skill.md](../../../.skills/requirements.skill.md) |
+| [roadmap.md](roadmap.md) | `docs/roadmap.md` with project direction and sequencing | [.ai/documentation.md](../../../.ai/documentation.md) |
+
+Templates follow the documentation rules ([.ai/documentation.md](../../../.ai/documentation.md)),
+especially the writing style in DOC-002. After template instantiation, AI agents translate
+the copied structure and write project-specific documents in Japanese. The
+foundation-owned template files remain English (ADR-0005).
+
+**Update trigger:** add a row here whenever a new template lands in this directory.

--- a/docs/foundation/templates/glossary.md
+++ b/docs/foundation/templates/glossary.md
@@ -1,0 +1,37 @@
+---
+id: glossary-template
+title: Glossary — {{PROJECT_NAME}}
+updated: {{YYYY-MM-DD}}
+---
+
+<!--
+  FOUNDATION TEMPLATE. Copy to docs/glossary.md, replace every {{...}}, and delete this
+  guidance comment. After template instantiation, translate the headings and fill the
+  project-specific document in Japanese unless the repository owner or an external
+  contract explicitly requires another language. Keep this template in English
+  (ADR-0005).
+-->
+
+# Glossary
+
+The project-specific ubiquitous language. Code identifiers, documentation, and
+conversation use one term per concept under COD-002. Check the reusable terms in
+`docs/foundation/glossary.md` before adding a project term.
+
+## Terms
+
+| Term | Definition | Context | Avoid | Not to be confused with |
+|------|------------|---------|-------|--------------------------|
+| {{TERM}} | {{ONE_SENTENCE_DEFINITION}} | {{BOUNDED_CONTEXT}} | {{BANNED_SYNONYMS_OR_DASH}} | {{DISTINCTION_OR_DASH}} |
+
+## Resolved ambiguities
+
+Append-only log of naming collisions and their resolution: one word carrying two
+meanings, or two words carrying one meaning. Move the surviving term into the table.
+
+<!--
+- "{{AMBIGUOUS_TERM}}" meant {{MEANING_A}} and {{MEANING_B}}; resolved
+  {{YYYY-MM-DD}}: use "{{TERM_A}}" and "{{TERM_B}}".
+-->
+
+*None yet.*

--- a/docs/foundation/templates/requirements.md
+++ b/docs/foundation/templates/requirements.md
@@ -1,0 +1,150 @@
+---
+id: requirements-template
+title: Requirements — {{PROJECT_OR_FEATURE_NAME}}
+status: draft
+updated: {{YYYY-MM-DD}}
+---
+
+<!--
+  FOUNDATION TEMPLATE. Copy to docs/requirements.md (whole project) or
+  docs/requirements/<initiative>.md (one initiative), then replace every {{...}} and
+  delete the guidance comments. Procedure and rationale: .skills/requirements.skill.md.
+  Style is binding — DOC-002: objective, conclusion-first, structure carries meaning,
+  define once and reference. After template instantiation, translate every heading and
+  table label in the copied document and fill it in Japanese. Use another language only
+  when the repository owner or an external contract explicitly requires it. Keep this
+  foundation-owned template file in English (ADR-0005).
+-->
+
+# Requirements — {{PROJECT_OR_FEATURE_NAME}}
+
+One sentence: what this document specifies and for whom.
+
+## 1. Terms
+
+<!-- Define each term once here; reference it by name everywhere else (DOC-002). -->
+
+| Term | Definition |
+|------|------------|
+| {{TERM}} | {{DEFINITION}} |
+
+## 2. Assumptions and constraints
+
+<!-- Defined once. Every requirement and cost figure below relies on these. -->
+
+| ID | Type | Statement | Impact if wrong |
+|----|------|-----------|-----------------|
+| A-1 | assumption | {{...}} | {{...}} |
+| C-1 | constraint | {{...}} | {{...}} |
+
+## 3. Purpose and scope
+
+- **Purpose (one sentence):** {{why this exists}}
+- **Success metrics (measurable):**
+
+  | Metric | Target | How measured |
+  |--------|--------|--------------|
+  | {{...}} | {{...}} | {{...}} |
+
+- **In scope:** {{what this delivers}}
+- **Non-scope (explicit exclusions):** {{what this deliberately does not deliver}}
+- **Stakeholders:**
+
+  | Role | Interest | Decision authority |
+  |------|----------|--------------------|
+  | {{...}} | {{...}} | {{...}} |
+
+## 4. Functional requirements
+
+<!-- One row per requirement. "Purpose served" = which §3 purpose or metric it traces to. -->
+
+| ID | Requirement | Purpose served | Priority | Basis |
+|----|-------------|----------------|----------|-------|
+| FR-001 | The system shall {{...}} | {{metric/purpose}} | Must | {{...}} |
+
+### 4.1 Use cases / user stories
+### 4.2 Business rules
+### 4.3 States and transitions
+### 4.4 Roles and permissions
+### 4.5 Error and exception handling
+
+## 5. Non-functional requirements
+
+<!-- Cover the ISO/IEC 25010 characteristics that apply. Every NFR needs a measurement
+     method — a target you cannot verify is not a requirement. Delete unused rows. -->
+
+| ID | Characteristic (ISO/IEC 25010) | Requirement | Target | Measurement method | Priority |
+|----|-------------------------------|-------------|--------|--------------------|----------|
+| NFR-001 | Performance efficiency | {{...}} | {{p95 < 300 ms}} | {{load test at N rps}} | Must |
+| NFR-002 | Reliability (availability, RTO, RPO) | {{...}} | {{...}} | {{...}} | |
+| NFR-003 | Security (authN/Z, encryption, audit) | {{...}} | {{...}} | {{...}} | |
+| NFR-004 | Maintainability | {{...}} | {{...}} | {{...}} | |
+| NFR-005 | Usability / accessibility | {{...}} | {{...}} | {{...}} | |
+| NFR-006 | Observability (logs, metrics, traces) | {{...}} | {{...}} | {{...}} | |
+| NFR-007 | Compatibility / portability | {{...}} | {{...}} | {{...}} | |
+| NFR-008 | Compliance / data protection | {{...}} | {{...}} | {{...}} | |
+
+## 6. Data requirements
+
+| Aspect | Specification |
+|--------|---------------|
+| Data model (overview) | {{entities, key relationships}} |
+| Expected volume | {{records, growth rate}} |
+| Retention | {{period, deletion policy}} |
+| PII classification | {{what PII, sensitivity level}} |
+| Backup / recovery | {{cadence; link to the RPO in NFR-002}} |
+
+## 7. External interfaces and dependencies
+
+| System / API | Direction | Contract | SLA | Failure handling |
+|--------------|-----------|----------|-----|------------------|
+| {{...}} | in / out | {{schema, protocol}} | {{...}} | {{retry, fallback}} |
+
+## 8. Infrastructure and cost estimate
+
+<!-- A number without its assumptions is not usable. State them (they live in §2). -->
+
+- **Architecture (overview):** {{components, hosting model}}
+- **Cost assumptions:** region {{...}}; unit prices as of {{date/source}}; assumed
+  traffic/volume {{...}}.
+
+| Component | Fixed / month | Usage-based basis | Est. / month at baseline | Increment per {{scale unit}} |
+|-----------|---------------|-------------------|--------------------------|------------------------------|
+| {{...}} | {{...}} | {{...}} | {{...}} | {{...}} |
+
+## 9. Operational requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| Monitoring / alerting | {{link to NFR-006}} |
+| Incident response | {{runbook reference}} |
+| Deploy / rollback | {{procedure, rollback trigger}} |
+| Migration | {{data/schema migration needs}} |
+
+## 10. Acceptance criteria
+
+<!-- Each becomes a Definition-of-Done item (WF-090) and maps to tests. Cite req IDs. -->
+
+| ID | Criterion | Verifies (req IDs) | Verification method |
+|----|-----------|--------------------|--------------------|
+| AC-1 | {{...}} | FR-001, NFR-001 | {{test / demo}} |
+
+## 11. Risks
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|----|------|-----------|--------|------------|
+| R-1 | {{...}} | {{L/M/H}} | {{L/M/H}} | {{...}} |
+
+## 12. Milestones
+
+| Milestone | Scope (req IDs) | Target date |
+|-----------|-----------------|-------------|
+| {{...}} | {{...}} | {{...}} |
+
+## 13. Open questions
+
+<!-- Undecided items only. Keep these out of the requirement sections above. -->
+
+| ID | Question | Blocks (req IDs) | Owner | Needed by |
+|----|----------|------------------|-------|-----------|
+| Q-1 | {{...}} | {{...}} | {{...}} | {{...}} |

--- a/docs/foundation/templates/roadmap.md
+++ b/docs/foundation/templates/roadmap.md
@@ -1,0 +1,40 @@
+---
+id: roadmap-template
+title: Roadmap — {{PROJECT_NAME}}
+updated: {{YYYY-MM-DD}}
+---
+
+# Roadmap
+
+<!--
+  FOUNDATION TEMPLATE. Copy to docs/roadmap.md, replace every {{...}}, and delete this
+  guidance comment. After template instantiation, translate every heading and fill the
+  project-specific document in Japanese unless the repository owner or an external
+  contract explicitly requires another language. Keep this template in English
+  (ADR-0005).
+-->
+
+Direction and sequencing. Agents use this to judge whether a proposed change aligns
+with where the project is going (mission.md success criteria) — not as a work queue
+(that's GitHub issues/milestones).
+
+**Update triggers:** milestone completed, priorities re-ordered, scope added/dropped.
+Keep `updated:` current; stale roadmaps mislead agents (DOC-040).
+
+## Now (current milestone)
+
+<!-- TEMPLATE: 1-3 outcomes being pursued right now, each linking a GitHub milestone.
+- Outcome: ... (milestone: ...)  -->
+
+## Next (1-2 milestones out)
+
+<!-- Committed direction, not yet started. -->
+
+## Later (intended, not committed)
+
+<!-- Direction only. Agents MUST NOT build ahead for "Later" items (COD-051). -->
+
+## Explicitly not planned
+
+<!-- Rejected scope, with the reason or ADR link — prevents agents and contributors
+     from re-proposing settled questions. -->


### PR DESCRIPTION
## What & why

Port the second dependency-safe batch from authenticated Template Sync source a177d1f: requirements placement guidance and the remaining project-document templates. Existing ChatChart requirements, glossary, and roadmap remain unchanged at project-owned docs paths.

Refs: #37

## Change classification (ARC-020)

- [x] Local (mechanical inherited documentation batch)
- [ ] Contract
- [ ] Architectural

## Breaking change?

- [x] No
- [ ] Yes

## Testing (GR-021 / TST-002)

- How verified: make format, make lint, make test (36/36), make doctor (73 governance tests, 4 target boundary tests, 71 guard tests), and git diff --check passed.
- Verified all five files exactly match generated branch chore/template_sync_a177d1f.
- Docs-only batch; no runtime behavior changed.

## Documentation (DOC-030)

- [x] Foundation templates added only under docs/foundation/templates/; project documents retained.

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against .ai/review-checklist.md completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] make format && make lint && make test green
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (.ai/guardrails.md)