### PR TITLE
docs(foundation): add inherited project guides

### DIFF
--- a/docs/foundation/guides/api.md
+++ b/docs/foundation/guides/api.md
@@ -1,0 +1,35 @@
+---
+id: api-docs
+title: API Documentation
+---
+
+# API Documentation
+
+Defines what an instantiated repository records under `docs/api/` for every interface
+the project exposes (HTTP, events, CLI).
+
+**Update triggers (DOC-030):** any change to a public endpoint, event schema, CLI
+command, or error contract. Breaking contract changes additionally require the
+`BREAKING CHANGE:` commit footer (WF-020) and consumer migration notes.
+
+## Recommended project content
+
+- **Schema first**: use the machine-readable contract (OpenAPI 3.x at `openapi.yaml`,
+  AsyncAPI for events, JSON Schema for payloads) is the source of truth; prose
+  commentary supplements, never contradicts.
+- Contract tests verify implementation against the schema (TST-001 integration level);
+  drift between schema and implementation is a CI failure, not a doc chore.
+- Document each endpoint's auth requirement (SEC-020), inputs with validation rules,
+  outputs, error responses with trigger conditions, idempotency, and rate limits.
+- Examples use obviously fake credentials (GR-002) and realistic payloads.
+- Versioning: breaking API changes follow expand→migrate→contract (REL-040); document
+  deprecation windows here.
+
+## Structure
+
+| File | Content |
+|------|---------|
+| `docs/api/openapi.yaml` | HTTP API contract (source of truth) |
+| `docs/api/events.md` / `docs/api/asyncapi.yaml` | Published/consumed events |
+| `docs/api/errors.md` | Error catalog: code → meaning → caller action |
+| `docs/api/changelog.md` | Contract-level changes and deprecation schedule |

--- a/docs/foundation/guides/architecture.md
+++ b/docs/foundation/guides/architecture.md
@@ -1,0 +1,36 @@
+---
+id: architecture-docs
+title: Architecture Documentation
+---
+
+# Architecture Documentation
+
+Defines what an instantiated repository records under `docs/architecture/`. The *rules*
+live in [.ai/architecture.md](../../../.ai/architecture.md); inherited decisions live in
+the [foundation ADRs](../adr/), and project decisions live in `docs/adr/`. If a project
+architecture document contradicts any of them, that project document is wrong.
+
+**Update triggers (DOC-030):** new module, changed module boundary, new external
+dependency/integration, changed data flow, new infrastructure component.
+
+## Structure (create these files as the system grows)
+
+| File | Content | Format |
+|------|---------|--------|
+| `docs/architecture/c4-context.md` | System in its environment: users, external systems | Mermaid C4/flowchart |
+| `docs/architecture/c4-container.md` | Deployable units and their interactions | Mermaid |
+| `docs/architecture/modules.md` | Bounded-context map: every `src/modules/*` + one-line purpose + dependencies between them | Mermaid + table |
+| `docs/architecture/data-flow.md` | How data moves for the 3–5 most important flows | Mermaid sequence |
+| `docs/architecture/infrastructure.md` | Runtime topology: compute, storage, network | Mermaid + table |
+
+## Conventions
+
+- Diagrams are **Mermaid in Markdown** — diffable, renderable on GitHub, writable by
+  agents. No binary diagram files (DOC-001).
+- Every diagram is followed by a prose paragraph stating what an agent should conclude
+  from it (diagrams alone are ambiguous).
+- Module-level detail belongs in each module's `MODULE.md`, not here — here is the map,
+  there is the territory.
+
+<!-- TEMPLATE: this directory starts empty except this README. Create modules.md with
+     the first real module. -->

--- a/docs/foundation/guides/deployment.md
+++ b/docs/foundation/guides/deployment.md
@@ -1,0 +1,33 @@
+---
+id: deployment-docs
+title: Deployment Documentation
+---
+
+# Deployment
+
+Defines what an instantiated repository records under `docs/deployment/` to explain how
+the project reaches each environment. All infrastructure is code (IaC); manual console
+changes are configuration drift and get reverted.
+
+**Update triggers (DOC-030):** new environment variable (also `.env.example`), new
+environment, changed deploy procedure, new infrastructure component, changed rollback
+procedure.
+
+## Structure
+
+| File | Content |
+|------|---------|
+| `docs/deployment/environments.md` | Environment matrix: name, purpose, URL, who may deploy, data class allowed (SEC-011) |
+| `docs/deployment/procedure.md` | Deploy pipeline: trigger → stages → verification → rollback; who/what approves (REL-010) |
+| `docs/deployment/configuration.md` | Every config variable: name, purpose, per-env source (secret manager path — never values, GR-001) |
+| `docs/deployment/provisioning.md` | How to create/modify infrastructure via IaC (`infra/`), state management, review flow |
+
+## Related binding rules
+
+- Environments: at minimum `staging` (production-like, safe for DAST) and `production`.
+- Production deployment and rollback follow
+  [`.ai/release.md`](../../../.ai/release.md) (REL-010, REL-040).
+- Deployment secrets follow [`.ai/guardrails.md`](../../../.ai/guardrails.md)
+  (GR-001/003).
+- Record smoke verification and rollback procedures under `docs/deployment/` and
+  `docs/runbook/`.

--- a/docs/foundation/guides/domain.md
+++ b/docs/foundation/guides/domain.md
@@ -1,0 +1,51 @@
+---
+id: domain-docs
+title: Domain Model Documentation
+---
+
+# Domain Model
+
+Defines how an instantiated repository documents the business reality it models (DDD).
+Code names follow reusable terms in the [foundation glossary](../glossary.md) and
+project terms in `docs/glossary.md` under [COD-002](../../../.ai/coding-rules.md).
+
+**Update triggers (DOC-030):** new domain concept, changed business rule, new bounded
+context, changed context relationships, PII-bearing entity added (also SEC-011).
+
+## Structure
+
+| File | Content |
+|------|---------|
+| `docs/domain/context-map.md` | Bounded contexts and their relationships (partnership, customer-supplier, ACL...) — Mermaid |
+| `docs/domain/<context>.md` | Per context: core entities, value objects, aggregates, invariants, domain events, state machines |
+
+## Per-context file template
+
+```markdown
+---
+id: domain-<context>
+title: <Context> Domain
+---
+
+# <Context>
+
+Purpose: <one paragraph — what business capability this context owns>
+
+## Aggregates
+| Aggregate | Root entity | Invariants that always hold |
+|-----------|-------------|-------------------------------|
+
+## Value objects
+| Name | Definition | Validation rules |
+
+## Domain events
+| Event | Emitted when | Consumed by |
+
+## Business rules
+Numbered, testable statements. Each rule should map to at least one test (TST-002).
+
+## Data classification (SEC-011)
+| Entity/field | Class (Secret/PII/Internal/Public) | Handling notes |
+```
+
+<!-- TEMPLATE: create context-map.md with the first bounded context. -->

--- a/docs/foundation/guides/operations.md
+++ b/docs/foundation/guides/operations.md
@@ -1,0 +1,29 @@
+---
+id: operations-docs
+title: Operations Documentation
+---
+
+# Operations
+
+Defines what an instantiated repository records under `docs/operations/` to keep the
+project healthy day-to-day: observability, SLOs, alerts, and maintenance.
+
+**Update triggers (DOC-030):** new critical path (needs metrics + alert), new alert,
+changed SLO, new scheduled maintenance task, post-incident action items.
+
+## Structure
+
+| File | Content |
+|------|---------|
+| `docs/operations/observability.md` | Where logs/metrics/traces go; how to query them; correlation IDs |
+| `docs/operations/slo.md` | SLIs and SLO targets per critical path; error budget policy |
+| `docs/operations/alerts.md` | Alert catalog: condition → severity → runbook link |
+| `docs/operations/maintenance.md` | Recurring tasks (rotation, cleanup, upgrades) with schedule and owner |
+
+## Related binding rules
+
+- Logging and data handling follow [`.ai/architecture.md`](../../../.ai/architecture.md)
+  (ARC-010) and [`.ai/security.md`](../../../.ai/security.md) (SEC-011).
+- Reliability review follows
+  [`.ai/review-checklist.md`](../../../.ai/review-checklist.md) (REV-REL).
+- Project alert severity and escalation policy belong in `docs/operations/alerts.md`.

--- a/docs/foundation/guides/project-documentation.md
+++ b/docs/foundation/guides/project-documentation.md
@@ -1,0 +1,33 @@
+---
+id: project-documentation-guide
+title: Project Documentation Guide
+---
+
+# Project Documentation Guide
+
+This guide defines where an instantiated repository stores project-owned documentation.
+Binding rules live in [`.ai/`](../../../.ai/); inherited decisions live in the
+[foundation ADRs](../adr/), project decisions live in `docs/adr/`, and writing rules live in
+[`.ai/documentation.md`](../../../.ai/documentation.md).
+
+| Directory | Content | Primary reader task |
+|-----------|---------|---------------------|
+| [docs/foundation/adr/](../adr/) | Synchronized foundation Architecture Decision Records (**normative** when accepted) | "why does the inherited foundation work this way?" |
+| `docs/adr/` | Project Architecture Decision Records (**normative** when accepted) | "why is this project built this way?" |
+| [docs/foundation/](../) | Synchronized foundation-owned guidance and document templates | use inherited documentation support |
+| `docs/requirements.md`, `docs/requirements/` | Project-owned whole-project and initiative requirements | determine what must be built and why |
+| `docs/architecture/` | System structure, C4 diagrams, data flows | understand before changing structure |
+| `docs/domain/` | Domain model, bounded contexts, ubiquitous language | understand the business rules |
+| `docs/api/` | API contracts (OpenAPI/schema + commentary) | integrate with or change an API |
+| `docs/deployment/` | Environments, deploy procedure, configuration | ship it |
+| `docs/operations/` | Monitoring, alerts, SLOs, maintenance | keep it running |
+| `docs/runbook/` | Step-by-step incident/ops procedures | 3am emergency |
+| `docs/troubleshooting/` | Known failure modes → diagnosis → fix | "it's broken, what now?" |
+| `docs/roadmap.md` | Direction and planned milestones | prioritize work |
+| `docs/glossary.md` | Project ubiquitous language dictionary | name things correctly |
+
+Contribution guide: [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+The guides in this directory define structure and **update triggers** without placing
+foundation-owned README files in project-owned paths. The doc-update matrix (DOC-030)
+tells you which project directory a given change must touch.

--- a/docs/foundation/guides/runbook.md
+++ b/docs/foundation/guides/runbook.md
@@ -1,0 +1,55 @@
+---
+id: runbook-index
+title: Runbooks
+---
+
+# Runbooks
+
+Defines the step-by-step procedures an instantiated repository stores under
+`docs/runbook/`. They must be executable under stress by a human or an AI agent with
+operational access, with an expected result and an "if not, then" branch for every step.
+
+**Update triggers (DOC-030):** new alert (every alert links here), new failure mode
+discovered in an incident, changed deploy/rollback procedure, risky release (REL-040).
+
+## Entry format (`docs/runbook/<slug>.md`)
+
+```markdown
+---
+id: runbook-<slug>
+title: <symptom or task name>
+severity: page | ticket
+last-verified: YYYY-MM-DD
+---
+
+# <Symptom or task>
+
+**Trigger:** <the alert or situation that brings you here>
+**Impact if unhandled:** <what breaks, for whom>
+**Safe to execute by agent:** yes / no — <destructive steps require human per GR-031>
+
+## Steps
+1. <action — exact command or console path>
+   - Expect: <observable result>
+   - If not: <next step or escalate to X>
+2. ...
+
+## Verification
+<how to confirm resolution — exact check>
+
+## Escalation
+<who/what, with contact/channel, when steps are exhausted>
+```
+
+## Checklist
+
+- Exact commands, no placeholders that require guessing; parameterize with env vars.
+- Mark destructive steps and link
+  [GR-031](../../../.ai/guardrails.md) so an agent requests explicit human approval.
+- Each runbook is re-verified after any related procedure change; stale runbooks are
+  worse than none — `last-verified` is mandatory.
+
+## Index
+
+<!-- | Runbook | Trigger | Severity | -->
+<!-- populate as runbooks are added -->

--- a/docs/foundation/guides/troubleshooting.md
+++ b/docs/foundation/guides/troubleshooting.md
@@ -1,0 +1,37 @@
+---
+id: troubleshooting-index
+title: Troubleshooting Guide
+---
+
+# Troubleshooting
+
+Defines how an instantiated repository records known project failure modes under
+`docs/troubleshooting/`: symptom → diagnosis → fix. Unlike runbooks (operational
+emergencies), this covers development-time and user-reported problems.
+
+**Update triggers (DOC-030):** every bug fix with a user-visible symptom
+(bugfix.skill.md step 7), every support question answered twice, every setup pitfall
+discovered.
+
+## Entry format (append to `docs/troubleshooting/known-issues.md`, or use one project
+file per area when it grows)
+
+```markdown
+## <Exact symptom — the error message or observable behavior, verbatim>
+
+**Affects:** <versions/environments>
+**Cause:** <one-sentence root cause>
+**Fix:**
+1. <exact steps/commands>
+
+**Prevention:** <what stops recurrence, if anything>
+**Refs:** #<issue>, <ADR/rule ID if relevant>
+```
+
+## Checklist
+
+- Headings are the **verbatim error message** where one exists — that's what agents and
+  humans search for.
+- Every entry links its issue; entries for fixed bugs state the fixed-in version and
+  are deleted once no supported version is affected (DOC-040).
+- If diagnosis requires more than 5 steps, it belongs in a runbook — link instead.


### PR DESCRIPTION
## What & why

Port the third dependency-safe batch from authenticated Template Sync source a177d1f: eight reusable guides for project documentation directories. The guides live only under docs/foundation/guides/ and do not overwrite ChatChart's Japanese project documents.

Refs: #37

## Change classification (ARC-020)

- [x] Local (mechanical inherited documentation batch)
- [ ] Contract
- [ ] Architectural

## Breaking change?

- [x] No
- [ ] Yes

## Testing (GR-021 / TST-002)

- How verified: make format, make lint, make test (36/36), make doctor (73 governance tests, 4 target boundary tests, 71 guard tests), and git diff --check passed.
- Verified all eight files exactly match generated branch chore/template_sync_a177d1f.
- Docs-only batch; no runtime behavior changed.

## Documentation (DOC-030)

- [x] Foundation guides added only under docs/foundation/guides/; project documents retained.

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against .ai/review-checklist.md completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] make format && make lint && make test green
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (.ai/guardrails.md)