### PR TITLE
docs(foundation): add inherited troubleshooting

### DIFF
--- a/docs/foundation/troubleshooting/README.md
+++ b/docs/foundation/troubleshooting/README.md
@@ -1,0 +1,17 @@
+---
+id: foundation-troubleshooting-index
+title: Foundation Troubleshooting
+---
+
+# Foundation Troubleshooting
+
+These runbooks diagnose reusable foundation tooling. Project-specific failures and
+their remedies belong in the project-owned `docs/troubleshooting/` path.
+
+| Guide | Scope |
+|-------|-------|
+| [github-governance.md](github-governance.md) | Governance policy validation and audit failures |
+| [template-inheritance.md](template-inheritance.md) | Direct-parent inheritance validation and planning failures |
+
+**Update trigger:** add or update an entry when foundation tooling gains a reusable
+failure mode or diagnostic procedure.

--- a/docs/foundation/troubleshooting/github-governance.md
+++ b/docs/foundation/troubleshooting/github-governance.md
@@ -1,0 +1,75 @@
+---
+id: github-governance-troubleshooting
+title: GitHub Governance Troubleshooting
+updated: 2026-07-18
+---
+
+# GitHub Governance Troubleshooting
+
+This guide resolves governance validation and read-only audit failures. It does not
+authorize or perform GitHub setting changes.
+
+## `audit` exits with status 1
+
+**Affects:** `scripts/github_governance.py audit`
+
+**Cause:** At least one control is `drift` or `unknown`. A required check name that is
+not observed on the target branch head is also drift.
+
+**Fix:**
+
+1. Read the JSON `controls` entries whose `status` is not `compliant`.
+2. For `drift`, review the desired policy and current GitHub state. Use the documented
+   exact-confirmation `apply` flow only after the change is approved.
+3. For `unknown`, rerun locally with `gh` authentication that can read repository
+   administration settings.
+4. For `branch.required_status_checks_observed`, verify the named workflow runs on the
+   target branch and rerun the audit after it completes.
+
+**Prevention:** Run `plan` after changing policy or required workflow names.
+
+**Refs:** #18, ADR-0003
+
+## `governance policy error: profiles must form one parent chain rooted at ai-dev-foundation`
+
+**Affects:** all `scripts/github_governance.py` commands
+
+**Cause:** Profiles are branched, cyclic, orphaned, or do not connect to the foundation
+root through their explicit `parent` fields. Duplicate IDs produce their own explicit
+error before chain validation.
+
+**Fix:** Keep only the profiles for this repository's direct-parent lineage. Set the
+first profile parent to `ai-dev-foundation` and each later parent to the preceding
+profile ID; file names do not set the order.
+
+**Prevention:** Run offline `validate` in the profile-owning template before inheritance.
+
+**Refs:** #32, ADR-0004
+
+## `governance policy error: profile directory must not use symlinks`
+
+**Affects:** all `scripts/github_governance.py` commands
+
+**Cause:** The profile directory or one of its parent components inside the repository
+is a symlink.
+
+**Fix:** Replace linked path components with reviewed regular directories inside the
+repository.
+
+**Prevention:** Keep the governance directory entirely repository-owned.
+
+**Refs:** #32, ADR-0004, SEC-010
+
+## `governance policy error: profile must be a regular file without symlinks`
+
+**Affects:** all `scripts/github_governance.py` commands
+
+**Cause:** A discovered `.github/governance/profiles/*.json` entry is a symlink or is not
+a regular file.
+
+**Fix:** Replace it with a reviewed regular JSON file inside the profile directory.
+
+**Prevention:** Inherit committed profile files; do not link policy from outside the
+repository.
+
+**Refs:** #32, ADR-0004, SEC-010

--- a/docs/foundation/troubleshooting/template-inheritance.md
+++ b/docs/foundation/troubleshooting/template-inheritance.md
@@ -1,0 +1,35 @@
+---
+id: template-inheritance-troubleshooting
+title: Template Inheritance Troubleshooting
+updated: 2026-07-18
+---
+
+# Template Inheritance Troubleshooting
+
+This guide diagnoses read-only inheritance validation and planning failures. It does not
+authorize fetching, materialization, deletion, or a lock change.
+
+## `parent origin does not match manifest.parent.repository`
+
+**Affects:** `scripts/template_inheritance.py plan`
+
+**Cause:** `--parent-root` points to a different GitHub repository than the manifest's
+direct parent.
+
+**Fix:** Select the declared parent's local checkout. If the manifest is wrong, change
+it only through a reviewed child-repository PR.
+
+**Refs:** #32, ADR-0004
+
+## `locked commit is not on the remote branch first-parent history`
+
+**Affects:** `scripts/template_inheritance.py plan`
+
+**Cause:** The lock is not on the local `origin/<branch>` first-parent chain, or the
+local parent checkout lacks the required history.
+
+**Fix:** Confirm the parent and branch from the manifest, then explicitly refresh the
+local parent checkout. Do not replace the lock merely to silence this error; investigate
+whether upstream history changed or the wrong parent was selected.
+
+**Refs:** #32, ADR-0004


### PR DESCRIPTION
## What & why

Port the fourth dependency-safe batch from authenticated Template Sync source a177d1f: reusable foundation troubleshooting for governance and template inheritance. ChatChart-specific troubleshooting remains project-owned and unchanged.

Refs: #37

## Change classification (ARC-020)

- [x] Local (mechanical inherited documentation batch)
- [ ] Contract
- [ ] Architectural

## Breaking change?

- [x] No
- [ ] Yes

## Testing (GR-021 / TST-002)

- How verified: make format, make lint, make test (36/36), make doctor (73 governance tests, 4 target boundary tests, 71 guard tests), and git diff --check passed.
- Verified all three files exactly match generated branch chore/template_sync_a177d1f.
- Docs-only batch; no runtime behavior changed.

## Documentation (DOC-030)

- [x] Foundation troubleshooting added only under docs/foundation/troubleshooting/.

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against .ai/review-checklist.md completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] make format && make lint && make test green
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (.ai/guardrails.md)