### PR TITLE
docs(foundation): add inherited onboarding guides

### DIFF
--- a/docs/foundation/guides/README.md
+++ b/docs/foundation/guides/README.md
@@ -1,0 +1,33 @@
+---
+id: foundation-documentation-guides
+title: Foundation Documentation Guides
+---
+
+# Foundation Documentation Guides
+
+These guides define the purpose, structure, and update triggers of project-owned
+documentation paths without occupying those paths with foundation-owned README files.
+They are descriptive mappings. Binding behavior remains in
+[`.ai/documentation.md`](../../../.ai/documentation.md) and the rule files it references.
+
+| Guide | Project-owned destination |
+|-------|---------------------------|
+| [project-documentation.md](project-documentation.md) | `docs/` |
+| [architecture.md](architecture.md) | `docs/architecture/` |
+| [domain.md](domain.md) | `docs/domain/` |
+| [api.md](api.md) | `docs/api/` |
+| [deployment.md](deployment.md) | `docs/deployment/` |
+| [operations.md](operations.md) | `docs/operations/` |
+| [runbook.md](runbook.md) | `docs/runbook/` |
+| [troubleshooting.md](troubleshooting.md) | `docs/troubleshooting/` |
+
+## Onboarding references
+
+| Guide | Purpose |
+|-------|---------|
+| [usage.md](usage.md) | Create a project from the foundation or develop the foundation itself |
+| [usage.ja.md](usage.ja.md) | Japanese human-facing version of the usage guide |
+| [ai-instruction-files.ja.md](ai-instruction-files.ja.md) | Japanese guide to the reusable AI instruction system |
+
+**Update trigger:** update the matching guide whenever the project documentation
+inventory, structure, or DOC-030 trigger changes.

--- a/docs/foundation/guides/ai-instruction-files.ja.md
+++ b/docs/foundation/guides/ai-instruction-files.ja.md
@@ -1,0 +1,312 @@
+---
+id: ai-instruction-files-ja
+title: AI指示ファイル・ガイド（日本語）
+updated: 2026-07-18
+---
+
+# AIへ指示を出すファイル群ガイド（日本語）
+
+このリポジトリには、AIエージェント（Claude Code / ChatGPT / Gemini / Codex など）の
+振る舞いを「指示・案内・制約」するファイルが多数あります。本書はそれら**すべて**について、
+**利用目的 / 利用シーン / 利用しないシーン / 利用例**を日本語でまとめた早見リファレンスです。
+
+> 人間向けの解説ドキュメントです（ADR-0002：ルール本体は英語、人間向け解説は日本語版可）。
+> 各ファイルの**内容の正**は元ファイル自身です。矛盾があれば元ファイルが優先します。
+
+## 0. 全体像 — 3層 + 補助
+
+```
+┌─ 入口 ────────────────────────────────────────────────┐
+│ CLAUDE.md（Claude Code）/ AGENTS.md（他エージェント）   │  ← まずここを読む
+└───────────────┬───────────────────────────────────────┘
+                │ 参照
+┌─ ルール本体（.ai/）─────────────────────────────────────┐
+│ guardrails > security > CLAUDE.md > その他 .ai/ > docs/  │  ← 唯一の「正」
+│ README(索引/ルーティング) + 各ドメインのルール           │
+└───────────────┬───────────────────────────────────────┘
+                │ タスク種別で選ぶ
+┌─ 手順書（.skills/）─────────────────────────────────────┐
+│ feature / bugfix / refactor / ... 各タスクの実行手順      │
+└───────────────────────────────────────────────────────┘
+
+  補助: .claude/（Claude固有の自動強制）, docs/foundation/adr/（基盤の意思決定）,
+        MODULE.md（モジュール契約）, Issue/PRテンプレート（AIへの構造化入力）,
+        ~/.claude・~/projects/CLAUDE.md（全リポ共通のグローバル指示）
+```
+
+**優先順位（矛盾時に強い方）**：`guardrails.md > security.md > CLAUDE.md/AGENTS.md >
+その他の .ai/*.md > docs/**`。矛盾は黙って解決せず、強い方に従い人間へ報告します。
+
+## 1. カテゴリ早見表
+
+| カテゴリ | ファイル | 一言 |
+|----------|----------|------|
+| 入口 | [CLAUDE.md](../../../CLAUDE.md), [AGENTS.md](../../../AGENTS.md) | 最初に読む運用マニュアル |
+| ルール索引 | [.ai/README.md](../../../.ai/README.md) | 優先順位・タスク別ルーティング表 |
+| ルール本体 | [.ai/](../../../.ai/) の各 `*.md` | 分野別の正準ルール（ID付き） |
+| 手順書 | [.skills/](../../../.skills/) の各 `*.skill.md` | タスク別の実行プレイブック |
+| 自動強制 | [.claude/](../../../.claude/) | Claude Code のフック（即時ブロック/整形）・権限制御・ネイティブSkill |
+| 意思決定 | [docs/foundation/adr/](../adr/)、`docs/adr/` | 基盤と利用先の「なぜ」を所有者別に記録 |
+| 用語 | [docs/foundation/glossary.md](../glossary.md)、`docs/glossary.md` | 基盤と利用先プロジェクトの統一用語 |
+| ソース構造 | [src/README.md](../../../src/README.md), [tests/README.md](../../../tests/README.md) | コード配置規約・MODULE.md雛形 |
+| 方向性 | `docs/roadmap.md` | 利用先で何を作る/作らないかの指針 |
+| 契約 | `src/modules/*/MODULE.md`, [profiles/README.md](../../../profiles/README.md) | モジュール/makeターゲットの契約 |
+| 構造化入力 | [.github/](../../../.github/) の Issue/PR テンプレート | AIへの指示を型化 |
+| グローバル | `~/.claude/CLAUDE.md`, `~/projects/CLAUDE.md` | 全リポ共通の好み（リポ外・Claude固有） |
+
+---
+
+## 2. 入口ファイル
+
+### `CLAUDE.md`
+
+- **利用目的**：全AIエージェント共通の運用マニュアル（拘束力あり）。§12 のみ Claude Code 固有。
+- **利用シーン**：セッション開始時に必ず全読。タスク種別の判定、`.ai/` へのルーティング、禁止事項の把握。
+- **利用しないシーン**：詳細な分野ルールの参照（要約なので、深掘りは `.ai/` 本体を読む）。個別スタックの具体コマンド（Makefile 実装を見る）。
+- **利用例**：Claude Code でリポジトリを開くと自動で読み込まれる。§2 のルーティング表で「バグ修正なら workflow.md + testing.md + bugfix.skill.md だけ読む」と判断。
+
+### `AGENTS.md`
+
+- **利用目的**：Claude 以外のエージェント（ChatGPT/Gemini/Codex）の入口。`CLAUDE.md` へ誘導し、§12（Claude固有）の等価手段を示す。
+- **利用シーン**：非Claudeエージェントにこのリポジトリを触らせるとき、最初に読ませる。
+- **利用しないシーン**：Claude Code を使うとき（`CLAUDE.md` が自動で読まれるため不要）。
+- **利用例**：ChatGPT に「まず `AGENTS.md` を読んで、その指示に従って」と指定 → フックが無い分、`make lint` を手動実行するなどの等価手段に読み替える。
+
+---
+
+## 3. ルール本体（`.ai/`）— 唯一の「正」
+
+すべて**ID付き**（GR-/SEC-/ARC-/COD-/TST-/REL-/DOC-/REV-/WF-/LOG-）。コミットやレビューで
+`「GR-010 違反」`のように一意参照します。
+
+### `.ai/README.md`（索引・ルーティング）
+
+- **利用目的**：`.ai/` の地図。優先順位（権威順）とタスク別の「読むべきファイル表」を提供。
+- **利用シーン**：タスク開始時に「何を読むべきか」を決める。矛盾の解決順を確認する。
+- **利用しないシーン**：具体的なルール内容そのものの参照（各ドメインファイルを見る）。
+- **利用例**：「新機能」→ 表に従い workflow / architecture / coding-rules / testing + feature.skill を読み込む。
+
+### ルール各ファイル（早見表）
+
+| ファイル | 利用目的（何を規定） | 利用シーン | 利用しないシーン | 利用例 |
+|----------|----------------------|------------|------------------|--------|
+| [guardrails.md](../../../.ai/guardrails.md) | 絶対禁止（GR）。指示でも覆せない | 全タスクの前提。破壊的操作の前 | 「推奨」レベルの判断（それは各ルール） | `curl\|sh` を実行しようとして GR-032 でブロック |
+| [security.md](../../../.ai/security.md) | セキュリティ運用（SEC） | 認証/入力/秘密情報/依存を扱う時、レビュー、リリース | UIの見た目調整など非セキュリティ作業 | 新エンドポイント追加時に SEC-020（既定deny）を適用 |
+| [architecture.md](../../../.ai/architecture.md) | 構造・層・依存方向（ARC） | 新機能、リファクタ、モジュール変更 | ドキュメントのみの修正 | domain から DB ドライバを import しようとして ARC-002 で回避 |
+| [coding-rules.md](../../../.ai/coding-rules.md) | 命名・エラー処理・依存方針（COD） | コードを書く/直す全般 | 設計そのものの是非（architecture へ） | 3回目の重複で初めて抽象化（COD-020） |
+| [testing.md](../../../.ai/testing.md) | テスト戦略・カバレッジ（TST） | テスト作成、バグ修正、リファクタ | 純粋なドキュメント変更 | バグ修正で「まず落ちる回帰テスト」を書く（TST-002） |
+| [workflow.md](../../../.ai/workflow.md) | タスクの進め方・コミット規約（WF） | ほぼ全タスク（intake→PR） | 単発の質問応答 | ブランチ名 `fix/207-null-avatar`、Conventional Commits（WF-020） |
+| [release.md](../../../.ai/release.md) | バージョニング・リリース手順（REL） | リリース準備 | 通常の機能開発中 | `feat` コミットから MINOR を自動導出（REL-001） |
+| [documentation.md](../../../.ai/documentation.md) | ドキュメント規約・更新マトリクス（DOC） | ドキュメント作成、機能変更に伴う更新 | コード内部だけの微修正 | API変更時に doc-update matrix で `docs/api/` 更新を判定（DOC-030） |
+| [review-checklist.md](../../../.ai/review-checklist.md) | 10観点のレビュー基準（REV） | PRレビュー、PR前のセルフレビュー | 実装中の細かい判断 | セルフレビューで REV-SEC を走査し秘密混入を確認 |
+| [mission.md](../../../.ai/mission.md) | プロジェクトの目的・成功基準 | 方向性の妥当性判断、オンボーディング | 日々の実装詳細 | 提案が mission の成功基準に沿うか照合 |
+| [decision-log.md](../../../.ai/decision-log.md) | 意思決定の追記索引（LOG/ADR） | 設計変更前に「既に決まってないか」確認、変更後に追記 | 通常の実装 | LOG-0006「jq無しでもガードが動く」を読み、正規表現を安易に簡素化しない |
+
+---
+
+## 4. 手順書（`.skills/`）— タスク別プレイブック
+
+各スキルは「目的 / 入力 / 手順 / 判断基準 / 出力 / チェックリスト」を持つ自己完結の手順書。
+ルーティング表（`.ai/README.md`）で**タスクに一致した時だけ**読み込みます。
+
+### [.skills/README.md](../../../.skills/README.md)
+
+- **利用目的**：スキルの形式契約と一覧。Claude Code ネイティブ Skill 化の方法も記載。
+- **利用シーン**：新しいスキルを追加/編集するとき、どのスキルがあるか俯瞰したいとき。
+- **利用しないシーン**：実タスクの実行中（個別スキルを直接読む）。
+- **利用例**：新スキル追加時に、必須セクション（目的/入力/…）の形式を確認。
+
+### スキル早見表
+
+| スキル | 利用目的 | 利用しないシーン | 利用例 |
+|--------|----------|------------------|--------|
+| [requirements](../../../.skills/requirements.skill.md) | 何を作るかを要件定義（目的優先・ゼロベース・対話で決定を詰める） | 実装作業そのもの（featureへ） | 目的を1文で固定→決定を1つずつ推奨案付きで詰める→FR/NFR採番→テンプレ記入 |
+| [feature](../../../.skills/feature.skill.md) | 新機能を端から端まで実装 | 既存バグの修正（bugfixへ） | issue の受入基準を Definition of Done として実装 |
+| [bugfix](../../../.skills/bugfix.skill.md) | 欠陥を根本原因から修正 | 新機能追加、純粋な整形 | 再現→落ちる回帰テスト→原因修正→周辺捜索 |
+| [refactor](../../../.skills/refactor.skill.md) | 振る舞いを変えず構造改善 | 挙動を変える変更（featureへ） | 特性テストで固定→機械的に段階リネーム/抽出 |
+| [architecture](../../../.skills/architecture.skill.md) | 構造/境界/技術の変更（ADR必須） | 局所的なコード修正 | 2〜4案（何もしない含む）比較→ADR→人間承認→段階移行 |
+| [test](../../../.skills/test.skill.md) | テストの追加/改善/flaky修復 | 実装そのもの | 振る舞い列挙→境界マトリクス（空/1/多/最大/異常） |
+| [security](../../../.skills/security.skill.md) | 脆弱性対応・堅牢化・監査 | 通常の機能実装 | スキャナ指摘の分類→信頼境界で修正→性質をテスト化 |
+| [documentation](../../../.skills/documentation.skill.md) | ドキュメント作成/保守 | コードのみの変更 | doc-update matrix の義務を満たし、リンク/コマンドを実検証 |
+| [review](../../../.skills/review.skill.md) | PRレビュー/セルフレビュー | 実装作業そのもの | 10観点を走査し Blocker>Major>Minor で file:line+ID+修正案 |
+| [release](../../../.skills/release.skill.md) | リリース準備（人間が承認） | 日常開発 | REL-020 ゲート検証→リスク要約→**マージは人間** |
+
+- **スキル全体を使わないシーン**：会話的な単発質問、些末な機械的編集（スキルを読むまでもない場合）。
+
+---
+
+## 5. Claude Code 固有の自動強制（`.claude/`）
+
+「コンテキストとしての指示」ではなく、**実際にコマンドを止める/実行する**強制層です（Claude Code のみ）。
+
+### [.claude/settings.json](../../../.claude/settings.json)
+
+- **利用目的**：フックの登録（PreToolUse ガード／PostToolUse 整形）と権限制御。`permissions.deny` で `.env` 等の読取拒否、`permissions.allow` で**非変更の読取専用コマンド**（`make doctor/lint/test`・読取系 git など）を事前許可し確認プロンプトを削減。`deny` が `allow` に優先。
+- **利用シーン**：Claude Code セッション中、常時自動適用（あなたが意識する必要はない）。
+- **利用しないシーン**：他エージェント（読まれない）。挙動を変えたい時は編集するが、`.local.json` は個人用。
+- **利用例**：ファイル編集後に自動で `make format`/`make lint` が走り、失敗はエージェントへフィードバックされる。`make test` は事前許可済みなので確認なしで実行、`make format`（変更を伴う）は引き続き確認される。
+
+### [.claude/skills/](../../../.claude/skills/)（ネイティブ Skill ラッパー）
+
+- **利用目的**：`.skills/*.skill.md` を Claude Code のネイティブ Skill として公開し、`/requirements` のように直接呼び出せるようにする薄いラッパー（`<name>/SKILL.md`）。中身は frontmatter ＋「`.skills/<name>.skill.md` を読んで従え」の1行のみで、手順の本体は `.skills/` が唯一の正。
+- **利用シーン**：Claude Code でスキルをコマンド的に起動したいとき。
+- **利用しないシーン**：他エージェント（ラッパーを無視し、ルーティング表経由で `.skills/` を直接読む）。ラッパーに手順を複製すること（正の二重化になる）。
+- **利用例**：`/requirements` で要件定義スキルを起動 → 実体の `.skills/requirements.skill.md` の手順が実行される。新スキル追加時は同PRで対応するラッパーも追加する。
+
+### [.claude/hooks/guard-bash.sh](../../../.claude/hooks/guard-bash.sh)
+
+- **利用目的**：ガードレール違反の Bash コマンドを実行前にブロック（GR-010/011/012/031/032）。
+- **利用シーン**：Claude Code が Bash を実行する度、自動で通過チェック。
+- **利用しないシーン**：手動で回避してはいけない（GR-012）。他エージェントでは AGENTS.md の等価手段（実行前に自己チェック）。
+- **利用例**：`git push origin main` → exit 2 でブロックし「PRを作れ」と提示。`rm -rf /etc` もブロック。
+
+### [.claude/hooks/post-edit-quality.sh](../../../.claude/hooks/post-edit-quality.sh)
+
+- **利用目的**：Edit/Write の後に対象ファイルを自動 format + lint（COD-001）。
+- **利用シーン**：コード編集の直後に自動。
+- **利用しないシーン**：Markdown 等の非コード（スキップされる）。テンプレート状態では Makefile が no-op のため実質何もしない。
+- **利用例**：`.py` を編集 → 自動整形、lint 失敗ならエージェントへ「先に直せ」と返る。
+
+### [.claude/hooks/tests/guard-bash.test.sh](../../../.claude/hooks/tests/guard-bash.test.sh)
+
+- **利用目的**：ガードの block/allow マトリクス全ケースを固定する回帰テスト（`make doctor` と CI が実行）。
+- **利用シーン**：ガードの正規表現を変更した時、CI/doctor で自動検証。
+- **利用しないシーン**：通常の開発中に手動で気にする必要はない。
+- **利用例**：ガードを直したら `bash .claude/hooks/tests/guard-bash.test.sh` で全件パスを確認。
+
+### [.claude/agents/code-reviewer.md](../../../.claude/agents/code-reviewer.md)（レビュー特化サブエージェント）
+
+- **利用目的**：現在の差分を10観点チェックリストでレビューする読み取り専用サブエージェント。WF-090 のセルフレビューを操作可能にする。観点・手順の本体は `.ai/review-checklist.md` と `.skills/review.skill.md` が正典で、定義は薄い参照のみ。
+- **利用シーン**：PR作成前のセルフレビュー、または差分レビューを依頼するとき。
+- **利用しないシーン**：ファイルの編集（読み取り専用・編集/コミット/pushはしない）。他エージェント（サブエージェントはClaude Code固有 → 等価には `.skills/review.skill.md` を直接読む）。
+- **利用例**：`code-reviewer` サブエージェントを起動 → `git diff` で対象を特定 → Blocker>Major>Minor で `file:line`＋ルールID＋修正案を報告（PRの改変はしない）。
+
+---
+
+## 6. 意思決定・用語・方向性（利用先の docs/）
+
+### [docs/foundation/adr/](../adr/) と `docs/adr/`（ADR）
+
+- **利用目的**：基盤の受理済み決定は `docs/foundation/adr/`、利用先固有の決定は `docs/adr/` に不変記録する（GR-022）。
+- **利用シーン**：構造/境界/技術の変更前に両方を確認し、利用先の新決定は `docs/adr/` に起票。
+- **利用しないシーン**：局所的な実装判断（それは decision-log の1行や why コメントで足りる）。
+- **利用例**：[0002](../adr/0002-ai-facing-docs-in-english.md)を読み基盤の言語方針を理解。利用先の新規ADRは [ADRテンプレート](../templates/adr.md) を `docs/adr/` へ複製。
+
+### [docs/foundation/glossary.md](../glossary.md) と `docs/glossary.md`（統一用語）
+
+- **利用目的**：基盤の再利用語と、利用先プロジェクト固有のユビキタス言語を所有者別に定義する（COD-002）。
+- **利用シーン**：新しい概念に名前を付ける前に両方を確認し、プロジェクト固有語は `docs/glossary.md` に同PRで追記。
+- **利用しないシーン**：一般的な技術用語（ここは「このプロジェクト固有の語」）。
+- **利用例**：「Contract change」と「breaking change」の違いを glossary で確認して用語を統一。
+
+### `docs/roadmap.md`（利用先の方向性）
+
+- **利用目的**：利用先プロジェクトの進む方向とマイルストーン。新規作成時は [roadmapテンプレート](../templates/roadmap.md) を使う。
+- **利用シーン**：機能提案の妥当性判断、優先順位の把握。「Now / Next / Later / 対象外」を確認。
+- **利用しないシーン**：日々の作業キュー（それは GitHub の issue/milestone）。"Later" 項目の先回り実装（COD-051 で禁止）。
+- **利用例**：提案が roadmap の「対象外」に該当すると分かり、着手せず理由を添えて差し戻す。
+
+---
+
+## 7. ソース構造と契約（`src/modules/*/MODULE.md`）
+
+- **利用目的**：モジュールの公開API・所有データ・不変条件・依存を1ページで宣言（ARC-003）。
+- **利用シーン**：そのモジュールを変更する前に必ず読む。契約が変わったら同PRで更新。
+- **利用しないシーン**：他モジュールの内部実装を知りたい時（内部は非公開。公開APIのみ参照）。
+- **利用例**：`src/modules/catalog/MODULE.md` が存在するリポジトリでは、公開API
+  `AddProduct.handle` と不変条件を把握してから改修。
+
+### [src/README.md](../../../src/README.md) / [tests/README.md](../../../tests/README.md)（配置規約）
+
+- **利用目的**：ソース/テストの配置規約と `MODULE.md` の雛形を示す構造ガイダンス（ARC-001）。
+- **利用シーン**：新モジュール作成、ファイルの置き場所を決めるとき、`MODULE.md` を新規作成するとき。
+- **利用しないシーン**：既存モジュール内の局所修正で構造が変わらないとき。
+- **利用例**：新機能の置き場所をレイアウト図で確認し、`tests/` が `src/` を鏡写しにする規約（TST-001）に従う。
+
+### [profiles/README.md](../../../profiles/README.md)（正準ターゲット契約）
+
+- **利用目的**：`make` 正準ターゲット（setup/format/lint/test/…/doctor）の**拘束力ある意味論**を定義。CLAUDE.md §11 が参照。
+- **利用シーン**：`make` ターゲットの挙動を確認するとき、スタック別プロファイル（Makefile）を追加/編集するとき。
+- **利用しないシーン**：特定スタックの具体コマンドそのもの（各 Makefile 実装を見る）。
+- **利用例**：`lint` は「チェック専用・自動修正しない」という契約を確認し、lint に fmt を混ぜない。
+
+---
+
+## 8. 構造化入力（`.github/` テンプレート）
+
+AIへ「指示を出す」ための入力を型化するファイル群。人間が埋めた内容がAIの作業指示になります。
+
+### Issue テンプレート（[.github/ISSUE_TEMPLATE/](../../../.github/ISSUE_TEMPLATE/)）
+
+- **利用目的**：バグ/機能/セキュリティ課題を、AIがそのまま着手できる形（受入基準・再現手順）で受け取る。
+- **利用シーン**：新しい作業を起票するとき。`feature_request` の受入基準 = AIの Definition of Done。
+- **利用しないシーン**：脆弱性の詳細（公開Issue禁止 → 非公開のセキュリティ報告へ）。
+- **利用例**：`bug_report.yml` の再現手順がそのまま回帰テストの素になる。
+
+### [PULL_REQUEST_TEMPLATE.md](../../../.github/PULL_REQUEST_TEMPLATE.md)
+
+- **利用目的**：PRに必要な情報（変更分類・テスト・依存の正当化・AI開示・セルフレビュー）を型化。
+- **利用シーン**：AIがPRを作成するとき、全セクションを埋める。
+- **利用しないシーン**：ドラフトの下書き段階（ただしマージ前には必須）。
+- **利用例**：依存を追加したら Dependencies 表に目的・代替・ライセンスを記入（GR-023）。
+
+---
+
+## 9. グローバル層（リポジトリ外・Claude Code 固有）
+
+Claude Code は起動時に**親ディレクトリを遡って** `CLAUDE.md` を読み込みます。全リポ共通の指示を効かせられます。
+
+| 場所 | 利用目的 | 利用シーン | 利用しないシーン | 利用例 |
+|------|----------|------------|------------------|--------|
+| `~/.claude/CLAUDE.md` | 全プロジェクト共通の個人設定 | 「常に日本語で応答」等の恒常的な好み | ハードなガードレール（失われる） | 応答言語・コミット文体を指定 |
+| `~/projects/CLAUDE.md` | その配下の全リポ共通ハウスルール | 複数リポをまとめる作業ディレクトリ | リポ固有の正準ルール（各 .ai/ が持つ） | 優先ライブラリ・役割分担を記述 |
+
+- **重要**：これは Claude Code 固有。ChatGPT/Gemini は親/グローバル `CLAUDE.md` を読みません。
+  **ハードな禁止事項は各リポの `.ai/` と PreToolUse フックに置く**こと（グローバル層“だけ”に置くと、
+  他所へcloneした/他エージェントが読むリポで失われる）。詳細は [usage.ja.md](usage.ja.md) の Q2。
+
+---
+
+## 10. エージェント別の使い分け
+
+| | Claude Code | ChatGPT / Gemini / Codex |
+|--|-------------|--------------------------|
+| 入口 | `CLAUDE.md`（自動読込） | `AGENTS.md` → `CLAUDE.md` を明示的に読ませる |
+| ルール/スキル | 同じ（`.ai/`, `.skills/`） | 同じ（プレーンMarkdownなので読める） |
+| 自動強制 | `.claude/` フックが自動で効く | フックは効かない → `make lint` 等を手動実行、GR を自己チェック |
+| グローバル層 | `~/.claude`・親 `CLAUDE.md` 自動 | 読まれない → 必要なら手動で貼る |
+
+---
+
+## 11. よくある落とし穴
+
+- **ハードルールをグローバル層だけに置く** → 他エージェント/他リポで失われる。`.ai/` とフックに置く。
+- **`.claude/` を他エージェントに期待する** → 読まれない。等価手段（手動 lint・自己チェック）を使う。
+- **要約（CLAUDE.md）と本体（.ai/）の食い違いを本体無視で進める** → 本体（.ai/）が正。迷ったら本体を読む。
+- **`CLAUDE.md` は強制ではない**（公式明記）。確実に止めたい操作は PreToolUse フックで実装する。
+- **フックを手動回避する（`--no-verify` 等）** → GR-012 違反。原因を直す。
+
+---
+
+関連：新環境セットアップ手順は [usage.ja.md](usage.ja.md)、`.ai/` の索引は
+[.ai/README.md](../../../.ai/README.md)、基盤の決定の経緯は [docs/foundation/adr/](../adr/) を参照。
+
+---
+
+## 12. 意図的に除外したファイルと、その理由
+
+本書は「主目的がAIの振る舞いを**指示・案内・制約**すること」を収録基準にしています。以下は基準から外れるため
+意図的に除外しました（AIが"使う/従う"対象ではあっても、指示文そのものではない）。
+
+| グループ | ファイル | 除外理由 |
+|----------|----------|----------|
+| ツール/自動化 | `Makefile`, `profiles/*/Makefile`, `.pre-commit-config.yaml`, `.github/workflows/*`, `scripts/*.sh`, `renovate.json`, `.github/dependabot.yml` | 実行インターフェースや強制機構であって挙動の"指示文"ではない（正準ターゲットの契約 = profiles/README.md は §7 に収録） |
+| 設定 | `.gitignore`, `.gitattributes`, `.editorconfig`, `.env.example`, `.mdformat.toml`, `.templatesyncignore`, `LICENSE` | 環境・整形・法務の設定 |
+| ガバナンス metadata | `.github/CODEOWNERS`, `labels.yml`, `discussion-categories.md` | レビュー経路・ラベル・カテゴリ定義。AIは使うが指示ではない |
+| 人間向け | `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `docs/foundation/guides/usage.md`, `usage.ja.md` | 人間向け。特に `README.md` はAIを「CLAUDE.mdへ」と誘導する側。AI向けセキュリティは `.ai/security.md`（§3収録）が担う |
+| 記述的ドキュメント | `docs/foundation/guides/*.md` | 権威レベル5の**記述（informative）**。利用先所有の`docs/**`を占有せず、各配置先の目的・構造・更新トリガーを案内する |
+| ドキュメント雛形 | `docs/foundation/templates/` | 基盤所有の記入用テンプレート（例：`requirements.md`）。指示文ではなく、`requirements` スキルが利用先の `docs/` へ展開する対象。書式規約は DOC-002（§3収録）が担う |
+| 例コード | `src/modules/catalog/**/*.py`, `tests/**/*.py` | "指示"ではなく"手本（imitateする参照, COD-050）"。契約は代表として `MODULE.md` を §7 に収録 |
+
+**線引きの原則**：規範（normative, 従うべき）は収録、記述（descriptive, 参考情報）と純粋な実行/設定は除外。
+記述的docsやツールも間接的にAIの行動に影響しますが、"指示の発生源"は `.ai/`・`.skills/`・契約ファイルに集約されています。

--- a/docs/foundation/guides/usage.ja.md
+++ b/docs/foundation/guides/usage.ja.md
@@ -1,0 +1,242 @@
+---
+id: usage-ja
+title: 使い方（日本語）— 新しいPC / 別アカウント / 新規プロジェクト
+updated: 2026-07-16
+---
+
+# 使い方（日本語セットアップ手順書）
+
+> English: [usage.md](usage.md) ／ このファイルは人間向けの日本語手順書です（ADR-0002：
+> ルール本体は英語、人間向けドキュメントは日本語版を併設可）。内容が英語版と食い違った場合は
+> **英語版が正**です。
+
+新しいPCや別のGitHubアカウントで基盤を使うときの手順。**まず2つのシナリオのどちらかを判断**
+してください。手順が変わります。
+
+| シナリオ | やりたいこと | 使うもの |
+|----------|--------------|----------|
+| A | この基盤の上で**新規プロジェクトを作る** | GitHub の **「Use this template」**（`git clone` ではない）|
+| B | **この基盤リポジトリ自体**を別マシンで開発継続する | `git clone` |
+
+`git clone` が正解なのはシナリオBだけです。シナリオAでcloneすると、新規プロジェクトにこの基盤の
+履歴とプレースホルダが混入します。テンプレート機能を使ってください。
+
+---
+
+## シナリオA — テンプレートから新規プロジェクトを作る
+
+テンプレートリポジトリ化フラグは有効済みなので、1アクション＋短いセットアップで済みます。
+
+### 1. テンプレートから新リポジトリを作成
+
+Web: テンプレートリポジトリを開く → **Use this template** → **Create a new repository**。
+
+CLI（同等）:
+```bash
+gh repo create <あなたのアカウント>/<新プロジェクト> \
+  --template Yukihide-Mitsuoka/ai-dev-foundation \
+  --private --clone
+cd <新プロジェクト>
+```
+これで**クリーンな履歴**の新リポジトリがあなたのアカウント配下にできます。
+
+### 2. テンプレートのプレースホルダを置換
+
+カスタマイズ対象はすべて `{{...}}` トークンです。全部洗い出す:
+```bash
+grep -rn "{{" . --exclude-dir=.git
+```
+最低限置換するもの: `.ai/mission.md` と `CLAUDE.md` の `{{PROJECT_NAME}}` `{{STACK}}` 等、
+`.github/CODEOWNERS` ・`.github/ISSUE_TEMPLATE/config.yml`・
+`.github/workflows/template-sync.yml` の `{{ORG}}`、pythonプロファイルを使うなら `{{PACKAGE}}`。
+
+### 3. CODEOWNERS をアカウント種別に合わせて修正
+
+`.github/CODEOWNERS` は既定で**チーム記法**（`@{{ORG}}/maintainers`）です。チームは
+**GitHub Organization にしか存在しません**。**個人アカウント**ではユーザー名に置換してください:
+```
+*   @your-username
+```
+個人リポジトリにチーム記法を残すと、CODEOWNERS が**黙って無効化**されます
+この判定は互換ラッパーの対象外なので、ガバナンス適用前に修正してください。
+
+### 4. Makefile プロファイルを選ぶ
+
+最も近いリファレンス実装をルートにコピーしてスタックに合わせます:
+```bash
+cp profiles/python-uv/Makefile ./Makefile      # または typescript-node / terraform-gcp
+```
+正準ターゲット契約は [profiles/README.md](../../../profiles/README.md) を参照。
+
+### 5. GitHub ガバナンスを点検
+
+```bash
+python3 scripts/github_governance.py validate --root .
+python3 scripts/github_governance.py plan --root . --repo OWNER/REPOSITORY
+python3 scripts/github_governance.py audit --root . --repo OWNER/REPOSITORY
+python3 scripts/github_governance.py apply --root . --repo OWNER/REPOSITORY \
+  --confirm-repo OWNER/REPOSITORY
+
+# 同じplan/apply経路を使う互換入口:
+DRY_RUN=1 bash scripts/setup-github.sh OWNER/REPOSITORY
+bash scripts/setup-github.sh OWNER/REPOSITORY --confirm-repo OWNER/REPOSITORY
+```
+
+`validate` はオフラインで動作し、foundation、`.github/governance/profiles/`内の単一
+profile chain、repository policyを自動的に解決します。required checksは単調合成され、
+profileとrepository policyはcheckを追加できますがfoundation checkを削除できません。
+`plan` と `audit` は認証済みのGET-only
+`gh api` を使用し、同じ秘匿化済みJSON比較を出力します。対象branch先端で必要check名が
+観測されない場合はdriftとし、無関係なcheckはdriftにしません。`plan` は比較完了時に0、
+`audit` はdriftまたは権限不足によるunknown時に1、policy・入力・GitHub読み取りの失敗時には
+どちらも2を返します。
+
+`audit`が1で終了した場合の対処は
+[GitHubガバナンスのトラブルシューティング](../troubleshooting/github-governance.md)を参照してください。
+
+`apply`の前に`plan`を確認してください。設定を変更するのは`apply`だけで、ローカルの
+Administration権限と対象名の完全一致確認が必要です。各操作は再読込で検証されます。
+policyはsquash-only mergeを必須化し、Discussionsとsquash commit messageの既定値は
+repository overrideで選択できます。setup互換ラッパーは`gh`を直接呼びません。`DRY_RUN`は
+`plan`、通常実行は完全一致する対象名を2回要求して`apply`へ委譲し、終了コードも引き継ぎます。
+
+固定スクリプトからの移行では、引数なし形式は廃止され、CODEOWNERSなどの手動設定案内も
+ラッパーからは出力されません。上記のとおり対象を明示し、このガイドをチェックリストとして
+使用してください。
+
+### 6. ローカルゲート導入 → エージェントに向ける
+
+```bash
+make setup                             # 依存導入 + pre-commit フック
+```
+Claude Code でリポジトリを開けば `CLAUDE.md` を自動で読みます。他のエージェントには
+`AGENTS.md` を読ませてください。あとは issue を割り当てるだけ。
+
+テンプレートには参照用の例モジュール（`src/modules/catalog/` ＋ `tests/modules/catalog/`）が
+同梱されています。形を真似る（COD-050）か、実コードを書き始めるときに両方削除してください。
+いつでも `make doctor` でテンプレートの自己チェック（frontmatter 整合性 + guard フックのテスト）が
+できます。
+
+---
+
+## シナリオB — 基盤リポジトリ自体を別マシンにclone
+
+```bash
+git clone https://github.com/Yukihide-Mitsuoka/ai-dev-foundation.git
+cd ai-dev-foundation
+# 素のテンプレートのルート Makefile は no-op なので、ここでは `make setup` は何もしません。
+# git フックを直接入れます（pre-commit が必要 — 前提ツール参照）:
+pre-commit install --hook-type pre-commit --hook-type pre-push
+make doctor                            # テンプレートが壊れていないか検証
+```
+これは文字通り「cloneするだけ」ですが、各マシンで下記の**前提ツール**と**認証**は一度必要です。
+
+---
+
+## マシンごとの前提ツール（両シナリオ共通）
+
+新しいマシンで一度だけ導入:
+
+| ツール | 用途 | 備考 |
+|--------|------|------|
+| `git`, `make` | 全般 | — |
+| `gh`（GitHub CLI）| ガバナンス`plan`/`audit`/`apply`・互換setup・認証 | `gh auth login` |
+| `pre-commit` | ローカルコミットゲート | `make setup`（プロファイル導入後）または `pre-commit install` |
+| スタックのツールチェーン | build/test | uv(python) / pnpm+node(ts) / terraform(iac) |
+| `gitleaks`, `trivy`, `syft` | ローカルの `make security-scan` / `sbom` | ローカルは任意。**CIは常時強制** |
+
+スキャナはローカル任意です。GitHub Actions が全PRで実行するので、未導入でも「ローカルで結果が
+見えない」だけです。
+
+---
+
+## 落とし穴（ぶつかる前に読む）
+
+### push には `workflow` OAuth スコープが必要
+`.github/workflows/` 配下を含む push はトークンの `workflow` スコープが必要です。
+*"refusing to allow an OAuth App to create or update workflow ... without workflow scope"*
+と拒否されたら:
+```bash
+gh auth refresh -h github.com -s workflow
+```
+これは**アカウント／マシンごと**の設定です。新環境ごとに一度実施する想定でいてください。
+
+### ソロ開発 × ブランチ保護 ＝ 自分のPRをマージできない
+`.github/governance/repository.json`の`required_approvals`をリポジトリ体制に合わせます。
+第二のレビュアーなしで1件必須にすると自己マージできません。どちらか選択:
+
+- **推奨（ガードレール維持）:** 共同開発者/レビュアーを1人追加、または AI レビュアー
+  （[ai-review.yml](../../../.github/workflows/ai-review.yml)）を有効化。ただしAIのレビューコメントは
+  GitHub上の *approval* にはならないため、真の自己マージには下の方法が必要。
+- **ソロ実用:** repository policyで`"required_approvals": 0`に設定。
+  これでも「ブランチ＋PR＋CI緑」（GR-010, GR-021）は保たれ、マージだけ自分で行えます。
+
+`scripts/setup-github.sh`も同じrepository policyへ委譲するため、直接CLIと互換入口のどちらでも
+設定したapproval件数が適用されます。
+
+### 改行コード
+`.gitattributes` がリポジトリ全体を LF 強制するので、Windows チェックアウトでもシェルフックと
+Makefile は壊れません。グローバル `core.autocrlf=true` でこれと戦わないこと（`.gitattributes` が
+対象ファイルでは勝ちますが、Git既定は素直にしておく）。
+
+---
+
+## 質問への回答
+
+### Q. 別アカウントから「Use this template」してよい？ → **可能。1台のPCで完結できます**
+
+テンプレートリポジトリにそのアカウントがアクセスできれば、どのアカウントからでも生成できます。
+
+| テンプレートの公開設定 | 「Use this template」できるアカウント |
+|------------------------|----------------------------------------|
+| public | 誰でも（あなたの別アカウント含む）|
+| private | 読み取り権限を持つアカウント（コラボレーター）／同じ Organization のメンバーのみ |
+
+- 生成先のアカウント／Org はテンプレートのドロップダウンで選べます（テンプレート所有者と別でOK）。
+- **結論:** このPC 1台で完結します。アカウントを切り替えて（または同一アカウントで）テンプレート
+  → 新リポ生成 → clone → 開発、の流れで複数PCは不要です。
+- 秘密情報を含まない基盤なので、再利用が多いなら **public** が最も手軽。厳密に管理したいなら
+  **Organization + private** が綺麗です。
+
+### Q. 全リポジトリを束ねる作業ディレクトリへの「グローバル指示」は仕組みとして想定されている？ → **はい（Claude Code の公式機能）**
+
+Claude Code は起動時にディレクトリツリーを遡って `CLAUDE.md` を読み込みます。したがって階層で
+グローバル指示を効かせられます（2026-07 時点の公式仕様で確認）:
+
+| スコープ | 場所 | 適用範囲 |
+|----------|------|----------|
+| 組織管理ポリシー | Linux/WSL: `/etc/claude-code/CLAUDE.md` | マシン上の全セッション・全リポジトリ（個人設定で除外不可）|
+| ユーザー | `~/.claude/CLAUDE.md` | あなたの全プロジェクト |
+| **束ねる親ディレクトリ** | 例 `~/projects/CLAUDE.md` | **その配下の全リポジトリ**（cwd から親を遡って読む）|
+| プロジェクト | `<repo>/CLAUDE.md` ＋ `.ai/` | そのリポジトリのみ（この基盤が提供）|
+
+読み込み順は root 側 → cwd 側で、**cwd に近いものが後に読まれ優先**されやすい。すべて連結して
+コンテキストに入ります（上書きではない）。
+
+**推奨する構成:**
+- 全リポ共通の「ハウスルール」→ `~/projects/CLAUDE.md`（例: 常に日本語で応答、あなたの名前・役割、
+  優先ライブラリ、コミット文体）。**200行以内**に保つ。
+- 真に全環境共通 → `~/.claude/CLAUDE.md`。
+- 各リポの `.ai/` は**自己完結の正準ルール**のまま（100リポにコピーしても単独で機能し、
+  ChatGPT/Gemini でも全ルールが読める）。
+
+**重要な注意:**
+- これは **Claude Code 固有**の仕組みです。ChatGPT/Gemini は親/グローバル `CLAUDE.md` を自動では
+  読みません。ベンダー中立性のため、**ハードなガードレールは各リポの `.ai/` と PreToolUse フック**
+  （この基盤の `guard-bash.sh` がまさにそれ）に置き、グローバル層は「競合しない補助的な好み」に
+  留めてください。ハードルールをグローバル層“だけ”に置くと、他所へcloneした/他エージェントが読む
+  リポジトリでそのルールが失われます。
+- `CLAUDE.md` は「コンテキストであって強制設定ではない」（公式明記）。確実に**ブロック**したい操作は
+  PreToolUse フックで実装します。
+
+複数リポで共有したいルール断片は `.claude/rules/` にシンボリックリンクを張る方法も公式サポート
+されています（例: `ln -s ~/shared-claude-rules .claude/rules/shared`）。
+
+---
+
+## クイックリファレンス:「別アカウントで clone だけで足りる？」
+
+- **基盤を開発する**（シナリオB）: はい。`git clone` ＋ `make setup` ＋（そのマシンで一度）
+  `gh auth refresh -s workflow`。
+- **新規プロジェクトを作る**（シナリオA）: いいえ。「Use this template」→ 上の6ステップ。
+  cloneでは新規プロジェクトにこの基盤の履歴とプレースホルダが混入します。

--- a/docs/foundation/guides/usage.md
+++ b/docs/foundation/guides/usage.md
@@ -1,0 +1,199 @@
+---
+id: usage
+title: Usage — New Machine, New Account, New Project
+updated: 2026-07-16
+---
+
+# Usage
+
+> 日本語版: [usage.ja.md](usage.ja.md)（人間向けセットアップ手順書）
+
+This guide covers using the foundation from a different machine or a different GitHub
+account. **First decide which of two scenarios you are in — the steps differ.**
+
+| Scenario | You want to... | Use |
+|----------|----------------|-----|
+| A | Start a **new project** built on this foundation | GitHub **"Use this template"** (not `git clone`) |
+| B | Continue developing **this foundation itself** on another machine | `git clone` |
+
+`git clone` alone is only the right answer for Scenario B. For Scenario A, cloning would
+drag this repo's history and identity into your new project; use the template flow.
+
+---
+
+## Scenario A — start a new project from the template
+
+The template repository flag is enabled, so this is one action plus a short setup.
+
+### 1. Create the new repo from the template
+
+Web: open the template repo → **Use this template** → **Create a new repository**.
+
+CLI (equivalent):
+```bash
+gh repo create <your-account>/<new-project> \
+  --template Yukihide-Mitsuoka/ai-dev-foundation \
+  --private --clone
+cd <new-project>
+```
+This gives you a **fresh repo with clean history** under your account.
+
+### 2. Replace template placeholders
+
+Every customizable value is a `{{...}}` token. Find them all:
+```bash
+grep -rn "{{" . --exclude-dir=.git
+```
+Replace at minimum: `{{PROJECT_NAME}}`, `{{STACK}}` and the other `{{...}}` in
+`.ai/mission.md` and `CLAUDE.md`; `{{ORG}}` in `.github/CODEOWNERS`,
+`.github/ISSUE_TEMPLATE/config.yml`, and `.github/workflows/template-sync.yml`;
+`{{PACKAGE}}` if you use the python profile.
+
+### 3. Fix CODEOWNERS for your account type
+
+`.github/CODEOWNERS` ships with **team** references (`@{{ORG}}/maintainers`). Teams only
+exist under **GitHub Organizations**. On a **personal account**, replace them with your
+username:
+```
+*   @your-username
+```
+Leaving team syntax on a personal repo makes CODEOWNERS silently ineffective —
+fix this file before applying governance because account-type inference is outside the
+compatibility wrapper.
+
+### 4. Pick a Makefile profile
+
+Copy the closest reference implementation to the repo root and wire it to your stack:
+```bash
+cp profiles/python-uv/Makefile ./Makefile      # or typescript-node / terraform-gcp
+```
+See [profiles/README.md](../../../profiles/README.md) for the canonical target contract.
+
+### 5. Inspect GitHub governance
+
+```bash
+python3 scripts/github_governance.py validate --root .
+python3 scripts/github_governance.py plan --root . --repo OWNER/REPOSITORY
+python3 scripts/github_governance.py audit --root . --repo OWNER/REPOSITORY
+python3 scripts/github_governance.py apply --root . --repo OWNER/REPOSITORY \
+  --confirm-repo OWNER/REPOSITORY
+
+# Compatibility entry point for the same plan/apply paths:
+DRY_RUN=1 bash scripts/setup-github.sh OWNER/REPOSITORY
+bash scripts/setup-github.sh OWNER/REPOSITORY --confirm-repo OWNER/REPOSITORY
+```
+
+`validate` is offline and automatically resolves the foundation, the single profile
+chain in `.github/governance/profiles/`, and repository policy. Required checks are
+monotonic: profiles and repository policy add checks but cannot remove foundation
+checks. `plan` and `audit` use authenticated, GET-only `gh api` calls and
+print the same redacted JSON comparison. The comparison flags a required check name that
+is not observed on the target branch head and ignores unrelated observed checks. `plan`
+returns 0 after a completed comparison; `audit` returns 1 for drift or permission-limited
+unknown state. Both return 2 for policy, input, or GitHub read failures.
+
+See [GitHub governance troubleshooting](../troubleshooting/github-governance.md) for an
+`audit` exit 1 diagnosis.
+
+Review `plan` before `apply`. Only `apply` changes settings; it requires local repository
+Administration access and an exact target confirmation, then verifies each action by
+read-back. Policy enforces squash-only merges and lets repository overrides choose
+Discussions and squash commit-message defaults. The setup compatibility wrapper makes no
+direct `gh` call: `DRY_RUN` maps to `plan`, while normal execution requires the exact
+target twice and maps to `apply`. Its exit code is the reconciler exit code.
+
+Migration from the fixed script: the no-argument form is removed, and the wrapper no
+longer prints CODEOWNERS or other manual onboarding reminders. Pass the target explicitly
+as shown above and use this guide as the onboarding checklist.
+
+### 6. Install local gates and point your agent at it
+
+```bash
+make setup                             # installs deps + pre-commit hooks
+```
+Open the repo with Claude Code (reads `CLAUDE.md` automatically) or tell any other agent
+to read `AGENTS.md`. Assign it an issue and go.
+
+The template ships a worked example module (`src/modules/catalog/` + `tests/modules/catalog/`)
+— imitate its shape (COD-050) or delete both when you start real code. Run `make doctor`
+anytime to self-check the template (frontmatter integrity + guard-hook tests).
+
+---
+
+## Scenario B — clone the foundation itself onto another machine
+
+```bash
+git clone https://github.com/Yukihide-Mitsuoka/ai-dev-foundation.git
+cd ai-dev-foundation
+# The bare template's root Makefile is a no-op, so `make setup` does nothing here.
+# Install the git hooks directly (needs pre-commit — see prerequisites):
+pre-commit install --hook-type pre-commit --hook-type pre-push
+make doctor                            # verify the template is intact
+```
+That is genuinely "just clone" — but each new machine still needs the one-time
+**prerequisites** and **auth** below.
+
+---
+
+## Per-machine prerequisites (both scenarios)
+
+Install once on each new machine:
+
+| Tool | Needed for | Notes |
+|------|-----------|-------|
+| `git`, `make` | everything | — |
+| `gh` (GitHub CLI) | Governance `plan`/`audit`/`apply`, compatibility setup, auth | `gh auth login` |
+| `pre-commit` | local commit gates | `make setup` (once a profile is wired) or `pre-commit install` |
+| Stack toolchain | build/test | uv (python), pnpm+node (ts), terraform (iac) — per your profile |
+| `gitleaks`, `trivy`, `syft` | local `make security-scan` / `sbom` | optional locally; **CI enforces them regardless** |
+
+The scanners are optional on your laptop — the GitHub Actions workflows run them on every
+PR, so a missing local tool only means you don't see findings until CI.
+
+---
+
+## Gotchas (read before you hit them)
+
+### `workflow` OAuth scope is required to push
+Pushing any change under `.github/workflows/` needs the token's `workflow` scope. If
+`git push` is rejected with *"refusing to allow an OAuth App to create or update
+workflow ... without workflow scope"*:
+```bash
+gh auth refresh -h github.com -s workflow
+```
+This is a **per-account / per-machine** setting — expect to do it once on each new setup.
+
+### Solo developer + branch protection = you can't merge your own PRs
+Set `required_approvals` in `.github/governance/repository.json` to match the repository.
+Requiring one approval on a repo with no second reviewer prevents self-merge. Choose one:
+
+- **Recommended (keeps the guardrail):** add a second collaborator/reviewer, or enable
+  the AI reviewer ([ai-review.yml](../../../.github/workflows/ai-review.yml)) — note an AI
+  review comment does not count as a GitHub *approval*, so for true self-merge you still
+  need option below.
+- **Solo pragmatic:** set `"required_approvals": 0` in repository policy.
+  You still branch + PR + green CI (GR-010, GR-021); you just merge it yourself.
+
+`scripts/setup-github.sh` delegates to the same repository policy, so the configured
+approval count applies equally through the direct CLI and compatibility entry point.
+
+### Line endings
+`.gitattributes` enforces LF repo-wide, so shell hooks and Makefiles stay valid on
+Windows. Don't override with a global `core.autocrlf=true` that fights it — the
+`.gitattributes` wins for matched files, but keep your Git default sane.
+
+### Placeholders that break automation if left unreplaced
+`{{ORG}}` in `template-sync.yml` and `CODEOWNERS`, and the issue-config URLs, are the
+ones that cause silent failures (ineffective CODEOWNERS, a sync job that can't find its
+source). The template-sync job is gated off by default (`TEMPLATE_SYNC_ENABLED`), so it
+stays inert until you deliberately enable it.
+
+---
+
+## Quick answer: "is `git clone` enough on a different account?"
+
+- **To develop this foundation** (Scenario B): yes — `git clone` + `make setup` +
+  `gh auth refresh -s workflow` on that machine.
+- **To start a new project** (Scenario A): no — use "Use this template", then the
+  6 setup steps above. Cloning would give the new project this repo's history and
+  placeholders instead of a clean start.


### PR DESCRIPTION
## What & why

Port the fifth dependency-safe batch from authenticated Template Sync source a177d1f: the foundation guide index, Japanese AI-instruction guide, and English/Japanese usage guides. ChatChart's Japanese project documents remain unchanged.

Refs: #37

## Change classification (ARC-020)

- [x] Local (mechanical inherited documentation batch)
- [ ] Contract
- [ ] Architectural

## Breaking change?

- [x] No
- [ ] Yes

## Testing (GR-021 / TST-002)

- How verified: make format, make lint, make test (36/36), make doctor (73 governance tests, 4 target boundary tests, 71 guard tests), and git diff --check passed.
- Verified all four files exactly match generated branch chore/template_sync_a177d1f.
- This 786-line mechanical batch is below the GR-020 hard limit; no runtime behavior changed.

## Documentation (DOC-030)

- [x] Foundation onboarding added only under docs/foundation/guides/; project documents retained.

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against .ai/review-checklist.md completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] make format && make lint && make test green
- [x] Mechanical batch is below GR-020 hard limits and justified above
- [x] No guardrail violated (.ai/guardrails.md)