### PR TITLE
docs(foundation): enforce inherited documentation ownership

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -54,7 +54,7 @@ Read only what the task requires. Do not load all files for every task.
 | New feature | workflow.md, architecture.md, coding-rules.md, testing.md | `.skills/feature.skill.md` |
 | Bug fix | workflow.md, testing.md | `.skills/bugfix.skill.md` |
 | Refactoring | architecture.md, coding-rules.md, testing.md | `.skills/refactor.skill.md` |
-| Architecture change | architecture.md, decision-log.md, `docs/adr/` | `.skills/architecture.skill.md` |
+| Architecture change | architecture.md, decision-log.md, `docs/foundation/adr/`, `docs/adr/` when present | `.skills/architecture.skill.md` |
 | Security work | security.md, guardrails.md | `.skills/security.skill.md` |
 | Writing tests | testing.md | `.skills/test.skill.md` |
 | Documentation | documentation.md | `.skills/documentation.skill.md` |

--- a/.ai/documentation.md
+++ b/.ai/documentation.md
@@ -55,15 +55,24 @@ Governs all prose in `.ai/` and `docs/`. `.skills/requirements.skill.md` and
 |----------|---------|-----------|
 | `.ai/` | rules for agents | yes (authority table) |
 | `CLAUDE.md`, `AGENTS.md` | agent entry points | yes |
-| `docs/adr/` | decisions with context | yes (accepted ADRs) |
-| `docs/foundation/` | synchronized foundation-owned guidance and document templates | descriptive |
+| `docs/foundation/adr/` | synchronized foundation decisions with context | yes (accepted ADRs) |
+| `docs/foundation/` | other synchronized foundation-owned guidance and document templates | descriptive |
+| `docs/adr/` | repository-specific decisions with context | yes (accepted ADRs) |
 | `docs/requirements.md`, `docs/requirements/` | whole-project and initiative requirements | contract |
+| `docs/glossary.md` | project-specific ubiquitous language | descriptive |
+| `docs/roadmap.md` | project direction and sequencing | descriptive |
 | `docs/architecture/` | diagrams, flows, C4 | descriptive |
 | `docs/domain/` | domain model, ubiquitous language | descriptive |
 | `docs/api/` | API contracts (OpenAPI etc.) | contract |
 | `docs/deployment/`, `docs/operations/`, `docs/runbook/`, `docs/troubleshooting/` | ops | descriptive |
 | `src/modules/*/MODULE.md` | module contracts | yes |
 | `README.md` | project front door | descriptive |
+
+The structure and update triggers for project-owned `docs/` paths are defined once in
+[`docs/foundation/guides/`](../docs/foundation/guides/). A project-owned documentation
+directory MUST NOT contain a foundation-owned placeholder README. A repository MAY add
+a local README only when it describes actual project content and is maintained by that
+repository.
 
 ## DOC-030: Doc-update matrix (binding — GR-024)
 
@@ -78,6 +87,7 @@ When a PR contains a change of type X, it MUST update the docs listed:
 | New dependency | PR justification (GR-023); `docs/architecture/` if structural |
 | Behavior change visible to users | README, CHANGELOG (via commit type) |
 | New error state / failure mode | `docs/troubleshooting/`, `docs/runbook/` if ops action needed |
+| New or changed reusable foundation term | `docs/foundation/glossary.md` |
 | New domain term | `docs/glossary.md` |
 | Decision that constrains the future | ADR + `.ai/decision-log.md` |
 | Change to how AI should behave | `.ai/*` (via reviewed PR) |
@@ -87,4 +97,6 @@ When a PR contains a change of type X, it MUST update the docs listed:
 - If you read a doc that contradicts the code: the code is usually truth for *behavior*,
   the doc for *intent*. Investigate, fix the wrong one in the current PR, note it.
 - Docs describing removed features are deleted, not marked "deprecated" forever.
-- Each `docs/**/README.md` lists its own update triggers; obey them.
+- Use the matching `docs/foundation/guides/` entry for directory structure and update
+  triggers. If a repository adds a project-owned README, obey its additional local
+  triggers as well.

--- a/.github/governance/README.md
+++ b/.github/governance/README.md
@@ -97,7 +97,8 @@ to read-only `plan`; normal execution requires the repository twice in the form
 `OWNER/REPOSITORY --confirm-repo OWNER/REPOSITORY` before delegating to `apply`. It makes
 no direct `gh` call, owns no fixed settings, and preserves the reconciler exit code.
 The former no-argument apply and inline onboarding reminders are intentionally removed;
-callers must migrate to the explicit target form and use `docs/usage.md` for onboarding.
+callers must migrate to the explicit target form and use the
+[foundation usage guide](../../docs/foundation/guides/usage.md) for onboarding.
 
 ## Apply action planning boundary
 

--- a/.github/inheritance/README.md
+++ b/.github/inheritance/README.md
@@ -5,7 +5,8 @@ title: Template Inheritance Contract
 
 # Template Inheritance Contract
 
-This directory defines the child-owned, direct-parent contract from [ADR-0004](../../docs/adr/0004-harden-multi-level-template-inheritance.md).
+This directory defines the child-owned, direct-parent contract from
+[ADR-0004](../../docs/foundation/adr/0004-harden-multi-level-template-inheritance.md).
 Validation and local history planning are read-only; materialization remains a follow-up.
 
 ## Schema version 1
@@ -66,4 +67,4 @@ commit immediately after it. The report classifies that commit's paths:
 
 Exit `0` prints the deterministic plan, including candidate and branch-head commits.
 Exit `2` reports invalid metadata, parent identity/history, Git state, or child path.
-See [template inheritance troubleshooting](../../docs/troubleshooting/template-inheritance.md).
+See [template inheritance troubleshooting](../../docs/foundation/troubleshooting/template-inheritance.md).

--- a/docs/foundation/README.md
+++ b/docs/foundation/README.md
@@ -1,0 +1,47 @@
+---
+id: foundation-docs-index
+title: Foundation Documentation
+---
+
+# docs/foundation/ — Foundation Documentation
+
+This directory contains descriptive guidance and document templates owned by
+`ai-dev-foundation`. In an instantiated repository, project-owned documentation stays at
+task-oriented paths directly under `docs/`; it MUST NOT be placed below this directory.
+
+Binding AI rules remain in [`.ai/`](../../.ai/), and task procedures remain in
+[`.skills/`](../../.skills/). Files here link to those sources instead of duplicating
+their rules.
+
+## Inventory
+
+| Path | Purpose |
+|------|---------|
+| [adr/](adr/) | Preserve and synchronize accepted foundation architecture decisions |
+| [glossary.md](glossary.md) | Define reusable foundation terminology without occupying the project glossary path |
+| [requirements.md](requirements.md) | Choose the project-owned requirements location and naming |
+| [guides/](guides/) | Define project documentation structure, onboarding, and update triggers without occupying project-owned paths |
+| [templates/](templates/) | Copyable skeletons for project-owned documents |
+| [troubleshooting/](troubleshooting/) | Diagnose reusable foundation tooling without occupying project-owned troubleshooting paths |
+
+## Template Sync ownership
+
+Template Sync excludes `docs/**` to protect project-owned documentation and selectively
+includes `docs/foundation/**`. `actions-template-sync@v2` passes ignore entries to
+`git reset --`; exclusions therefore use Git pathspec `:!` syntax, not `.gitignore` `!`
+negation. Existing downstream repositories must append this exception block to the end
+of their local `.templatesyncignore`:
+
+```gitignore
+docs/**
+:!docs/foundation/
+:!docs/foundation/**
+```
+
+The local `.templatesyncignore` is itself protected from synchronization. Review and
+merge this change in each existing downstream repository before manually running the
+Template Sync workflow. New repositories created from the updated template already have
+the exception.
+
+**Update trigger:** add or update an entry whenever foundation-owned guidance or a
+template moves into, within, or out of this namespace.

--- a/scripts/template-check.sh
+++ b/scripts/template-check.sh
@@ -9,6 +9,7 @@
 #   2. No file carries the "collapsed frontmatter" signature a non-frontmatter-aware
 #      formatter produces (guards against the LOG-0007 regression recurring).
 #   3. GitHub governance inheritance rejects invalid or weakening policy.
+#   4. Foundation-owned project-documentation guides do not occupy project-owned paths.
 
 set -u
 cd "$(dirname "$0")/.." || exit 9
@@ -38,6 +39,82 @@ fi
 # 3. Foundation-level governance policy contract tests (ADR-0003).
 python3 -m unittest discover -s scripts/tests -p 'test_*.py' || err "GitHub governance policy tests failed"
 python3 scripts/github_governance.py validate --root . >/dev/null || err "GitHub governance policy is invalid"
+
+# 4. ADR-0006 ownership boundary: reusable scaffolding belongs under docs/foundation/.
+# Only the canonical foundation repository bans legacy project-path copies. Legacy
+# direct Template Sync children do not necessarily carry an inheritance manifest, so
+# manifest absence cannot identify the root. Children may validly create repository-owned
+# files at these paths, including README files (DOC-010).
+foundation_origin="$(git config --get remote.origin.url 2>/dev/null)"
+case "$foundation_origin" in
+  https://github.com/Yukihide-Mitsuoka/ai-dev-foundation | \
+    https://github.com/Yukihide-Mitsuoka/ai-dev-foundation.git | \
+    git@github.com:Yukihide-Mitsuoka/ai-dev-foundation.git | \
+    ssh://git@github.com/Yukihide-Mitsuoka/ai-dev-foundation.git)
+    is_foundation_root=true
+    ;;
+  *)
+    is_foundation_root=false
+    ;;
+esac
+
+if [ "$is_foundation_root" = true ]; then
+  for path in \
+    docs/README.md \
+    docs/api/README.md \
+    docs/architecture/README.md \
+    docs/deployment/README.md \
+    docs/domain/README.md \
+    docs/operations/README.md \
+    docs/runbook/README.md \
+    docs/troubleshooting/README.md \
+    docs/usage.md \
+    docs/usage.ja.md \
+    docs/ai-instruction-files.ja.md \
+    docs/troubleshooting/github-governance.md \
+    docs/troubleshooting/template-inheritance.md \
+    docs/glossary.md \
+    docs/roadmap.md; do
+    if [ -e "$path" ]; then
+      err "$path: foundation-owned guidance must live under docs/foundation/ (ADR-0006)"
+    fi
+  done
+  if find docs/adr -type f -print -quit 2>/dev/null | grep -q .; then
+    err "docs/adr/: ai-dev-foundation ADRs must live under docs/foundation/adr/ (ADR-0006)"
+  fi
+fi
+
+for path in \
+  docs/foundation/guides/README.md \
+  docs/foundation/guides/api.md \
+  docs/foundation/guides/architecture.md \
+  docs/foundation/guides/deployment.md \
+  docs/foundation/guides/domain.md \
+  docs/foundation/guides/operations.md \
+  docs/foundation/guides/project-documentation.md \
+  docs/foundation/guides/runbook.md \
+  docs/foundation/guides/troubleshooting.md \
+  docs/foundation/guides/usage.md \
+  docs/foundation/guides/usage.ja.md \
+  docs/foundation/guides/ai-instruction-files.ja.md \
+  docs/foundation/adr/README.md \
+  docs/foundation/adr/0001-record-architecture-decisions.md \
+  docs/foundation/adr/0002-ai-facing-docs-in-english.md \
+  docs/foundation/adr/0003-reconcile-github-governance-from-inherited-policy.md \
+  docs/foundation/adr/0004-harden-multi-level-template-inheritance.md \
+  docs/foundation/adr/0005-separate-foundation-and-project-document-languages.md \
+  docs/foundation/adr/0006-reserve-a-foundation-documentation-namespace.md \
+  docs/foundation/troubleshooting/README.md \
+  docs/foundation/troubleshooting/github-governance.md \
+  docs/foundation/troubleshooting/template-inheritance.md \
+  docs/foundation/glossary.md \
+  docs/foundation/templates/adr.md \
+  docs/foundation/templates/glossary.md \
+  docs/foundation/templates/roadmap.md; do
+  if [ ! -f "$path" ]; then
+    err "$path: required foundation documentation guide is missing"
+  fi
+done
 
 if [ "$errors" -eq 0 ]; then
   echo "doctor: OK — template invariants hold"

--- a/scripts/tests/test_foundation_docs_portability.py
+++ b/scripts/tests/test_foundation_docs_portability.py
@@ -1,0 +1,34 @@
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+TEMPLATE_CHECK = REPOSITORY_ROOT / "scripts" / "template-check.sh"
+AI_GUIDE = (
+    REPOSITORY_ROOT
+    / "docs"
+    / "foundation"
+    / "guides"
+    / "ai-instruction-files.ja.md"
+)
+
+
+class FoundationDocsPortabilityTest(unittest.TestCase):
+    def test_root_check_does_not_classify_legacy_children_by_manifest_absence(self):
+        script = TEMPLATE_CHECK.read_text(encoding="utf-8")
+
+        self.assertNotIn('if [ ! -f .github/inheritance/manifest.json ]; then', script)
+        self.assertIn("Yukihide-Mitsuoka/ai-dev-foundation", script)
+
+    def test_optional_example_module_is_not_a_required_local_link(self):
+        guide = AI_GUIDE.read_text(encoding="utf-8")
+
+        self.assertNotIn(
+            "[src/modules/catalog/MODULE.md](../../../src/modules/catalog/MODULE.md)",
+            guide,
+        )
+        self.assertIn("`src/modules/catalog/MODULE.md`", guide)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

Complete the reviewable propagation of authenticated Template Sync source a177d1f. Add the foundation namespace index, update inherited ownership/link rules, and enforce portable documentation invariants without classifying legacy direct children as the foundation root.

Refs: #37

## Change classification (ARC-020)

- [x] Local (final inherited rules/index/invariant batch; product architecture unchanged)
- [ ] Contract
- [ ] Architectural

## Breaking change?

- [x] No
- [ ] Yes

## Testing (GR-021 / TST-002)

- How verified: make format, make lint, make test (36/36), make doctor (75 governance tests, 4 target boundary tests, 71 guard tests), and git diff --check passed.
- Verified all seven files exactly match generated branch chore/template_sync_a177d1f.
- The inherited portability regression tests protect legacy children and optional example links.

## Documentation (DOC-030)

- [x] Ownership rule now states foundation docs under docs/foundation/** and ChatChart docs at direct task-oriented docs paths in Japanese.

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against .ai/review-checklist.md completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] make format && make lint && make test green
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (.ai/guardrails.md)