### PR TITLE
docs: CODEOWNERSのガイド参照を修正

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # CODEOWNERS — review routing. Later rules win.
-# Personal account: all review routes to the owner (docs/usage.md step 3).
+# Personal account: all review routes to the owner (docs/foundation/guides/usage.md step 3).
 
 # Default: everything needs a maintainer review
 *                       @Yukihide-Mitsuoka

--- a/tests/documentation-ownership.test.ts
+++ b/tests/documentation-ownership.test.ts
@@ -38,6 +38,7 @@ test('foundation docs are not duplicated in the project namespace', async () => 
 
 test('project governance references use the foundation ADR namespace', async () => {
   const decisionLog = await readFile(`${repositoryRoot}/.ai/decision-log.md`, 'utf8');
+  const codeowners = await readFile(`${repositoryRoot}/.github/CODEOWNERS`, 'utf8');
   const architectureSkill = await readFile(
     `${repositoryRoot}/.skills/architecture.skill.md`,
     'utf8',
@@ -48,6 +49,8 @@ test('project governance references use the foundation ADR namespace', async () 
   );
 
   assert.doesNotMatch(decisionLog, /\.\.\/docs\/adr\/000[1-4]-/u);
+  assert.match(codeowners, /docs\/foundation\/guides\/usage\.md/u);
+  assert.doesNotMatch(codeowners, /docs\/usage\.md/u);
   assert.match(architectureSkill, /docs\/foundation\/templates\/adr\.md/u);
   assert.doesNotMatch(projectAdr0005, /docs\/adr\/0000-template\.md/u);
 });


### PR DESCRIPTION
## 概要

旧docs/usage.md削除後もCODEOWNERSコメントに残っていた参照を、docs/foundation/guides/usage.mdの正本へ更新します。

## 検証

- 回帰テストを失敗させてから実装
- make format
- make lint
- make test（40件成功）
- make doctor（75 + 4 + 71件成功）
- git diff --check

Refs #37