### PR TITLE
feat(executor): execute use case with binding resolution and audit

### DIFF
--- a/src/modules/executor/MODULE.md
+++ b/src/modules/executor/MODULE.md
@@ -17,12 +17,16 @@ definitions, or NL→SQL generation.
 | Entry point | Layer | Description |
 |-------------|-------|-------------|
 | `bindQuery(sql, binding, policy)` | domain | Validate a query and rewrite it so every physical table is bound to the tenant's dataset and every row-scoped table is wrapped in its scope filter. Returns `BoundQuery` or a typed `Rejection` |
+| `ExecuteQuery.execute(tenantId, sql, params)` | application | Resolve the tenant's binding, bind the SQL, run it, audit what actually ran. Refusals never reach the runner |
+| `ports.ts` interfaces | application | What adapters must implement (`QueryRunner`, `BindingResolver`, `AuditSink`) |
 
 ## Events
 
 | Direction | Event | Schema | Notes |
 |-----------|-------|--------|-------|
-| (none yet) | — | — | the execute use case will publish `query.execute` audit records |
+| publishes | `query.execute` | `AuditSink` port | on success; carries the **bound** SQL and the tables touched |
+| publishes | `query.refused` | `AuditSink` port | on a binder rejection, with the rejection code |
+| publishes | `query.failed` | `AuditSink` port | on a runner error; the driver message stays audit-side |
 
 ## Owned data
 
@@ -44,12 +48,20 @@ reads the tenant's analytics dataset.
    the caller's dataset; a walker gap therefore yields `rewrite-failed`, never a leak.
 7. Identifiers and scope values emitted into SQL text are charset-validated; anything
    else is refused.
+8. Nothing reaches the `QueryRunner` that has not been through `bindQuery` — a refusal
+   short-circuits before execution.
+9. The binding is resolved from a server-supplied `tenantId`; a resolver returning a
+   binding for a different tenant is refused rather than followed.
+10. Query parameters are passed to the runner as parameters, never interpolated into the
+    SQL text.
+11. An audit-sink failure never fails an otherwise successful query, and never masks a
+    refusal.
 
 ## Dependencies
 
 | Uses module | Via | Why |
 |-------------|-----|-----|
-| (none) | — | Consumed by `gate` through its `QueryExecutor` port once the execute use case and BigQuery adapter land (#55) |
+| (none) | — | Adapters shipped: in-memory (tests, ARC-005 second adapter). Pending: the BigQuery `QueryRunner`, and wiring into `gate`'s `QueryExecutor` port (#55). `BindingResolver` is served by the control-plane module once it exists |
 
 External: `node-sql-parser` (Apache-2.0) for BigQuery-dialect parse/serialize — see the
 COD-040 justification in the PR that introduced it.

--- a/src/modules/executor/application/execute.ts
+++ b/src/modules/executor/application/execute.ts
@@ -1,0 +1,87 @@
+// The execute use case (ADR-0005 §7, MCP step): resolve the tenant's binding,
+// compile the boundary into the SQL, run it, and audit what actually ran.
+//
+// Order matters and is load-bearing: nothing reaches the runner that has not
+// been through bindQuery, and the binding comes from the control plane keyed by
+// a server-resolved tenantId — never from the caller (原則B).
+import { bindQuery } from '../domain/bind.ts';
+import type { TenantId } from '../domain/types.ts';
+import type { AuditSink, BindingResolver, ParamValue, QueryRunner } from './ports.ts';
+
+export type ExecuteFailure = {
+  readonly ok: false;
+  /** 400: the query was refused. 404: unknown tenant. 500: execution failed. */
+  readonly status: 400 | 404 | 500;
+  readonly reason: string;
+};
+export type ExecuteResult =
+  { readonly ok: true; readonly rows: readonly unknown[]; readonly sql: string } | ExecuteFailure;
+
+export interface ExecuteDeps {
+  readonly bindings: BindingResolver;
+  readonly runner: QueryRunner;
+  readonly audit: AuditSink;
+}
+
+export class ExecuteQuery {
+  readonly #d: ExecuteDeps;
+
+  constructor(deps: ExecuteDeps) {
+    this.#d = deps;
+  }
+
+  /**
+   * @param tenantId server-resolved (from the gate's verified context)
+   * @param sql      the report's query, as authored — unbound
+   * @param params   named query parameters, passed through to the runner
+   */
+  async execute(
+    tenantId: TenantId,
+    sql: string,
+    params: Readonly<Record<string, ParamValue>> = {},
+  ): Promise<ExecuteResult> {
+    const binding = await this.#d.bindings.resolve(tenantId);
+    if (binding === null) return { ok: false, status: 404, reason: 'unknown-tenant' };
+    // Defence in depth: a resolver bug that returns another tenant's binding
+    // would silently redirect the dataset, so refuse the mismatch outright.
+    if (binding.tenantId !== tenantId)
+      return { ok: false, status: 500, reason: 'binding-tenant-mismatch' };
+
+    const policy = await this.#d.bindings.policyFor(tenantId);
+    const bound = bindQuery(sql, binding, policy);
+    if (!bound.ok) {
+      await this.#audit(tenantId, 'query.refused', {
+        code: bound.code,
+        detail: bound.detail,
+      });
+      return { ok: false, status: 400, reason: bound.code };
+    }
+
+    const result = await this.#d.runner.run(bound.sql, params);
+    if (!result.ok) {
+      await this.#audit(tenantId, 'query.failed', { reason: result.reason });
+      return { ok: false, status: 500, reason: 'execution-failed' };
+    }
+
+    // Audit the SQL that actually ran, not what was submitted — the bound form
+    // is the evidence that the boundary was applied.
+    await this.#audit(tenantId, 'query.execute', {
+      sql: bound.sql,
+      tables: bound.tables.join(','),
+    });
+    return { ok: true, rows: result.rows, sql: bound.sql };
+  }
+
+  async #audit(
+    tenantId: TenantId,
+    action: string,
+    detail: Readonly<Record<string, string>>,
+  ): Promise<void> {
+    try {
+      await this.#d.audit.record({ tenantId, action, detail });
+    } catch {
+      // An audit-sink outage must not fail a request that already succeeded,
+      // nor mask the original refusal. Surfacing this is the sink's job.
+    }
+  }
+}

--- a/src/modules/executor/application/ports.ts
+++ b/src/modules/executor/application/ports.ts
@@ -1,0 +1,35 @@
+// Ports the executor needs from outside (ARC-002: dependencies point inward).
+// Two implementations are expected (ARC-005): the BigQuery adapter and the
+// in-memory adapter that backs tests and local runs.
+import type { QueryPolicy, TenantBinding, TenantId } from '../domain/types.ts';
+
+/** A named query parameter value. Values are never interpolated into SQL. */
+export type ParamValue = string | number | boolean;
+
+/**
+ * Runs already-bound SQL. Implementations MUST pass `params` as native query
+ * parameters — string interpolation here would undo the AST binding.
+ */
+export interface QueryRunner {
+  run(
+    sql: string,
+    params: Readonly<Record<string, ParamValue>>,
+  ): Promise<
+    | { readonly ok: true; readonly rows: readonly unknown[] }
+    | { readonly ok: false; readonly reason: string }
+  >;
+}
+
+/** Where a tenant's queryable surface comes from (control plane, 原則D). */
+export interface BindingResolver {
+  resolve(tenantId: TenantId): Promise<TenantBinding | null>;
+  policyFor(tenantId: TenantId): Promise<QueryPolicy>;
+}
+
+export interface AuditSink {
+  record(event: {
+    readonly tenantId: TenantId;
+    readonly action: string;
+    readonly detail: Readonly<Record<string, string>>;
+  }): Promise<void>;
+}

--- a/src/modules/executor/infrastructure/memory.ts
+++ b/src/modules/executor/infrastructure/memory.ts
@@ -1,0 +1,67 @@
+// In-memory adapters — the ARC-005 second implementation. They keep the
+// application layer runnable and testable without BigQuery, and stand in for
+// the control plane until that module exists.
+import type { QueryPolicy, TenantBinding, TenantId } from '../domain/types.ts';
+import type { AuditSink, BindingResolver, ParamValue, QueryRunner } from '../application/ports.ts';
+
+export class MemoryBindingResolver implements BindingResolver {
+  readonly #bindings: ReadonlyMap<TenantId, TenantBinding>;
+  readonly #policy: QueryPolicy;
+
+  constructor(bindings: Record<TenantId, TenantBinding>, policy: QueryPolicy) {
+    this.#bindings = new Map(Object.entries(bindings));
+    this.#policy = policy;
+  }
+
+  async resolve(tenantId: TenantId): Promise<TenantBinding | null> {
+    return this.#bindings.get(tenantId) ?? null;
+  }
+
+  async policyFor(): Promise<QueryPolicy> {
+    return this.#policy;
+  }
+}
+
+/**
+ * Records the SQL it was asked to run and replays a canned result. Useful for
+ * asserting *what* reached the warehouse — the point of the boundary work.
+ */
+export class RecordingQueryRunner implements QueryRunner {
+  readonly calls: { sql: string; params: Record<string, ParamValue> }[] = [];
+  #next: { ok: true; rows: readonly unknown[] } | { ok: false; reason: string } = {
+    ok: true,
+    rows: [],
+  };
+
+  willReturn(rows: readonly unknown[]): void {
+    this.#next = { ok: true, rows };
+  }
+  willFail(reason: string): void {
+    this.#next = { ok: false, reason };
+  }
+
+  async run(sql: string, params: Readonly<Record<string, ParamValue>>) {
+    this.calls.push({ sql, params: { ...params } });
+    return this.#next;
+  }
+
+  get lastSql(): string | undefined {
+    return this.calls.at(-1)?.sql;
+  }
+}
+
+export class MemoryAuditSink implements AuditSink {
+  readonly events: { tenantId: TenantId; action: string; detail: Record<string, string> }[] = [];
+
+  async record(event: {
+    tenantId: TenantId;
+    action: string;
+    detail: Readonly<Record<string, string>>;
+  }): Promise<void> {
+    this.events.push({ ...event, detail: { ...event.detail } });
+  }
+
+  actions(): readonly string[] {
+    return this.events.map((e) => e.action);
+  }
+}

--- a/tests/modules/executor/execute.test.ts
+++ b/tests/modules/executor/execute.test.ts
@@ -1,0 +1,140 @@
+// The execute use case. The assertions that matter are about *what reaches the
+// runner*: nothing unbound, never another tenant's dataset, params passed as
+// parameters rather than interpolated.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ExecuteQuery } from '../../../src/modules/executor/application/execute.ts';
+import {
+  MemoryAuditSink,
+  MemoryBindingResolver,
+  RecordingQueryRunner,
+} from '../../../src/modules/executor/infrastructure/memory.ts';
+import type { QueryPolicy, TenantBinding } from '../../../src/modules/executor/domain/types.ts';
+
+const POLICY: QueryPolicy = {
+  tables: [{ name: 'orders', scopeColumn: 'store_id' }, { name: 'categories' }],
+};
+const ALPHA: TenantBinding = {
+  tenantId: 't_alpha',
+  dataset: 't_alpha',
+  scope: { kind: 'all' },
+};
+const BRAVO: TenantBinding = {
+  tenantId: 't_bravo',
+  dataset: 't_bravo',
+  scope: { kind: 'stores', storeIds: ['s9'] },
+};
+
+function harness(bindings: Record<string, TenantBinding> = { t_alpha: ALPHA, t_bravo: BRAVO }) {
+  const runner = new RecordingQueryRunner();
+  const audit = new MemoryAuditSink();
+  const exec = new ExecuteQuery({
+    bindings: new MemoryBindingResolver(bindings, POLICY),
+    runner,
+    audit,
+  });
+  return { exec, runner, audit };
+}
+
+test('the runner only ever sees bound SQL', async () => {
+  const { exec, runner } = harness();
+  runner.willReturn([{ category: 'A' }]);
+  const r = await exec.execute('t_alpha', 'SELECT category FROM orders');
+  assert.ok(r.ok);
+  assert.match(runner.lastSql ?? '', /t_alpha\.orders/);
+  assert.doesNotMatch(runner.lastSql ?? '', /FROM\s+orders/i);
+});
+
+test('the same query run by two tenants hits two different datasets', async () => {
+  const { exec, runner } = harness();
+  await exec.execute('t_alpha', 'SELECT category FROM orders');
+  await exec.execute('t_bravo', 'SELECT category FROM orders');
+  const [a, b] = runner.calls.map((c) => c.sql);
+  assert.match(a ?? '', /t_alpha\.orders/);
+  assert.match(b ?? '', /t_bravo\.orders/);
+  assert.doesNotMatch(b ?? '', /t_alpha/);
+  assert.match(b ?? '', /store_id IN \('s9'\)/); // bravo's row scope came along
+});
+
+test('a refused query never reaches the runner and is audited', async () => {
+  const { exec, runner, audit } = harness();
+  const r = await exec.execute('t_alpha', 'SELECT * FROM t_bravo.orders');
+  assert.equal(r.ok, false);
+  assert.equal(r.ok === false && r.status, 400);
+  assert.equal(r.ok === false && r.reason, 'qualified-table-not-allowed');
+  assert.equal(runner.calls.length, 0); // nothing executed
+  assert.deepEqual(audit.actions(), ['query.refused']);
+});
+
+test('DML is refused before execution', async () => {
+  const { exec, runner } = harness();
+  const r = await exec.execute('t_alpha', 'DELETE FROM orders');
+  assert.equal(r.ok, false);
+  assert.equal(r.ok === false && r.status, 400);
+  assert.equal(runner.calls.length, 0);
+});
+
+test('an unknown tenant is refused without touching the runner', async () => {
+  const { exec, runner } = harness();
+  const r = await exec.execute('t_ghost', 'SELECT category FROM orders');
+  assert.equal(r.ok, false);
+  assert.equal(r.ok === false && r.status, 404);
+  assert.equal(runner.calls.length, 0);
+});
+
+test('a resolver returning a mismatched binding is refused (defence in depth)', async () => {
+  // Simulates the worst resolver bug: t_alpha resolves to bravo's binding.
+  const { exec, runner } = harness({ t_alpha: BRAVO });
+  const r = await exec.execute('t_alpha', 'SELECT category FROM orders');
+  assert.equal(r.ok, false);
+  assert.equal(r.ok === false && r.status, 500);
+  assert.equal(r.ok === false && r.reason, 'binding-tenant-mismatch');
+  assert.equal(runner.calls.length, 0); // bravo's dataset was never queried
+});
+
+test('named parameters are passed through, not interpolated', async () => {
+  const { exec, runner } = harness();
+  await exec.execute('t_alpha', 'SELECT category FROM orders WHERE created_at >= @since', {
+    since: '2026-01-01',
+  });
+  assert.deepEqual(runner.calls[0]?.params, { since: '2026-01-01' });
+  assert.match(runner.lastSql ?? '', /@since/); // still a placeholder
+  assert.doesNotMatch(runner.lastSql ?? '', /2026-01-01/); // value not in the SQL
+});
+
+test('a runner failure surfaces as 500 and is audited, without leaking the driver message', async () => {
+  const { exec, runner, audit } = harness();
+  runner.willFail('bigquery: quota exceeded for project xyz');
+  const r = await exec.execute('t_alpha', 'SELECT category FROM orders');
+  assert.equal(r.ok, false);
+  assert.equal(r.ok === false && r.status, 500);
+  assert.equal(r.ok === false && r.reason, 'execution-failed'); // generic to the caller
+  assert.deepEqual(audit.actions(), ['query.failed']);
+  assert.match(audit.events[0]?.detail['reason'] ?? '', /quota exceeded/); // detail kept audit-side
+});
+
+test('a successful run audits the bound SQL and the tables it touched', async () => {
+  const { exec, audit } = harness();
+  await exec.execute('t_alpha', 'SELECT c.name FROM orders o JOIN categories c ON o.cat = c.id');
+  assert.deepEqual(audit.actions(), ['query.execute']);
+  const detail = audit.events[0]?.detail ?? {};
+  assert.match(detail['sql'] ?? '', /t_alpha\.orders/); // evidence the boundary applied
+  assert.equal(detail['tables'], 't_alpha.categories,t_alpha.orders');
+});
+
+test('an audit-sink outage does not fail an otherwise successful query', async () => {
+  const runner = new RecordingQueryRunner();
+  runner.willReturn([{ category: 'A' }]);
+  const exec = new ExecuteQuery({
+    bindings: new MemoryBindingResolver({ t_alpha: ALPHA }, POLICY),
+    runner,
+    audit: {
+      async record() {
+        throw new Error('audit store unreachable');
+      },
+    },
+  });
+  const r = await exec.execute('t_alpha', 'SELECT category FROM orders');
+  assert.ok(r.ok);
+  assert.deepEqual(r.rows, [{ category: 'A' }]);
+});


### PR DESCRIPTION
## Summary

**A-1 of #55** — the application layer that turns `bindQuery` from a pure function into a use case. `ExecuteQuery` resolves the tenant's binding from the control plane (keyed by a **server-resolved** `tenantId`, never the caller's — 原則B), compiles the boundary into the SQL, runs it, and audits what actually ran.

The ordering is load-bearing: **nothing reaches the `QueryRunner` that has not been through `bindQuery`**, so a refusal short-circuits before any warehouse call.

Two further guards worth calling out:
- A resolver that returns a binding for a **different tenant** is refused as `binding-tenant-mismatch` rather than followed — a resolver bug would otherwise silently redirect the dataset.
- Driver error text stays **audit-side**; the caller gets a generic `execution-failed` (no quota/project details leaked).

Audit records the **bound** SQL and the tables touched — the evidence the boundary was applied — as `query.execute` / `query.refused` / `query.failed`. An audit-sink outage never fails an otherwise successful query nor masks a refusal.

## Verification — 10 tests

| Assertion | Why it matters |
|---|---|
| the runner only ever sees bound SQL | the core claim |
| identical SQL from two tenants → two different datasets (+ bravo's row scope) | isolation is per-caller, not per-query |
| refused query / DML / unknown tenant → **0 runner calls** | refusals cost nothing and leak nothing |
| mismatched binding → 500, runner untouched | defence in depth against a resolver bug |
| params passed as parameters, value absent from SQL text | interpolation would undo the AST binding |
| runner failure → generic reason to caller, detail in audit | no driver-message leakage |
| audit-sink outage → query still succeeds | availability of the sink is not on the request path |

Ports: `QueryRunner`, `BindingResolver`, `AuditSink`, with in-memory adapters as the **ARC-005 second implementation**. `RecordingQueryRunner` exists so tests can assert on exactly what SQL reached the warehouse.

## Notes

- 343 lines / 5 files — over the GR-020 soft limit, under hard; 140 of those are tests.
- No new dependencies; lockfile untouched.
- `make lint` / `make test` green (67 tests total).

**Next in #55**: the BigQuery `QueryRunner` (named query parameters only), then wiring into the gate's executor SEAM.

Refs: #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)