### PR TITLE
feat(executor): BigQuery query runner over the REST jobs.query endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "0.0.0",
       "dependencies": {
+        "google-auth-library": "^10.9.0",
         "node-sql-parser": "^5.4.0"
       },
       "devDependencies": {
@@ -35,6 +36,35 @@
       "integrity": "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==",
       "license": "MIT"
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -42,6 +72,238 @@
       "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-sql-parser": {
@@ -73,6 +335,26 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -93,6 +375,15 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typescript": "^5.8.0"
   },
   "dependencies": {
+    "google-auth-library": "^10.9.0",
     "node-sql-parser": "^5.4.0"
   }
 }

--- a/src/modules/executor/MODULE.md
+++ b/src/modules/executor/MODULE.md
@@ -56,12 +56,14 @@ reads the tenant's analytics dataset.
     SQL text.
 11. An audit-sink failure never fails an otherwise successful query, and never masks a
     refusal.
+12. The BigQuery runner never returns a partial answer as if it were complete: an
+    incomplete job or a paged result is an error, not truncated rows.
 
 ## Dependencies
 
 | Uses module | Via | Why |
 |-------------|-----|-----|
-| (none) | — | Adapters shipped: in-memory (tests, ARC-005 second adapter). Pending: the BigQuery `QueryRunner`, and wiring into `gate`'s `QueryExecutor` port (#55). `BindingResolver` is served by the control-plane module once it exists |
+| (none) | — | Adapters shipped: BigQuery `QueryRunner` (REST `jobs.query` + ADC) and in-memory (tests, ARC-005 second adapter). Pending: wiring into `gate`'s `QueryExecutor` port (#55). `BindingResolver` is served by the control-plane module once it exists |
 
 External: `node-sql-parser` (Apache-2.0) for BigQuery-dialect parse/serialize — see the
 COD-040 justification in the PR that introduced it.

--- a/src/modules/executor/infrastructure/bigquery.ts
+++ b/src/modules/executor/infrastructure/bigquery.ts
@@ -1,0 +1,190 @@
+// BigQuery QueryRunner over the REST jobs.query endpoint.
+//
+// Uses fetch rather than @google-cloud/bigquery deliberately: the official
+// client pulls 48 packages (+563 lockfile lines, over the GR-020 hard limit in
+// one PR), while the surface we need here is one endpoint. Credentials still
+// come from google-auth-library — hand-rolling service-account OAuth would be
+// the wrong thing to own.
+//
+// Values are ALWAYS sent as named query parameters. Interpolating them into the
+// SQL text would undo the AST binding the domain layer just applied.
+import type { ParamValue, QueryRunner } from '../application/ports.ts';
+
+export interface AccessTokenProvider {
+  getToken(): Promise<string>;
+}
+
+/** The slice of fetch this adapter uses — injectable so tests need no network. */
+export type FetchLike = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+}>;
+
+export interface BigQueryRunnerOptions {
+  readonly projectId: string;
+  readonly tokens: AccessTokenProvider;
+  readonly fetchImpl?: FetchLike;
+  /** Rows beyond this are a hard error, never a silent truncation. */
+  readonly maxRows?: number;
+  readonly location?: string;
+  readonly timeoutMs?: number;
+}
+
+interface BqField {
+  name?: string;
+  type?: string;
+}
+interface BqCell {
+  v?: unknown;
+}
+interface BqRow {
+  f?: BqCell[];
+}
+interface BqResponse {
+  jobComplete?: boolean;
+  schema?: { fields?: BqField[] };
+  rows?: BqRow[];
+  pageToken?: string;
+  totalRows?: string;
+  error?: { message?: string };
+  errors?: { message?: string }[];
+}
+
+function queryParameter(name: string, value: ParamValue) {
+  const type =
+    typeof value === 'boolean'
+      ? 'BOOL'
+      : typeof value === 'number'
+        ? Number.isInteger(value)
+          ? 'INT64'
+          : 'FLOAT64'
+        : 'STRING';
+  return {
+    name,
+    parameterType: { type },
+    parameterValue: { value: String(value) },
+  };
+}
+
+/** BigQuery returns every value as a string; restore the schema's type. */
+function decodeCell(raw: unknown, type: string | undefined): unknown {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== 'string') return raw; // nested/repeated values pass through
+  switch (type) {
+    case 'INTEGER':
+    case 'INT64': {
+      const n = Number(raw);
+      // Keep the string when the value cannot survive as a JS number.
+      return Number.isSafeInteger(n) ? n : raw;
+    }
+    case 'FLOAT':
+    case 'FLOAT64':
+    case 'NUMERIC':
+    case 'BIGNUMERIC': {
+      const n = Number(raw);
+      return Number.isFinite(n) ? n : raw;
+    }
+    case 'BOOLEAN':
+    case 'BOOL':
+      return raw === 'true';
+    default:
+      return raw;
+  }
+}
+
+export class BigQueryRunner implements QueryRunner {
+  readonly #o: BigQueryRunnerOptions;
+  readonly #fetch: FetchLike;
+  readonly #maxRows: number;
+
+  constructor(options: BigQueryRunnerOptions) {
+    this.#o = options;
+    this.#fetch = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    this.#maxRows = options.maxRows ?? 10_000;
+  }
+
+  async run(
+    sql: string,
+    params: Readonly<Record<string, ParamValue>>,
+  ): Promise<{ ok: true; rows: readonly unknown[] } | { ok: false; reason: string }> {
+    const body = {
+      query: sql,
+      useLegacySql: false,
+      parameterMode: 'NAMED',
+      queryParameters: Object.entries(params).map(([k, v]) => queryParameter(k, v)),
+      maxResults: this.#maxRows,
+      timeoutMs: this.#o.timeoutMs ?? 30_000,
+      ...(this.#o.location !== undefined && { location: this.#o.location }),
+    };
+
+    let token: string;
+    try {
+      token = await this.#o.tokens.getToken();
+    } catch (e) {
+      return { ok: false, reason: `credentials unavailable: ${message(e)}` };
+    }
+
+    let raw: string;
+    let httpOk: boolean;
+    let status: number;
+    try {
+      const res = await this.#fetch(
+        `https://bigquery.googleapis.com/bigquery/v2/projects/${encodeURIComponent(
+          this.#o.projectId,
+        )}/queries`,
+        {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${token}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        },
+      );
+      httpOk = res.ok;
+      status = res.status;
+      raw = await res.text();
+    } catch (e) {
+      return { ok: false, reason: `request failed: ${message(e)}` };
+    }
+
+    let parsed: BqResponse;
+    try {
+      parsed = JSON.parse(raw) as BqResponse;
+    } catch {
+      return { ok: false, reason: `unparsable response (HTTP ${status})` };
+    }
+    if (!httpOk) {
+      return { ok: false, reason: parsed.error?.message ?? `HTTP ${status}` };
+    }
+    const firstError = parsed.errors?.[0]?.message;
+    if (firstError !== undefined) return { ok: false, reason: firstError };
+    if (parsed.jobComplete === false) {
+      // Returning the partial result would look like a complete answer.
+      return { ok: false, reason: 'query did not complete within the timeout' };
+    }
+    if (parsed.pageToken !== undefined) {
+      return {
+        ok: false,
+        reason: `result exceeds maxRows (${this.#maxRows}); refine the query`,
+      };
+    }
+
+    const fields = parsed.schema?.fields ?? [];
+    const rows = (parsed.rows ?? []).map((row) => {
+      const out: Record<string, unknown> = {};
+      fields.forEach((field, i) => {
+        const name = field.name ?? `f${i}`;
+        out[name] = decodeCell(row.f?.[i]?.v, field.type);
+      });
+      return out;
+    });
+    return { ok: true, rows };
+  }
+}
+
+const message = (e: unknown): string => (e instanceof Error ? e.message : String(e));

--- a/src/modules/executor/infrastructure/google-auth.ts
+++ b/src/modules/executor/infrastructure/google-auth.ts
@@ -1,0 +1,32 @@
+// Application Default Credentials token source for the BigQuery runner.
+// Isolated in its own file so the runner itself stays dependency-free and
+// testable with an injected token provider.
+import { GoogleAuth } from 'google-auth-library';
+import type { AccessTokenProvider } from './bigquery.ts';
+
+const BIGQUERY_SCOPE = 'https://www.googleapis.com/auth/bigquery';
+
+/**
+ * Resolves credentials the standard GCP way: `gcloud auth
+ * application-default login` locally, the attached service account in Cloud
+ * Run. Nothing is read from the repo (GR-001).
+ */
+export class AdcTokenProvider implements AccessTokenProvider {
+  readonly #auth: GoogleAuth;
+
+  constructor(scopes: readonly string[] = [BIGQUERY_SCOPE]) {
+    this.#auth = new GoogleAuth({ scopes: [...scopes] });
+  }
+
+  async getToken(): Promise<string> {
+    const client = await this.#auth.getClient();
+    const { token } = await client.getAccessToken();
+    if (!token) throw new Error('no access token returned by ADC');
+    return token;
+  }
+
+  /** The project ADC resolved to — handy for wiring, not used for authz. */
+  async projectId(): Promise<string> {
+    return this.#auth.getProjectId();
+  }
+}

--- a/tests/modules/executor/bigquery.test.ts
+++ b/tests/modules/executor/bigquery.test.ts
@@ -1,0 +1,210 @@
+// BigQuery runner over a fake fetch — no network, no credentials. The
+// assertions cover the request we send (parameters, never interpolation) and
+// the failure modes where a wrong answer would be worse than an error.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  BigQueryRunner,
+  type FetchLike,
+} from '../../../src/modules/executor/infrastructure/bigquery.ts';
+
+interface Captured {
+  url: string;
+  body: Record<string, unknown>;
+  headers: Record<string, string>;
+}
+
+function fakeFetch(
+  response: unknown,
+  opts: { ok?: boolean; status?: number; raw?: string } = {},
+): { fetchImpl: FetchLike; captured: Captured[] } {
+  const captured: Captured[] = [];
+  const fetchImpl: FetchLike = async (url, init) => {
+    captured.push({
+      url,
+      body: JSON.parse(init.body) as Record<string, unknown>,
+      headers: init.headers,
+    });
+    return {
+      ok: opts.ok ?? true,
+      status: opts.status ?? 200,
+      async text() {
+        return opts.raw ?? JSON.stringify(response);
+      },
+    };
+  };
+  return { fetchImpl, captured };
+}
+
+const tokens = {
+  async getToken() {
+    return 'test-token';
+  },
+};
+const runner = (fetchImpl: FetchLike, maxRows?: number) =>
+  new BigQueryRunner({
+    projectId: 'kotonoha-bi-dev',
+    tokens,
+    fetchImpl,
+    ...(maxRows !== undefined && { maxRows }),
+  });
+
+const OK_RESPONSE = {
+  jobComplete: true,
+  schema: {
+    fields: [
+      { name: 'category', type: 'STRING' },
+      { name: 'total', type: 'INTEGER' },
+    ],
+  },
+  rows: [{ f: [{ v: 'A' }, { v: '40000' }] }, { f: [{ v: 'B' }, { v: '25000' }] }],
+};
+
+test('decodes rows into typed objects using the schema', async () => {
+  const { fetchImpl } = fakeFetch(OK_RESPONSE);
+  const r = await runner(fetchImpl).run('SELECT 1', {});
+  assert.ok(r.ok);
+  assert.deepEqual(r.rows, [
+    { category: 'A', total: 40000 },
+    { category: 'B', total: 25000 },
+  ]);
+});
+
+test('values are sent as named parameters, never interpolated into the SQL', async () => {
+  const { fetchImpl, captured } = fakeFetch(OK_RESPONSE);
+  const sql = 'SELECT category FROM t_alpha.orders WHERE created_at >= @since AND n > @n';
+  await runner(fetchImpl).run(sql, { since: '2026-01-01', n: 5 });
+  const body = captured[0]?.body ?? {};
+  assert.equal(body['query'], sql); // SQL passed through untouched
+  assert.equal(body['parameterMode'], 'NAMED');
+  assert.equal(body['useLegacySql'], false);
+  assert.deepEqual(body['queryParameters'], [
+    { name: 'since', parameterType: { type: 'STRING' }, parameterValue: { value: '2026-01-01' } },
+    { name: 'n', parameterType: { type: 'INT64' }, parameterValue: { value: '5' } },
+  ]);
+});
+
+test('parameter types are inferred per value', async () => {
+  const { fetchImpl, captured } = fakeFetch(OK_RESPONSE);
+  await runner(fetchImpl).run('SELECT 1', { s: 'x', i: 7, f: 1.5, b: true });
+  const types = (
+    captured[0]?.body['queryParameters'] as { name: string; parameterType: { type: string } }[]
+  ).map((p) => [p.name, p.parameterType.type]);
+  assert.deepEqual(types, [
+    ['s', 'STRING'],
+    ['i', 'INT64'],
+    ['f', 'FLOAT64'],
+    ['b', 'BOOL'],
+  ]);
+});
+
+test('the access token is sent as a bearer credential', async () => {
+  const { fetchImpl, captured } = fakeFetch(OK_RESPONSE);
+  await runner(fetchImpl).run('SELECT 1', {});
+  assert.equal(captured[0]?.headers['authorization'], 'Bearer test-token');
+  assert.match(captured[0]?.url ?? '', /projects\/kotonoha-bi-dev\/queries$/);
+});
+
+test('an integer too large for a JS number is kept as a string', async () => {
+  const { fetchImpl } = fakeFetch({
+    jobComplete: true,
+    schema: { fields: [{ name: 'big', type: 'INT64' }] },
+    rows: [{ f: [{ v: '9007199254740993' }] }],
+  });
+  const r = await runner(fetchImpl).run('SELECT 1', {});
+  assert.ok(r.ok);
+  assert.deepEqual(r.rows, [{ big: '9007199254740993' }]); // not silently rounded
+});
+
+test('booleans and nulls decode correctly', async () => {
+  const { fetchImpl } = fakeFetch({
+    jobComplete: true,
+    schema: {
+      fields: [
+        { name: 'flag', type: 'BOOL' },
+        { name: 'missing', type: 'STRING' },
+      ],
+    },
+    rows: [{ f: [{ v: 'true' }, { v: null }] }, { f: [{ v: 'false' }, {}] }],
+  });
+  const r = await runner(fetchImpl).run('SELECT 1', {});
+  assert.ok(r.ok);
+  assert.deepEqual(r.rows, [
+    { flag: true, missing: null },
+    { flag: false, missing: null },
+  ]);
+});
+
+test('an empty result set is success with no rows', async () => {
+  const { fetchImpl } = fakeFetch({ jobComplete: true, schema: { fields: [] } });
+  const r = await runner(fetchImpl).run('SELECT 1', {});
+  assert.ok(r.ok);
+  assert.deepEqual(r.rows, []);
+});
+
+// --- failure modes: an error must never masquerade as a complete answer ----
+
+test('an incomplete job is an error, not a partial result', async () => {
+  const { fetchImpl } = fakeFetch({ jobComplete: false, rows: [{ f: [{ v: 'A' }] }] });
+  const r = await runner(fetchImpl).run('SELECT 1', {});
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.reason : '', /did not complete/);
+});
+
+test('a paged result is an error rather than a silent truncation', async () => {
+  const { fetchImpl } = fakeFetch({ ...OK_RESPONSE, pageToken: 'more' });
+  const r = await runner(fetchImpl, 2).run('SELECT 1', {});
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.reason : '', /exceeds maxRows \(2\)/);
+});
+
+test('an HTTP error surfaces the API message', async () => {
+  const { fetchImpl } = fakeFetch(
+    { error: { message: 'Access Denied: Table t_bravo.orders' } },
+    { ok: false, status: 403 },
+  );
+  const r = await runner(fetchImpl).run('SELECT 1', {});
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.reason : '', /Access Denied/);
+});
+
+test('a job-level error is reported even on HTTP 200', async () => {
+  const { fetchImpl } = fakeFetch({
+    jobComplete: true,
+    errors: [{ message: 'Syntax error at [1:1]' }],
+  });
+  const r = await runner(fetchImpl).run('SELECT 1', {});
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.reason : '', /Syntax error/);
+});
+
+test('an unparsable body is an error, not a crash', async () => {
+  const { fetchImpl } = fakeFetch(null, { raw: '<html>gateway timeout</html>', status: 504 });
+  const r = await runner(fetchImpl).run('SELECT 1', {});
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.reason : '', /unparsable response/);
+});
+
+test('a transport failure is an error, not a throw', async () => {
+  const boom: FetchLike = async () => {
+    throw new Error('ECONNRESET');
+  };
+  const r = await runner(boom).run('SELECT 1', {});
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.reason : '', /request failed: ECONNRESET/);
+});
+
+test('missing credentials are an error, not a throw', async () => {
+  const { fetchImpl } = fakeFetch(OK_RESPONSE);
+  const r = await new BigQueryRunner({
+    projectId: 'p',
+    tokens: {
+      async getToken() {
+        throw new Error('reauth required');
+      },
+    },
+    fetchImpl,
+  }).run('SELECT 1', {});
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.reason : '', /credentials unavailable: reauth required/);
+});


### PR DESCRIPTION
## Summary

**A-2 of #55** — the `QueryRunner` port implemented against BigQuery. Values go out **exclusively as named query parameters**; interpolating them would undo the AST binding the domain layer just applied.

## Dependency choice (COD-040) — decided by measurement

I measured both options before picking:

| Option | packages | lockfile | PR total |
|---|---|---|---|
| `@google-cloud/bigquery` | 48 | +563 | **~850 lines → over the GR-020 hard limit on its own** |
| `google-auth-library` + `fetch` | 23 | +291 | 727 lines ✅ |

The surface actually needed is **one endpoint**, so this uses `fetch` directly and takes `google-auth-library` (Apache-2.0) only for credentials — hand-rolling service-account OAuth would be the wrong thing to own. Using `fetch` also keeps the adapter runtime-portable, consistent with ADR-0006's thin-adapter rule.

## Failure handling is deliberately strict

A wrong answer is worse than an error here:

| Situation | Behaviour |
|---|---|
| job not complete | error — **not** the partial rows |
| result has a `pageToken` | error naming `maxRows` — **never a silent truncation** |
| INT64 beyond `Number.MAX_SAFE_INTEGER` | kept as a string, not silently rounded |
| job-level error on HTTP 200 | reported |
| transport failure / unparsable body / missing credentials | returns a reason, does not throw |

The execute use case (#58) keeps those reasons audit-side and hands the caller a generic `execution-failed`.

## Verification — 14 tests, no network

Driven over a fake `fetch` with an injected token provider, so the suite needs neither credentials nor connectivity. Asserts on the **request we send** (SQL passed through untouched, `parameterMode: NAMED`, per-value type inference STRING/INT64/FLOAT64/BOOL, bearer credential) and on decoding (schema-typed rows, booleans, nulls, empty sets).

## ⚠️ Not yet verified against live BigQuery

Local ADC currently fails with `invalid_rapt` (re-auth required), so **this adapter has not executed a real query yet**. Two follow-ups once credentials are refreshed:

1. a live smoke query (read-only, against a public dataset — no resource creation), and
2. the two-tenant cross-dataset isolation measurement, which needs a decision from you on creating `t_alpha` / `t_bravo` datasets in `kotonoha-bi-dev`.

To refresh: `gcloud auth application-default login`.

## Notes

- 727 lines / 6 files — over the GR-020 soft limit, under hard. 291 is the lockfile and 210 the tests.
- `make lint` / `make test` green (81 tests total).

Refs: #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)