### PR TITLE
chore(inheritance): declare foundation document ownership

### DIFF
--- a/.github/inheritance/lock.json
+++ b/.github/inheritance/lock.json
@@ -2,6 +2,6 @@
   "schema_version": 1,
   "parent": {
     "repository": "Yukihide-Mitsuoka/ai-dev-foundation",
-    "commit": "9ab06004ed129d0d27e4a1876aa03b04d067cc71"
+    "commit": "a177d1f694d6e754588c0753fb6ddf188753a8ea"
   }
 }

--- a/.github/inheritance/manifest.json
+++ b/.github/inheritance/manifest.json
@@ -38,7 +38,8 @@
     "LICENSE",
     "SECURITY.md",
     "renovate.json",
-    "scripts/"
+    "scripts/",
+    "docs/foundation/"
   ],
   "protected_paths": [
     ".ai/architecture.md",
@@ -77,10 +78,16 @@
     "CLAUDE.md",
     "Makefile",
     "README.md",
-    "docs/",
     "profiles/",
     "spikes/",
     "src/",
-    "tests/"
+    "tests/",
+    "docs/adr/",
+    "docs/discovery-log.md",
+    "docs/glossary.md",
+    "docs/requirements.md",
+    "docs/roadmap.md",
+    "docs/status.md",
+    "docs/system-design.md"
   ]
 }


### PR DESCRIPTION
## What & why

`chat-chart` のmanifestで `docs/` 全体を保護していた状態を解消します。`docs/foundation/` を基盤から継承し、ADR・要件・状態・システム設計などのプロジェクト固有文書だけを直接 `docs/` 配下で保護します。lockは `ai-dev-foundation@a177d1f` に更新します。

Refs: リポジトリ所有者の依頼（GitHub issueなし）

## Change classification (ARC-020)

- [ ] Local (inside one module, contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [x] Architectural — parent ADR-0006 (`docs/foundation/adr/0006-reserve-a-foundation-documentation-namespace.md`)

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: 2026-07-22に `make format && make lint && make test && make doctor` を実行し成功。Nodeテストと基盤テストはいずれも成功。
- Not verified (be honest — GR-042): GitHub ActionsはPR作成後に実行。

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: n/a — 物理的な文書配置は既に正しく、所有manifestのみを更新

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes: リポジトリ所有者の承認済み文書所有境界を適用。

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)