### PR TITLE
fix(sync): adopt safe parent propagation

### DIFF
--- a/.github/inheritance/README.md
+++ b/.github/inheritance/README.md
@@ -6,7 +6,9 @@ title: Template Inheritance Contract
 # Template Inheritance Contract
 
 This directory defines the child-owned, direct-parent contract from
-[ADR-0004](../../docs/foundation/adr/0004-harden-multi-level-template-inheritance.md).
+[ADR-0004](../../docs/foundation/adr/0004-harden-multi-level-template-inheritance.md)
+and the bounded legacy transport from
+[ADR-0007](../../docs/foundation/adr/0007-constrain-transitional-template-sync.md).
 Validation and local history planning are read-only; materialization remains a follow-up.
 
 ## Schema version 1
@@ -34,6 +36,23 @@ absolute paths, traversal, `.git`, duplicates, and overlap within or across owne
 classes are invalid. Protected roots must cover the manifest, selected lock file,
 `.gitignore`, `.templatesyncignore`, local governance policy, and sync workflow.
 
+During the transitional Template Sync period, `.templatesyncignore` must also:
+
+- cover every manifest `protected_paths` root;
+- contain `.github/workflows/**`; and
+- contain no `:!` exception that re-includes a protected root or workflow.
+
+Entries ending in `/**` are treated as directory roots. The `:!` prefix is a Git
+pathspec exclusion used by `actions-template-sync`, not `.gitignore` negation. The
+intentional `:!docs/foundation/**` exception permits only the inherited foundation
+documentation namespace.
+
+`actions-template-sync@v2` exposes an abbreviated source hash even though its action
+metadata calls the value a Git hash. The workflow must expand that exact abbreviation
+through the GitHub commits API and validate the resulting 40-character commit before
+writing PR provenance. Resolving only the current parent branch head is insufficient
+because the parent can move while synchronization runs.
+
 ## Validate
 
 ```bash
@@ -42,6 +61,24 @@ python3 scripts/template_inheritance.py validate --root .
 
 Exit `0` prints deterministic JSON; exit `2` reports invalid input on stderr. The command
 performs no network request, file write, deletion, Git operation, or GitHub API call.
+`make doctor` runs this validation automatically when the repository contains a child
+manifest; the foundation root has no manifest and skips only this child-specific check.
+
+## Propagate a parent change
+
+Apply each row in order. Do not prepare a grandchild from an unmerged intermediate
+template.
+
+| Step | Required evidence |
+|------|-------------------|
+| 1. Update a direct child | Template Sync PR names the direct parent and the exact 40-character source commit |
+| 2. Review inherited files | Accepted lock-to-source range reviewed; no protected path changed by transport |
+| 3. Port workflows | Separate maintainer-authenticated PR verified against the same direct-parent source commit |
+| 4. Advance the lock | Lock changes only in a reviewed PR after the complete parent delta is accepted |
+| 5. Merge and continue | Only the merged child commit becomes the source for its direct children |
+
+Template Sync must never auto-merge or apply repository governance. If validation fails,
+disable `TEMPLATE_SYNC_ENABLED` until the manifest and local ignore contract agree.
 
 ## Plan the next parent commit
 

--- a/.github/inheritance/lock.json
+++ b/.github/inheritance/lock.json
@@ -2,6 +2,6 @@
   "schema_version": 1,
   "parent": {
     "repository": "Yukihide-Mitsuoka/ai-dev-foundation",
-    "commit": "a177d1f694d6e754588c0753fb6ddf188753a8ea"
+    "commit": "86eb9243a5ea1d1696588bceb1573afdfe182ce9"
   }
 }

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -5,7 +5,8 @@
 # OPT-IN and safe by default: the job only runs when the repository variable
 # TEMPLATE_SYNC_ENABLED is set to "true". So the template repo itself and any unmodified
 # downstream repo never run it (no spurious weekly failures). To enable sync in a
-# downstream repo: set repo variable TEMPLATE_SYNC_ENABLED=true.
+# downstream repo: set repo variable TEMPLATE_SYNC_ENABLED=true and verify its direct
+# parent below.
 name: Template Sync
 
 on:
@@ -25,22 +26,54 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
-      - name: Resolve full foundation source commit
-        id: foundation-source
-        shell: bash
-        run: |
-          set -euo pipefail
-          read -r source_sha _ <<< "$(git ls-remote https://github.com/Yukihide-Mitsuoka/ai-dev-foundation.git refs/heads/main)"
-          if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Unable to resolve the full ai-dev-foundation main commit" >&2
-            exit 1
-          fi
-          echo "sha=$source_sha" >> "$GITHUB_OUTPUT"
       - uses: AndreasAugustin/actions-template-sync@v2
+        id: template-sync
         with:
+          # This repository syncs only from its direct parent. A repository created from
+          # chat-chart must repoint this field to Yukihide-Mitsuoka/chat-chart.
           source_repo_path: "Yukihide-Mitsuoka/ai-dev-foundation"
           upstream_branch: main
           pr_title: "build: sync with ai-dev-foundation template"
-          pr_body: "Foundation-source: https://github.com/Yukihide-Mitsuoka/ai-dev-foundation@${{ steps.foundation-source.outputs.sha }}"
+          pr_body: >-
+            Direct-parent source commit will be recorded after synchronization. Before
+            merge, review the accepted lock-to-source range and update
+            .github/inheritance/lock.json in this PR.
           pr_labels: "type:ci,type:dependencies"
           pr_commit_msg: "build: sync with ai-dev-foundation template"
+      - name: Record exact direct-parent source commit
+        if: steps.template-sync.outputs.pr_branch != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.template-sync.outputs.pr_number }}
+          PR_BRANCH: ${{ steps.template-sync.outputs.pr_branch }}
+          SOURCE_SHORT: ${{ steps.template-sync.outputs.template_git_hash }}
+          SOURCE_REPOSITORY: "Yukihide-Mitsuoka/ai-dev-foundation"
+        run: |
+          set -euo pipefail
+          if [[ -z "$SOURCE_SHORT" ]]; then
+            SOURCE_SHORT="${PR_BRANCH##*_}"
+          fi
+          if [[ ! "$SOURCE_SHORT" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "Template Sync returned an invalid abbreviated source commit" >&2
+            exit 1
+          fi
+          SOURCE_COMMIT="$(gh api "repos/${SOURCE_REPOSITORY}/commits/${SOURCE_SHORT}" --jq .sha)"
+          if [[ ! "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ || "$SOURCE_COMMIT" != "$SOURCE_SHORT"* ]]; then
+            echo "Unable to expand the Template Sync source commit" >&2
+            exit 1
+          fi
+          if [[ -z "$PR_NUMBER" ]]; then
+            PR_NUMBER="$(gh pr view "$PR_BRANCH" --json number --jq .number)"
+          fi
+          if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Template Sync returned an invalid pull request number" >&2
+            exit 1
+          fi
+          body="Direct-parent-source: https://github.com/${SOURCE_REPOSITORY}@${SOURCE_COMMIT}
+
+Before merge:
+- Review the accepted lock-to-source commit range.
+- Port direct-parent workflow changes in a separate reviewed PR.
+- Update .github/inheritance/lock.json only after the complete parent delta is accepted."
+          gh pr edit "$PR_NUMBER" --body "$body"

--- a/docs/foundation/adr/0007-constrain-transitional-template-sync.md
+++ b/docs/foundation/adr/0007-constrain-transitional-template-sync.md
@@ -1,0 +1,98 @@
+# ADR-0007: Constrain transitional Template Sync
+
+| Field | Value |
+|-------|-------|
+| Status | accepted |
+| Date | 2026-07-22 |
+| Deciders | repository owner (approved in PR #53 on 2026-07-22) |
+| Author | Codex (AI agent) |
+| Supersedes / Superseded by | Extends the migration rules of ADR-0004 |
+
+## Context
+
+ADR-0004 selects a manifest-driven, local-first reconciler and disables scheduled
+write-capable Template Sync by default. Materialization is not implemented yet, so the
+current repository fleet still uses `actions-template-sync` to open reviewed migration
+PRs. The transitional configuration has drifted between repositories: some children do
+not protect every manifest-owned path, some allow inherited workflow changes that the
+GitHub App cannot push without Workflows permission, and some PRs do not identify the
+exact parent commit being reviewed.
+
+This has produced failed sync pushes and makes it possible to merge an ambiguous or
+unsafe parent delta. Multi-level inheritance adds an ordering constraint: a grandchild
+must review the intermediate template's merged result, not bypass it or advance its lock
+to an unmerged upstream commit.
+
+Constraints are: every propagation remains a human-reviewed PR; no privileged PAT or
+GitHub App credential is introduced; repository-owned files and project documentation
+remain protected; workflow changes still propagate through an explicit review path; and
+the interim mechanism must remain compatible with the ADR-0004 local-first destination.
+
+## Options considered
+
+### Option 1: Do nothing
+
+Keep each repository's current ignore list and PR metadata. This has no migration cost,
+but repeats known permission failures and leaves ownership safety dependent on manually
+remembered exceptions. Rejected.
+
+### Option 2: Grant Template Sync Workflows permission
+
+Use a PAT or GitHub App that can update workflow files. This gives one automatic
+transport for all inherited files, but increases credential scope and still does not
+prove that protected paths match the inheritance manifest. Rejected.
+
+### Option 3: Bound the transitional transport by the inheritance contract
+
+Keep Template Sync only as a PR-producing transport for non-workflow inherited files.
+Exclude all workflows and every protected manifest root, include the exact direct-parent
+commit in the PR, and port workflow changes through a separate reviewed PR. Validate the
+ignore/manifest relationship in CI and propagate multi-level changes one merged hop at a
+time. This adds a manual workflow-update step but has the smallest credential and
+overwrite blast radius.
+
+## Decision
+
+Adopt Option 3 until ADR-0004 materialization replaces `actions-template-sync`.
+
+- A child MUST name only its direct parent. Multi-level propagation MUST proceed in
+  parent-to-child order, and each hop MUST merge before the next hop is prepared.
+- `.templatesyncignore` MUST protect every `protected_paths` root in the child manifest.
+  CI MUST fail when the two contracts diverge. The manifest, lock, ignore file, local
+  governance policy, `.gitignore`, and Template Sync workflow remain child-owned.
+- `.github/workflows/**` MUST be excluded from legacy Template Sync. Inherited workflow
+  changes MUST be ported in an explicit reviewed PR using maintainer authentication and
+  verified against the direct parent's exact commit.
+- Every sync PR MUST identify the direct parent repository and full 40-character source
+  commit. A reviewer MUST compare the accepted lock-to-source range before merging.
+- The inheritance lock MUST advance only in the reviewed PR that accepts the parent
+  delta. It MUST NOT advance past an unmerged direct-parent commit.
+- Template Sync MUST NOT auto-merge or apply GitHub governance. Its only permitted write
+  outcome is a reviewable branch and PR.
+
+Git pathspec and ignore-file syntax MUST be treated as different contracts. In
+particular, `actions-template-sync` restores ignored files with `git reset --`, so the
+existing `:!docs/foundation/**` Git pathspec exception is intentional and MUST NOT be
+rewritten as `.gitignore` negation without an implementation change and regression test.
+
+## Consequences
+
+**Positive:** legacy sync cannot overwrite manifest-protected paths; ordinary inherited
+files still arrive as reviewable PRs; workflow-write failures are removed from the
+automated path; reviewers can reproduce the exact parent delta; and multi-level
+inheritance preserves the direct-parent boundary.
+
+**Negative:** workflow updates require a second, maintainer-authenticated PR; every child
+must maintain and test its local ignore contract; a stale lock remains possible until a
+reviewer accepts the delta; and propagation latency increases at each inheritance hop.
+
+Migration is expand-first: add validation and PR provenance, protect all workflows and
+manifest-owned paths, then run one reviewed sync per direct child. After direct-child
+merges, repeat from each intermediate template to its children. Rollback disables
+`TEMPLATE_SYNC_ENABLED`; protected files and accepted locks remain unchanged. The final
+contract-and-apply implementation from ADR-0004 can replace this transport without
+changing path ownership or direct-parent topology.
+
+**Follow-ups:** add the reusable ignore/manifest validator and tests; update the
+inheritance guide with the ordered fleet runbook and the permission/provenance lessons;
+migrate every enabled child; and audit the complete repository graph after all PRs merge.

--- a/docs/foundation/adr/README.md
+++ b/docs/foundation/adr/README.md
@@ -29,5 +29,6 @@ process in `.skills/architecture.skill.md`.
 | [0004](0004-harden-multi-level-template-inheritance.md) | Harden multi-level template inheritance | accepted | 2026-07-16 |
 | [0005](0005-separate-foundation-and-project-document-languages.md) | Separate foundation and project document languages | accepted | 2026-07-18 |
 | [0006](0006-reserve-a-foundation-documentation-namespace.md) | Reserve a foundation documentation namespace | accepted | 2026-07-18 |
+| [0007](0007-constrain-transitional-template-sync.md) | Constrain transitional Template Sync | accepted | 2026-07-22 |
 
 <!-- Append new ADRs to this table (newest last). -->

--- a/scripts/template-check.sh
+++ b/scripts/template-check.sh
@@ -9,7 +9,9 @@
 #   2. No file carries the "collapsed frontmatter" signature a non-frontmatter-aware
 #      formatter produces (guards against the LOG-0007 regression recurring).
 #   3. GitHub governance inheritance rejects invalid or weakening policy.
-#   4. Foundation-owned project-documentation guides do not occupy project-owned paths.
+#   4. Child repositories with a manifest satisfy the local inheritance and legacy
+#      Template Sync protection contract.
+#   5. Foundation-owned project-documentation guides do not occupy project-owned paths.
 
 set -u
 cd "$(dirname "$0")/.." || exit 9
@@ -40,7 +42,14 @@ fi
 python3 -m unittest discover -s scripts/tests -p 'test_*.py' || err "GitHub governance policy tests failed"
 python3 scripts/github_governance.py validate --root . >/dev/null || err "GitHub governance policy is invalid"
 
-# 4. ADR-0006 ownership boundary: reusable scaffolding belongs under docs/foundation/.
+# 4. ADR-0007: validate the actual child contract, not only unit-test fixtures. The
+# foundation root has no child manifest, so this remains a no-op there.
+if [ -f ".github/inheritance/manifest.json" ]; then
+  python3 scripts/template_inheritance.py validate --root . >/dev/null || \
+    err "Template inheritance and legacy sync protection contract is invalid"
+fi
+
+# 5. ADR-0006 ownership boundary: reusable scaffolding belongs under docs/foundation/.
 # Only the canonical foundation repository bans legacy project-path copies. Legacy
 # direct Template Sync children do not necessarily carry an inheritance manifest, so
 # manifest absence cannot identify the root. Children may validly create repository-owned
@@ -104,6 +113,7 @@ for path in \
   docs/foundation/adr/0004-harden-multi-level-template-inheritance.md \
   docs/foundation/adr/0005-separate-foundation-and-project-document-languages.md \
   docs/foundation/adr/0006-reserve-a-foundation-documentation-namespace.md \
+  docs/foundation/adr/0007-constrain-transitional-template-sync.md \
   docs/foundation/troubleshooting/README.md \
   docs/foundation/troubleshooting/github-governance.md \
   docs/foundation/troubleshooting/template-inheritance.md \

--- a/scripts/template_inheritance.py
+++ b/scripts/template_inheritance.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 SCHEMA_VERSION = 1
 MANIFEST_PATH = ".github/inheritance/manifest.json"
+TEMPLATE_SYNC_IGNORE_PATH = ".templatesyncignore"
 MAX_CONTRACT_BYTES = 1_000_000
 MAX_OWNERSHIP_ROOTS = 1_000
 MAX_FIRST_PARENT_COMMITS = 100_000
@@ -24,6 +25,7 @@ REQUIRED_PROTECTED_PATHS = {
     ".github/workflows/template-sync.yml",
     ".templatesyncignore",
 }
+REQUIRED_TEMPLATE_SYNC_IGNORES = {".github/workflows/"}
 
 
 class InheritanceError(ValueError):
@@ -137,6 +139,74 @@ def _read_json(root, relative_path):
         raise InheritanceError(f"{relative_path} must contain valid UTF-8 JSON") from error
 
 
+def _read_template_sync_ignore(root):
+    candidate = root / TEMPLATE_SYNC_IGNORE_PATH
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as error:
+        raise InheritanceError(
+            f"{TEMPLATE_SYNC_IGNORE_PATH} must be a file inside the repository root"
+        ) from error
+    if resolved != candidate or not resolved.is_relative_to(root) or not resolved.is_file():
+        raise InheritanceError(
+            f"{TEMPLATE_SYNC_IGNORE_PATH} must be a non-symlink file inside the repository root"
+        )
+    try:
+        if resolved.stat().st_size > MAX_CONTRACT_BYTES:
+            raise InheritanceError(f"{TEMPLATE_SYNC_IGNORE_PATH} exceeds {MAX_CONTRACT_BYTES} bytes")
+        lines = resolved.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as error:
+        raise InheritanceError(f"{TEMPLATE_SYNC_IGNORE_PATH} must contain valid UTF-8 text") from error
+
+    positive = []
+    exceptions = []
+    for line_number, line in enumerate(lines, start=1):
+        entry = line.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        destination = exceptions if entry.startswith(":!") else positive
+        root_entry = entry[2:] if destination is exceptions else entry
+        if root_entry.endswith("/**"):
+            root_entry = root_entry[:-2]
+        try:
+            destination.append(
+                _ownership_root(root_entry, f"{TEMPLATE_SYNC_IGNORE_PATH}:{line_number}")
+            )
+        except InheritanceError as error:
+            raise InheritanceError(
+                f"{TEMPLATE_SYNC_IGNORE_PATH}:{line_number} must be a literal path, "
+                "directory, directory/**, or :! exception"
+            ) from error
+    return positive, exceptions
+
+
+def _covers(outer, inner):
+    return outer == inner or (outer.endswith("/") and inner.startswith(outer))
+
+
+def _validate_template_sync_ignore(root, protected):
+    positive, exceptions = _read_template_sync_ignore(root)
+    required = sorted(set(protected) | REQUIRED_TEMPLATE_SYNC_IGNORES)
+    missing = sorted(
+        path for path in required if not any(_covers(entry, path) for entry in positive)
+    )
+    if missing:
+        raise InheritanceError(f"template sync ignore is missing protected paths: {missing}")
+    unsafe_exceptions = sorted(
+        exception
+        for exception in exceptions
+        if any(_overlaps(exception, protected_root) for protected_root in required)
+    )
+    if unsafe_exceptions:
+        raise InheritanceError(
+            f"template sync exception re-includes protected paths: {unsafe_exceptions}"
+        )
+    return {
+        "ignore_file": TEMPLATE_SYNC_IGNORE_PATH,
+        "required": required,
+    }
+
+
 def validate_inheritance(root):
     """Validate manifest, lock, and exclusive path ownership without external I/O."""
     try:
@@ -172,6 +242,8 @@ def validate_inheritance(root):
     if missing:
         raise InheritanceError(f"manifest is missing required protected paths: {missing}")
 
+    template_sync = _validate_template_sync_ignore(repository_root, protected)
+
     lock = _read_json(repository_root, lock_file)
     _object(lock, {"schema_version", "parent"}, "lock")
     if type(lock["schema_version"]) is not int or lock["schema_version"] != SCHEMA_VERSION:
@@ -189,6 +261,7 @@ def validate_inheritance(root):
         "parent": {"repository": parent_repository, "branch": parent_branch, "commit": commit},
         "lock_file": lock_file,
         "ownership": {"inherited": sorted(inherited), "protected": sorted(protected)},
+        "template_sync": template_sync,
     }
 
 

--- a/scripts/tests/test_foundation_docs_portability.py
+++ b/scripts/tests/test_foundation_docs_portability.py
@@ -20,6 +20,15 @@ class FoundationDocsPortabilityTest(unittest.TestCase):
         self.assertNotIn('if [ ! -f .github/inheritance/manifest.json ]; then', script)
         self.assertIn("Yukihide-Mitsuoka/ai-dev-foundation", script)
 
+    def test_child_doctor_validates_the_local_inheritance_contract(self):
+        script = TEMPLATE_CHECK.read_text(encoding="utf-8")
+
+        self.assertIn('if [ -f ".github/inheritance/manifest.json" ]; then', script)
+        self.assertIn(
+            "python3 scripts/template_inheritance.py validate --root .",
+            script,
+        )
+
     def test_optional_example_module_is_not_a_required_local_link(self):
         guide = AI_GUIDE.read_text(encoding="utf-8")
 

--- a/scripts/tests/test_template_inheritance.py
+++ b/scripts/tests/test_template_inheritance.py
@@ -45,11 +45,16 @@ class TemplateInheritanceTest(unittest.TestCase):
         self.inheritance_directory.mkdir(parents=True)
         self.manifest_path = self.inheritance_directory / "manifest.json"
         self.lock_path = self.inheritance_directory / "lock.json"
+        self.ignore_path = self.root / ".templatesyncignore"
         self.write_contract(valid_manifest(), valid_lock())
+        self.write_ignore(valid_manifest()["protected_paths"] + [".github/workflows/**"])
 
     def write_contract(self, manifest, lock):
         self.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
         self.lock_path.write_text(json.dumps(lock), encoding="utf-8")
+
+    def write_ignore(self, entries):
+        self.ignore_path.write_text("\n".join(entries) + "\n", encoding="utf-8")
 
     def assert_manifest_error(self, manifest):
         self.write_contract(manifest, valid_lock())
@@ -101,6 +106,38 @@ class TemplateInheritanceTest(unittest.TestCase):
             manifest["protected_paths"].remove(path)
             with self.subTest(path=path):
                 self.assert_manifest_error(manifest)
+
+    def test_every_protected_root_must_be_covered_by_template_sync_ignore(self):
+        self.write_ignore(
+            path for path in valid_manifest()["protected_paths"] if path != ".gitignore"
+        )
+
+        with self.assertRaisesRegex(
+            inheritance.InheritanceError,
+            r"template sync ignore.*\.gitignore",
+        ):
+            inheritance.validate_inheritance(self.root)
+
+    def test_template_sync_must_exclude_every_workflow(self):
+        self.write_ignore(valid_manifest()["protected_paths"])
+
+        with self.assertRaisesRegex(
+            inheritance.InheritanceError,
+            r"template sync ignore.*\.github/workflows/",
+        ):
+            inheritance.validate_inheritance(self.root)
+
+    def test_template_sync_exception_cannot_reinclude_a_protected_root(self):
+        self.write_ignore(
+            valid_manifest()["protected_paths"]
+            + [".github/workflows/**", ":!.github/workflows/security.yml"]
+        )
+
+        with self.assertRaisesRegex(
+            inheritance.InheritanceError,
+            r"template sync exception.*security.yml",
+        ):
+            inheritance.validate_inheritance(self.root)
 
     def test_lock_must_match_parent_and_pin_a_full_commit(self):
         for parent, commit in (("acme/other", COMMIT), (PARENT, "abc123"), (PARENT, "0" * 40)):

--- a/scripts/tests/test_template_inheritance_plan.py
+++ b/scripts/tests/test_template_inheritance_plan.py
@@ -102,6 +102,11 @@ class TemplateInheritancePlanTest(unittest.TestCase):
         lock = {"schema_version": 1, "parent": {"repository": PARENT_REPOSITORY, "commit": commit}}
         self.write(self.child, ".github/inheritance/manifest.json", json.dumps(manifest))
         self.write(self.child, ".github/inheritance/lock.json", json.dumps(lock))
+        self.write(
+            self.child,
+            ".templatesyncignore",
+            "\n".join(PROTECTED_PATHS + [".github/workflows/**"]) + "\n",
+        )
 
     def snapshot_child(self):
         return {

--- a/scripts/tests/test_template_sync_ignore.py
+++ b/scripts/tests/test_template_sync_ignore.py
@@ -4,21 +4,37 @@ from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).parents[2]
 IGNORE_FILE = REPOSITORY_ROOT / ".templatesyncignore"
+WORKFLOW_FILE = REPOSITORY_ROOT / ".github" / "workflows" / "template-sync.yml"
 
 
 class TemplateSyncIgnoreTest(unittest.TestCase):
-    def test_foundation_docs_use_git_pathspec_exclusions(self):
-        entries = {
+    def entries(self):
+        return {
             line.strip()
             for line in IGNORE_FILE.read_text(encoding="utf-8").splitlines()
             if line.strip() and not line.lstrip().startswith("#")
         }
+
+    def test_foundation_docs_use_git_pathspec_exclusions(self):
+        entries = self.entries()
 
         self.assertIn("docs/**", entries)
         self.assertIn(":!docs/foundation/", entries)
         self.assertIn(":!docs/foundation/**", entries)
         self.assertNotIn("!docs/foundation/", entries)
         self.assertNotIn("!docs/foundation/**", entries)
+
+    def test_legacy_sync_excludes_every_workflow(self):
+        self.assertIn(".github/workflows/**", self.entries())
+
+    def test_sync_pr_records_the_source_commit_used_by_the_action(self):
+        workflow = WORKFLOW_FILE.read_text(encoding="utf-8")
+
+        self.assertIn("id: template-sync", workflow)
+        self.assertIn("steps.template-sync.outputs.pr_branch", workflow)
+        self.assertIn('gh api "repos/${SOURCE_REPOSITORY}/commits/${SOURCE_SHORT}"', workflow)
+        self.assertIn("Unable to expand the Template Sync source commit", workflow)
+        self.assertIn("gh pr edit", workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_template_sync_workflow.py
+++ b/scripts/tests/test_template_sync_workflow.py
@@ -7,19 +7,14 @@ WORKFLOW = REPOSITORY_ROOT / ".github" / "workflows" / "template-sync.yml"
 
 
 class TemplateSyncWorkflowTest(unittest.TestCase):
-    def test_pull_request_body_contains_full_foundation_source_commit(self):
+    def test_pull_request_body_contains_exact_action_source_commit(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")
 
-        self.assertIn(
-            "git ls-remote https://github.com/Yukihide-Mitsuoka/ai-dev-foundation.git",
-            workflow,
-        )
-        self.assertIn(
-            'pr_body: "Foundation-source: '
-            'https://github.com/Yukihide-Mitsuoka/ai-dev-foundation@'
-            '${{ steps.foundation-source.outputs.sha }}"',
-            workflow,
-        )
+        self.assertIn("id: template-sync", workflow)
+        self.assertIn("steps.template-sync.outputs.pr_branch", workflow)
+        self.assertIn('SOURCE_REPOSITORY: "Yukihide-Mitsuoka/ai-dev-foundation"', workflow)
+        self.assertIn('gh api "repos/${SOURCE_REPOSITORY}/commits/${SOURCE_SHORT}"', workflow)
+        self.assertIn("gh pr edit", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

Adopts the complete ADR-0007 safety contract from direct parent `ai-dev-foundation` at `86eb9243a5ea1d1696588bceb1573afdfe182ce9`. Root cause: the previous workflow resolved the moving parent branch before Template Sync ran, so the SHA recorded in the PR could differ from the source commit actually consumed by the Action. The workflow now expands the Action-reported abbreviated SHA after synchronization, updates the PR provenance, and `make doctor` validates the real child manifest/ignore boundary.

Sibling search: the same pre-action `git ls-remote` pattern was checked in the other direct child and is being removed through the coordinated propagation work.

Refs: ai-dev-foundation #54 and #55, ADR-0007

## Change classification (ARC-020)

- [ ] Local (inside one module, contract unchanged)
- [x] Contract (synchronizes the accepted direct-parent inheritance contract)
- [ ] Architectural (ADR required — inherited ADR-0007 is already accepted)

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- Failing-first: commit `253de8d` made `make doctor` fail because the old workflow lacked Action-derived source provenance.
- How verified: `make setup`, `make format`, `make lint`, `make test`, `make build`, `make security-scan`, and `make doctor` passed. Application suite: 115/115; inherited governance suite: 81/81; sync boundary: 4/4; guard suite: 71/71; npm audit: 0 vulnerabilities.
- Not verified (GR-042): live scheduled or manually dispatched Template Sync run.

## Documentation (DOC-030)

- [x] Doc-update matrix checked; imported accepted ADR-0007 and the authoritative inheritance runbook from the exact parent lock.

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against `.ai/review-checklist.md` completed; no application data path, authentication, or tenant isolation code changed.
- [ ] Authored by human
- Prompts/context notes: coordinated repository-wide migration to reviewed, direct-parent-only Template Sync.

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff is an atomic contract migration; the apparent size is mechanical inherited docs, validator, and regression tests from the exact parent SHA
- [x] No guardrail violated (`.ai/guardrails.md`)
