### PR TITLE
fix(sync): keep PR body inside workflow script

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -72,8 +72,8 @@ jobs:
           fi
           body="Direct-parent-source: https://github.com/${SOURCE_REPOSITORY}@${SOURCE_COMMIT}
 
-Before merge:
-- Review the accepted lock-to-source commit range.
-- Port direct-parent workflow changes in a separate reviewed PR.
-- Update .github/inheritance/lock.json only after the complete parent delta is accepted."
+          Before merge:
+          - Review the accepted lock-to-source commit range.
+          - Port direct-parent workflow changes in a separate reviewed PR.
+          - Update .github/inheritance/lock.json only after the complete parent delta is accepted."
           gh pr edit "$PR_NUMBER" --body "$body"

--- a/scripts/tests/test_template_sync_workflow.py
+++ b/scripts/tests/test_template_sync_workflow.py
@@ -16,6 +16,17 @@ class TemplateSyncWorkflowTest(unittest.TestCase):
         self.assertIn('gh api "repos/${SOURCE_REPOSITORY}/commits/${SOURCE_SHORT}"', workflow)
         self.assertIn("gh pr edit", workflow)
 
+    def test_pull_request_body_stays_inside_the_run_block(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertNotIn("\nBefore merge:\n", workflow)
+        self.assertIn("\n          Before merge:\n", workflow)
+        self.assertIn(
+            "\n          - Update .github/inheritance/lock.json only after the complete "
+            "parent delta is accepted.",
+            workflow,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What & why

Template Sync could not be dispatched because the final text in the `run: |` block was outside the script indentation. Indent the PR body consistently and add a failing-first regression test for the workflow boundary.

Closes #75

## Change classification (ARC-020)

- [x] Local (inside one module, contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- Failing-first regression commit: `563d2d5`
- How verified: `make format`, `make lint`, `make doctor`, `make test`, `make build`, and `make security-scan` pass locally.
- Not verified (GR-042): CI-hosted scanners unavailable locally; CI remains authoritative.

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: n/a — workflow syntax defect only

## AI disclosure

- [x] Authored by AI agent: OpenAI Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)