### PR TITLE
fix(security): configure CodeQL language matrix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,10 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TEMPLATE: set your language(s): javascript-typescript, python, go, java-kotlin,
-        # csharp, cpp, ruby, swift. Empty matrix = workflow skipped until configured.
-        language: []
-        # language: [javascript-typescript]
+        language: [javascript-typescript, python]
     steps:
       - uses: actions/checkout@v6
       - uses: github/codeql-action/init@v3

--- a/scripts/tests/test_codeql_workflow.py
+++ b/scripts/tests/test_codeql_workflow.py
@@ -1,0 +1,17 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class CodeQLWorkflowTest(unittest.TestCase):
+    def test_all_executable_source_languages_are_analyzed(self) -> None:
+        workflow = (ROOT / ".github/workflows/codeql.yml").read_text()
+
+        self.assertIn("language: [javascript-typescript, python]", workflow)
+        self.assertNotIn("language: []", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

The protected CodeQL workflow did not analyze every executable source language in this repository. Configure the matrix for JavaScript/TypeScript and Python and add a regression test that rejects an empty or incomplete matrix; this change is repository-local because Template Sync excludes protected workflows.

Closes #77

## Change classification (ARC-020)

- [x] Local (inside one module, contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- Failing-first regression commit: `273b841`
- How verified: `make format`, `make lint`, `make doctor`, and `make test` pass locally.
- Not verified (GR-042): the GitHub-hosted CodeQL analysis itself runs in CI after review.

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: n/a — protected workflow configuration only

## AI disclosure

- [x] Authored by AI agent: OpenAI Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)