### PR TITLE
ci(security): pin workflow dependencies by commit SHA

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -24,12 +24,12 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
       # TEMPLATE: verify inputs against the installed version of the action —
       # https://github.com/anthropics/claude-code-action
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: npm
@@ -29,15 +29,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: npm
       - run: make setup
       - run: make coverage
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage
           path: coverage/
@@ -46,8 +46,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: npm
@@ -60,7 +60,7 @@ jobs:
     # the no-op template Makefile can't. Dependency-free (pure bash).
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - run: make doctor
 
   link-check:
@@ -68,9 +68,9 @@ jobs:
     # Offline mode: verify local file links resolve; external URLs are not fetched.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Check links (offline)
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: "--offline --no-progress ."
           fail: true
@@ -83,7 +83,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Validate PR title (Conventional Commits)
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: PR size guard (GR-020)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,12 +24,12 @@ jobs:
       matrix:
         language: [javascript-typescript, python]
     steps:
-      - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/autobuild@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+      - uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -20,7 +20,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Detect Dockerfile
         id: detect
         # The workflow can be triggered by editing this file itself; only actually
@@ -37,7 +37,7 @@ jobs:
         run: docker build -t local/scan-target:${{ github.sha }} .
       - name: Trivy image scan
         if: steps.detect.outputs.found == 'true'
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: local/scan-target:${{ github.sha }}
           severity: HIGH,CRITICAL
@@ -45,6 +45,6 @@ jobs:
           ignore-unfixed: true
       - name: Dockerfile best practices (hadolint)
         if: steps.detect.outputs.found == 'true'
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: Dockerfile

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -22,7 +22,7 @@ jobs:
     if: vars.DAST_TARGET_URL != '' || inputs.target != ''
     steps:
       - name: ZAP baseline scan
-        uses: zaproxy/action-baseline@v0.15.0
+        uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:
           target: ${{ inputs.target || vars.DAST_TARGET_URL }}
           allow_issue_writing: true

--- a/.github/workflows/iac.yml
+++ b/.github/workflows/iac.yml
@@ -25,7 +25,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Detect IaC
         id: detect
         # The workflow can be triggered by editing this file itself; only scan when real
@@ -41,14 +41,14 @@ jobs:
           fi
       - name: Trivy config scan
         if: steps.detect.outputs.found == 'true'
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: config
           severity: MEDIUM,HIGH,CRITICAL
           exit-code: "1"
       - name: Checkov (second opinion — defense in depth)
         if: steps.detect.outputs.found == 'true'
-        uses: bridgecrewio/checkov-action@v12.1347.0
+        uses: bridgecrewio/checkov-action@99bb2caf247dfd9f03cf984373bc6043d4e32ebf # v12.1347.0
         with:
           soft_fail: false
           quiet: true

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -17,8 +17,8 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: crazy-max/ghaction-github-labeler@v5
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: crazy-max/ghaction-github-labeler@24d110aa46a59976b8a7f35518cb7f14f434c916 # v5
         with:
           yaml-file: .github/labels.yml
           skip-delete: true   # never mass-delete labels automatically (GR-031 spirit)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: rp
         with:
           # TEMPLATE: set release-type (node, python, go, rust, simple, ...)
@@ -35,14 +35,14 @@ jobs:
       id-token: write      # SLSA provenance signing
       attestations: write  # SLSA provenance storage
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
       - run: make setup
       - name: Full test suite (gate)
         run: make test
       - name: Vulnerability gate
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scanners: vuln
@@ -50,7 +50,7 @@ jobs:
           exit-code: "1"
           ignore-unfixed: true
       - name: Generate SBOM (SPDX + CycloneDX)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           format: spdx-json
           output-file: sbom.spdx.json
@@ -60,7 +60,7 @@ jobs:
         run: make build
       - name: Attest build provenance (SLSA — SEC-031)
         if: hashFiles('dist/**') != ''
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: "dist/**"
       # TEMPLATE: add artifact publishing (registry push, package publish) here;

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,14 +16,14 @@ jobs:
       security-events: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v2.4.3
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,11 +20,11 @@ jobs:
       # that endpoint 403s without this (public repos never notice).
       pull-requests: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0   # full history — leaked-then-deleted secrets still count (GR-001)
       - name: gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Org use requires GITLEAKS_LICENSE (free for individuals/OSS):
@@ -33,9 +33,9 @@ jobs:
   dependency-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Trivy — vulnerabilities & misconfig (fail on HIGH/CRITICAL)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scanners: vuln,misconfig
@@ -46,9 +46,9 @@ jobs:
   license-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Trivy — license policy (REL-030)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scanners: license

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -25,8 +25,8 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: AndreasAugustin/actions-template-sync@v2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: AndreasAugustin/actions-template-sync@8a0f668b83c32a0f673353086d74f12b8853d4f5 # v2
         id: template-sync
         with:
           # This repository syncs only from its direct parent. A repository created from

--- a/scripts/tests/test_workflow_dependency_pins.py
+++ b/scripts/tests/test_workflow_dependency_pins.py
@@ -1,0 +1,30 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SHA = re.compile(r"[0-9a-f]{40}")
+USES = re.compile(r"\buses:\s*([^\s#]+)")
+
+
+class WorkflowDependencyPinsTest(unittest.TestCase):
+    def test_external_workflow_dependencies_use_commit_shas(self) -> None:
+        unpinned: list[str] = []
+        for workflow in sorted((ROOT / ".github/workflows").glob("*.y*ml")):
+            for line_number, line in enumerate(workflow.read_text().splitlines(), 1):
+                match = USES.search(line)
+                if not match:
+                    continue
+                target = match.group(1)
+                if target.startswith(("./", "docker://")):
+                    continue
+                reference = target.rsplit("@", 1)[-1]
+                if not SHA.fullmatch(reference):
+                    unpinned.append(f"{workflow.relative_to(ROOT)}:{line_number}: {target}")
+
+        self.assertEqual([], unpinned, "unpinned workflow dependencies:\n" + "\n".join(unpinned))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What & why

External actions and reusable workflows used mutable tag references even though SEC-031 and Renovate require digest pinning. Resolve each existing tag through the GitHub API, replace it with the currently referenced 40-character commit SHA, retain the tag as a readable update hint, and enforce the property with a repository-local contract test.

This is a mechanical protected-workflow hardening change: permissions, triggers, inputs, and intended action versions are unchanged. The 12–14-file size exceeds the GR-020 file-count guideline only because the same one-line pinning rule is applied across every workflow.

Closes #80

## Change classification (ARC-020)

- [x] Local (protected CI configuration; application contracts unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- Failing-first regression commit: `ebef3c6`
- How verified: `make setup`, `make format`, `make lint`, `make doctor` (86 tests), `make test`, `make build`, and `make security-scan` pass locally; npm reports 0 vulnerabilities.
- Not verified (GR-042): CI-hosted gitleaks and Trivy are unavailable locally; CI remains authoritative.

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: n/a — implements existing SEC-031 and Renovate policy without changing operation

## AI disclosure

- [x] Authored by AI agent: OpenAI Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] Canonical format, lint, and tests are green as reported above
- [x] Mechanical diff contains no permissions, triggers, inputs, or unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)