### PR TITLE
feat(build): container image for the two Node services (ADR-0012 T2)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Keep the build context small and free of anything secret (GR-001).
+.git
+.github
+node_modules
+coverage
+dist
+docs
+spikes
+tests
+infra
+profiles
+.claude
+.devcontainer
+.env
+.env.*
+!.env.example
+*.md

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,20 @@
+# What `gcloud builds submit` uploads. Mirrors .dockerignore — most importantly
+# it keeps .env and .git out of the build context (GR-001).
+#
+# `gcloud` would otherwise default to honouring .gitignore, which does NOT
+# exclude everything we want kept out of an upload.
+.git
+.github
+node_modules
+coverage
+dist
+docs
+spikes
+tests
+infra
+profiles
+.claude
+.devcontainer
+.env
+.env.*
+!.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# One image, two services (ADR-0012 T2). The Cloud Run service overrides the
+# command to pick control-plane or executor, so both always run identical code.
+#
+# No build step: Node >= 24 strips TypeScript types natively, which is why the
+# test suite already runs .ts directly. Keeping the image source-only avoids a
+# bundler dependency and keeps what runs in production identical to what CI ran.
+
+# --- build stage: the only place npm is needed -------------------------------
+FROM node:24-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --no-fund --no-audit
+
+# --- runtime stage -----------------------------------------------------------
+FROM node:24-slim
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+# npm is a BUILD tool; shipping it puts its bundled dependency tree (tar,
+# brace-expansion, undici — none of them ours) into the production attack
+# surface, where the image scanner reports their CVEs and we can do nothing
+# about them. Nothing at runtime invokes npm, so remove it.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY src ./src
+
+# Never run as root; Cloud Run does not require it and least privilege applies
+# to the container user too.
+USER node
+
+# Both services expose GET /health. Probed with node itself rather than curl or
+# wget: adding either would put back attack surface we just removed with npm.
+# Cloud Run ignores this and uses the probes declared on the service instead
+# (see infra/terraform/services.tf) — this covers plain `docker run`.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD ["node", "-e", "fetch('http://127.0.0.1:'+(process.env.PORT||8788)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+
+# Cloud Run injects PORT; env.ts reads it and falls back per service.
+# Overridden per service in Terraform — this default is only for a bare
+# `docker run` and points at the control plane.
+CMD ["node", "src/main/control-plane-server.ts"]


### PR DESCRIPTION
## What

ADR-0012 実装の**1/2**。元PR #107 が **GR-020 のハード上限（800行/20ファイル）を9行超過**したため分割しました。こちらはコンテナ化のみ（3ファイル・80行）。

## 中身

- **1イメージ2サービス**（T2）。Cloud Run側でコマンドを差し替えるので、control-plane と executor は常に同一コード
- **ビルド工程なし** — Node 24 がネイティブに型を剥がすため（テストが既に `.ts` を直接実行しているのと同じ理由）。バンドラ依存を持たず、**CIが試したものと本番が同一**になります
- **マルチステージで npm を実行時イメージから除去**

## npm を消した理由（実測ベース）

Trivy が HIGH×4・CRITICAL×1 を検出しました：`tar` / `brace-expansion` / `undici`。**いずれも自社依存ではありません**（`npm ls --omit=dev` の本番ツリーは `google-auth-library` / `node-sql-parser` / `postgres` のみ）。`node:24-slim` に同梱される **npm のバンドル依存**です。

npm は**ビルド用**で実行時には誰も呼ばないので、runtime ステージから削除しました。抑制ではなく**攻撃面そのものの除去**です。→ Trivy **pass**。

## HEALTHCHECK

Checkov の CKV_DOCKER_2 に対し、`/health` は既にあるので**実体を追加**。ただし `curl`/`wget` を入れると**いま削ったばかりの攻撃面が戻る**ので、既にある `node` で実装しています。

（Cloud Run はイメージの HEALTHCHECK を見ないため、本番で実際に効くプローブは Terraform 側で宣言します＝分割後のもう一方のPR。こちらは `docker run` 用です）

## Verification

CI の Trivy / Checkov がこのイメージを実ビルドして検証します。ローカルの Docker デーモンが停止中のため、ビルド検証はCIに委ねています。

## AI disclosure

Written by Claude (Opus 4.8)。CVEの帰属は `npm ls --omit=dev` で実際に確認しました（推測ではありません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
