### PR TITLE
test: drive the deployed gate end to end with real signed tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.pem
 *.key
 secrets/
+# Signing key minted by the live-e2e spike. Public half goes in VENDOR_KEYS;
+# this is the private half and stays local.
+spikes/live-e2e/.vendor-key.json
 
 # Terraform local state & plugins — state lives in GCS (ADR-0012 T6), but a
 # stray local run must never commit state: it can contain resource metadata.

--- a/spikes/live-e2e/README.md
+++ b/spikes/live-e2e/README.md
@@ -1,0 +1,104 @@
+---
+id: spike-live-e2e
+title: Live end-to-end — deployed gate through to BigQuery
+updated: 2026-07-26
+---
+
+# Spike: live end-to-end
+
+Drives the **deployed** gate over real HTTP with real signed tokens. Nothing is
+stubbed: Cloudflare Workers → Cloud Run → Neon (and BigQuery on the ② path).
+
+This is the live counterpart to two earlier results that were both measured in
+process: the vertical slice (LOG-0031, 12/12) and the fixture-backed slice
+(LOG-0035, 8/8). Passing here means the same guarantees hold across real
+network boundaries, real RLS, and real IAM.
+
+## What it asserts
+
+| # | Assertion | What it proves |
+|---|---|---|
+| 1 | alpha gets the report shell | JWT verification, the gate→control-plane HTTP transport, authz resolved out of Postgres under RLS |
+| 2 | shell served again | ① cache path |
+| 3 | ungranted report refused | the report allow-list (原則E②) |
+| 4 | no token refused | — |
+| 5 | wrong `aud` refused | audience binding |
+| 6 | expired token refused | `exp` enforcement |
+| 7 | unknown tenant refused | the principal must exist in the control plane |
+| 8 | alpha gets query results | ② path: executor → BigQuery via D1 impersonation |
+| 9 | second request is a cache hit | ② result cache |
+| 10 | **bravo never receives alpha rows** | no cross-tenant leak on the live wire |
+
+## Prerequisites
+
+- GCP and Cloudflare deployed (`make deploy`, `npx wrangler deploy`).
+- `.env` holds `DATABASE_URL`; `GOOGLE_CLOUD_PROJECT` is exported.
+- The LOG-0052 fixtures exist: datasets `t_alpha` / `t_bravo` with an `orders`
+  table, and service accounts `t-alpha-reader` / `t-bravo-reader`.
+
+### Extra prerequisites for the ② data path only
+
+Assertions 1–7 pass without these; 8–10 need them.
+
+**a. The executor must be allowed to impersonate the tenant service accounts.**
+LOG-0052 granted `tokenCreator` to the owner's own account, which is right for
+a local spike and wrong for a deployed service. Point it at the running
+identity instead:
+
+```bash
+for T in alpha bravo; do
+  gcloud iam service-accounts add-iam-policy-binding \
+    "t-${T}-reader@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
+    --project="$GOOGLE_CLOUD_PROJECT" \
+    --member="serviceAccount:executor-run@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com" \
+    --role="roles/iam.serviceAccountTokenCreator"
+done
+```
+
+> These are test fixtures, deliberately kept out of Terraform's `tenants`
+> (ADR-0012). A real tenant gets this binding from Terraform.
+
+**b. The executor needs a table allowlist.** It ships fail-closed
+(`{"tables":[]}` refuses everything, LOG-0039), so allow the fixture table:
+
+```bash
+make deploy QUERY_POLICY='{"tables":[{"name":"orders","scopeColumn":"store_id"}]}'
+```
+
+## Run
+
+```bash
+node spikes/live-e2e/setup.mjs
+```
+
+Seeds two demo tenants and prints a `VENDOR_KEYS` line. Put it in
+`wrangler.toml` under `[vars]` and redeploy — it is a **public** key, so
+committing it is fine (GR-001 permits public keys; `vendor_keys` stores only
+public keys for the same reason). The matching private key is written to a
+gitignored file and never leaves the machine.
+
+```bash
+npx wrangler deploy
+GATE_URL=https://gate.<subdomain>.workers.dev node spikes/live-e2e/verify.mjs
+```
+
+## Teardown
+
+```bash
+node spikes/live-e2e/setup.mjs --teardown
+```
+
+Removes the demo tenants and deletes the local private key. The GCP fixtures
+and the deployed services are left alone — `make destroy ALLOW_DESTROY=yes`
+handles those.
+
+## Notes
+
+- The demo tenants use fixed UUIDs so re-running is idempotent, and teardown
+  deletes exactly what was seeded rather than guessing.
+- Seeding connects as the database **owner** on purpose: RLS stops
+  `app_runtime` writing tenant rows, which is the behaviour proven in LOG-0032,
+  not an obstacle to work around.
+- Assertion 10 is the one that matters most. Same URL, same query id, different
+  tenant token — if the caches or the boundary were wrong anywhere along the
+  chain, this is where it would show.

--- a/spikes/live-e2e/setup.mjs
+++ b/spikes/live-e2e/setup.mjs
@@ -1,0 +1,133 @@
+// Phase 1 of the live end-to-end check: mint a vendor key pair and seed two
+// demo tenants into the real control plane.
+//
+// Two phases are unavoidable: the gate can only verify a JWT once its public
+// key is deployed in VENDOR_KEYS, so this prints the key for you to install
+// before verify.mjs can sign anything.
+//
+//   node spikes/live-e2e/setup.mjs            # generate + seed
+//   node spikes/live-e2e/setup.mjs --teardown # remove the seeded rows
+//
+// The PRIVATE key is written to a gitignored file next to this script. It only
+// signs test tokens for these demo tenants, but it is still a signing key, so
+// it never enters the repository (GR-001).
+import { readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postgres from 'postgres';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const KEY_FILE = join(HERE, '.vendor-key.json');
+
+// Fixed ids so re-running is idempotent and teardown is exact.
+export const ALPHA = 'e2e0a1pha-0000-4000-8000-000000000001';
+export const BRAVO = 'e2e0b4a0-0000-4000-8000-000000000002';
+export const KID = 'e2e-vendor';
+export const SUBJECT = 'e2e-user';
+
+for (const line of (() => {
+  try {
+    return readFileSync(join(HERE, '..', '..', '.env'), 'utf8').split('\n');
+  } catch {
+    return [];
+  }
+})()) {
+  const m = line.match(/^([A-Z][A-Z0-9_]*)=(.*)$/);
+  if (m && process.env[m[1]] === undefined) process.env[m[1]] = m[2];
+}
+
+const databaseUrl = process.env['DATABASE_URL'];
+if (!databaseUrl) {
+  console.error('DATABASE_URL is not set (put it in .env)');
+  process.exit(2);
+}
+// Seeding is an owner operation: RLS deliberately stops app_runtime writing
+// tenant rows, so the migration/ownership credential is the right one here.
+const owner = postgres(databaseUrl.replace('-pooler.', '.'), { max: 1, onnotice: () => {} });
+
+/** Children first — the composite FKs refuse a tenant delete otherwise. */
+async function cleanup() {
+  for (const t of [
+    'audit_logs',
+    'revocation_events',
+    'report_queries',
+    'role_reports',
+    'user_roles',
+    'datasources',
+    'reports',
+    'roles',
+    'users',
+  ]) {
+    await owner.unsafe(`delete from ${t} where tenant_id in ($1, $2)`, [ALPHA, BRAVO]);
+  }
+  await owner`delete from tenants where id in (${ALPHA}, ${BRAVO})`;
+  await owner`delete from vendors where name = 'e2e-live'`;
+}
+
+async function seed() {
+  await cleanup();
+  const [v] = await owner`insert into vendors (name) values ('e2e-live') returning id`;
+
+  // Each tenant sees ONLY its own dataset, and only its own store. Bravo exists
+  // purely so the cross-tenant assertions in verify.mjs have something to fail
+  // against.
+  for (const [id, slug, store] of [
+    [ALPHA, 'alpha', 's1'],
+    [BRAVO, 'bravo', 's9'],
+  ]) {
+    await owner`insert into tenants (id, vendor_id, name, auth_epoch)
+                values (${id}, ${v.id}, ${`e2e-${slug}`}, 0)`;
+    const [u] = await owner`insert into users (tenant_id, external_subject, auth_epoch)
+                            values (${id}, ${SUBJECT}, 0) returning id`;
+    const [r] = await owner`insert into roles (tenant_id, name, data_scope)
+                            values (${id}, 'manager', ${owner.json({ store_ids: [store] })})
+                            returning id`;
+    await owner`insert into user_roles (tenant_id, user_id, role_id) values (${id}, ${u.id}, ${r.id})`;
+    const [rep] = await owner`insert into reports (tenant_id, slug, title, definition_ref, report_version)
+                              values (${id}, 'r_e2e', 'E2E', 'ref', 1) returning id`;
+    await owner`insert into role_reports (tenant_id, role_id, report_id) values (${id}, ${r.id}, ${rep.id})`;
+    await owner`insert into report_queries (tenant_id, report_id, query_id, sql_text)
+                values (${id}, ${rep.id}, 'q_e2e', 'SELECT category, SUM(amount) AS total FROM orders GROUP BY category')`;
+    // Points at the LOG-0052 fixtures: dataset t_alpha / t_bravo, read as the
+    // per-tenant service account (the D1 connection principal).
+    await owner`insert into datasources (tenant_id, type, dataset, project_id, connection_ref, data_version, status)
+                values (${id}, 'bigquery', ${`t_${slug}`}, ${process.env['GOOGLE_CLOUD_PROJECT'] ?? 'unset'},
+                        ${`t-${slug}-reader@${process.env['GOOGLE_CLOUD_PROJECT'] ?? 'unset'}.iam.gserviceaccount.com`},
+                        1, 'active')`;
+  }
+}
+
+async function makeVendorKey() {
+  const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ]);
+  const publicJwk = await crypto.subtle.exportKey('jwk', pair.publicKey);
+  const privateJwk = await crypto.subtle.exportKey('jwk', pair.privateKey);
+  writeFileSync(KEY_FILE, JSON.stringify({ kid: KID, publicJwk, privateJwk }), { mode: 0o600 });
+  return publicJwk;
+}
+
+async function main() {
+  if (process.argv.includes('--teardown')) {
+    await cleanup();
+    if (existsSync(KEY_FILE)) rmSync(KEY_FILE);
+    console.log('torn down: demo tenants removed, vendor key deleted');
+    return;
+  }
+
+  await seed();
+  const publicJwk = await makeVendorKey();
+  console.log('seeded: 2 demo tenants (e2e-alpha, e2e-bravo)\n');
+  console.log('Set this as VENDOR_KEYS in wrangler.toml [vars], then `npx wrangler deploy`.');
+  console.log('It is a PUBLIC key — safe to commit (GR-001 allows public keys):\n');
+  console.log(`VENDOR_KEYS = '${JSON.stringify({ [KID]: publicJwk })}'\n`);
+  console.log('Then: node spikes/live-e2e/verify.mjs');
+}
+
+main()
+  .catch((e) => {
+    console.error('setup failed:', e instanceof Error ? e.message : String(e));
+    process.exitCode = 1;
+  })
+  .finally(() => owner.end());

--- a/spikes/live-e2e/verify.mjs
+++ b/spikes/live-e2e/verify.mjs
@@ -1,0 +1,131 @@
+// Phase 2: drive the DEPLOYED gate over real HTTP with real signed tokens.
+//
+// Everything here crosses the actual wire — Cloudflare Workers -> Cloud Run ->
+// Neon (and BigQuery for the data path). Nothing is stubbed. This is the live
+// counterpart to the in-process vertical slice (LOG-0031) and the fixture-based
+// slice (LOG-0035).
+//
+//   GATE_URL=https://gate.example.workers.dev node spikes/live-e2e/verify.mjs
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ALPHA, BRAVO, KID, SUBJECT } from './setup.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GATE = (process.env['GATE_URL'] ?? '').replace(/\/$/, '');
+if (!GATE) {
+  console.error('GATE_URL is not set, e.g. https://gate.<subdomain>.workers.dev');
+  process.exit(2);
+}
+
+const { privateJwk } = JSON.parse(readFileSync(join(HERE, '.vendor-key.json'), 'utf8'));
+const signingKey = await crypto.subtle.importKey(
+  'jwk',
+  privateJwk,
+  { name: 'ECDSA', namedCurve: 'P-256' },
+  false,
+  ['sign'],
+);
+
+const b64url = (bytes) =>
+  btoa(String.fromCharCode(...bytes))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '');
+const jsonB64 = (o) => b64url(new TextEncoder().encode(JSON.stringify(o)));
+
+/** Sign a token the way the vendor's backend would (ADR-0005 §7). */
+async function mint(tenantId, over = {}) {
+  const payload = {
+    sub: SUBJECT,
+    tenant_id: tenantId,
+    sid: `sess-${tenantId.slice(0, 8)}`,
+    aud: 'gate',
+    epoch: 0,
+    exp: Math.floor(Date.now() / 1000) + 300,
+    ...over,
+  };
+  const input = `${jsonB64({ alg: 'ES256', typ: 'JWT', kid: KID })}.${jsonB64(payload)}`;
+  const sig = await crypto.subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    signingKey,
+    new TextEncoder().encode(input),
+  );
+  return `${input}.${b64url(new Uint8Array(sig))}`;
+}
+
+const get = async (path, token) => {
+  const res = await fetch(`${GATE}${path}`, {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
+  const body = await res.text();
+  return { status: res.status, body };
+};
+
+let pass = 0;
+let fail = 0;
+const check = (label, ok, extra = '') => {
+  ok ? pass++ : fail++;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}${extra ? `  ${extra}` : ''}`);
+};
+
+const alphaToken = await mint(ALPHA);
+const bravoToken = await mint(BRAVO);
+
+// --- ① shell: proves JWT verification, the control-plane HTTP transport, and
+//     authz resolution out of Postgres under RLS.
+const shell = await get('/r/r_e2e', alphaToken);
+check('alpha gets the report shell', shell.status === 200, `[${shell.status}] ${shell.body.slice(0, 60)}`);
+
+const shell2 = await get('/r/r_e2e', alphaToken);
+check('shell is served again (① cache path)', shell2.status === 200, `[${shell2.status}]`);
+
+// --- authorization denials
+const forbidden = await get('/r/r_not_granted', alphaToken);
+check('a report the role does not grant is refused', forbidden.status === 403 || forbidden.status === 404,
+  `[${forbidden.status}]`);
+
+const noToken = await get('/r/r_e2e');
+check('no token is refused', noToken.status === 401, `[${noToken.status}]`);
+
+const wrongAud = await get('/r/r_e2e', await mint(ALPHA, { aud: 'not-gate' }));
+check('a token for another audience is refused', wrongAud.status === 401, `[${wrongAud.status}]`);
+
+const expired = await get('/r/r_e2e', await mint(ALPHA, { exp: Math.floor(Date.now() / 1000) - 60 }));
+check('an expired token is refused', expired.status === 401, `[${expired.status}]`);
+
+// A token whose tenant claim does not match a real tenant must not resolve.
+const ghost = await get('/r/r_e2e', await mint('00000000-0000-4000-8000-0000000000ff'));
+check('an unknown tenant is refused', ghost.status === 401, `[${ghost.status}]`);
+
+// --- ② data: adds the executor and BigQuery to the path.
+const data = await get('/r/r_e2e/data/q_e2e', alphaToken);
+const dataOk = data.status === 200;
+check('alpha gets query results (② path: executor -> BigQuery)', dataOk,
+  `[${data.status}] ${data.body.slice(0, 120)}`);
+
+if (dataOk) {
+  const second = await get('/r/r_e2e/data/q_e2e', alphaToken);
+  const cached = (() => {
+    try {
+      return JSON.parse(second.body).cached === true;
+    } catch {
+      return false;
+    }
+  })();
+  check('the second identical request is a ② cache hit', cached, `[${second.status}]`);
+
+  // The load-bearing one: same URL, same query, different tenant token.
+  const bravoData = await get('/r/r_e2e/data/q_e2e', bravoToken);
+  const differs = bravoData.status !== 200 || bravoData.body !== data.body;
+  check('bravo never receives alpha rows (no cross-tenant leak)', differs,
+    `[${bravoData.status}] ${bravoData.body.slice(0, 80)}`);
+} else {
+  console.log('\n  ② skipped its follow-ups: the data path did not return 200.');
+  console.log('  Usual causes — QUERY_POLICY is still {"tables":[]} (fail-closed by design),');
+  console.log('  or executor-run lacks tokenCreator on the tenant service accounts.');
+  console.log('  See spikes/live-e2e/README.md.');
+}
+
+console.log(`\nresult: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## What & why

デプロイ済みの全構成を**実HTTP・実JWTで貫通**させる検証スパイクです。スタブは一切なし：**Cloudflare Workers → Cloud Run → Neon**（②経路では BigQuery まで）。

LOG-0031（インプロセス 12/12）と LOG-0035（fixture 8/8）の**実インフラ版**にあたります。同じ保証が実ネットワーク境界・実RLS・実IAMをまたいでも成立するかを見ます。

Refs: LOG-0058

## 10項目の検証

| # | 検証 | 何を証明するか |
|---|---|---|
| 1 | alphaがシェルを取得 | JWT検証・gate→control-planeのHTTPトランスポート・**RLS下のPostgresから認可解決** |
| 2 | シェル再取得 | ①キャッシュ経路 |
| 3 | 未許可レポートを拒否 | レポート許可リスト（原則E②） |
| 4-7 | トークン無し／`aud`違い／期限切れ／不明テナント を拒否 | 認証の各判定 |
| 8 | alphaがクエリ結果を取得 | ②経路：executor → **D1なりすまし** → BigQuery |
| 9 | 2回目はキャッシュヒット | ②結果キャッシュ |
| 10 | **bravoにalphaの行が渡らない** | **実ネットワーク上で越境ゼロ** |

10番が本命です。同じURL・同じqueryId・別テナントのトークン — 経路のどこかでキャッシュか境界が壊れていれば、ここに出ます。

## 2フェーズな理由

gateは**公開鍵がデプロイされるまでJWTを検証できない**ので、鍵生成→デプロイ→検証の順が避けられません。`setup.mjs` がデモテナントを投入し `VENDOR_KEYS` 行を出力します（**公開鍵**なのでコミット可。秘密鍵側はgitignoreされたファイルに書き、リポジトリには入りません — GR-001）。

固定UUIDにしてあるので**再実行は冪等**、teardownは**投入したものだけを正確に削除**します。

シードは**DBオーナーで接続**します — RLSが `app_runtime` のテナント行書き込みを止めるのは LOG-0032 で実証した正しい挙動であって、回避すべき障害ではないためです。

## ②経路だけ追加の前提が要ります

1〜7 はデプロイ済みなら通ります。8〜10 には：

- **`executor-run` に tokenCreator** — LOG-0052 ではオーナー個人アカウントに付けました。ローカルスパイクとしては正しく、**デプロイされたサービスとしては誤り**なので付け替えが要ります
- **`QUERY_POLICY`** — executorは全テーブル拒否で出荷される（fail-closed、LOG-0039）

READMEに両方のコマンドを載せ、`verify.mjs` はデータ経路が200でないとき**この2つを名指しします**（ただ落ちるのではなく）。

## Change classification (ARC-020)

- [x] Local — `spikes/` 配下の新規追加のみ。`src/` に変更なし、公開契約の変更なし
- [ ] Contract
- [ ] Architectural

## Breaking change?

- [x] No
- [ ] Yes

## Testing (GR-021 / TST-002)

本PRは検証ハーネスそのもので、プロダクトコードの挙動を変えません（`src/` 無変更）。したがって GR-021 の「挙動変更にはテスト」は追加テストではなくこのハーネス自体で満たされます。

- How verified: `node --check` を両スクリプトで通過、`make lint` exit 0、`git check-ignore spikes/live-e2e/.vendor-key.json` で秘密鍵パスの除外を確認
- Not verified (GR-042): **ハーネス自体はまだ実走していません**。実行にはNeonへの書き込みとGCP操作が伴い、オーナーの資格情報が要るためです。10項目の結果は本PRでは主張しません

## Dependencies (GR-023 / COD-040)

追加・メジャー更新なし（`postgres` は既存スパイクと同じ依存を再利用）。

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: `spikes/live-e2e/README.md`（前提条件・実行手順・teardown を含む）

## AI disclosure

- [x] Authored by AI agent: Claude Opus 5 — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes: シード内容は既存の `spikes/control-plane-neon` の実績あるパターンに合わせています。

## Self-review checklist (WF-090)

- [x] `make lint` green — 上記に記載（`make test` は `src/` 無変更のため差分なし）
- [x] Diff within size limits (GR-020) — 371 lines / 4 files、無関係な変更なし
- [x] No guardrail violated — 秘密鍵はgitignore、公開鍵のみ配布（GR-001）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
