### PR TITLE
fix(executor): give the impersonation source cloud-platform scope

### DIFF
--- a/src/main/executor-server.ts
+++ b/src/main/executor-server.ts
@@ -64,7 +64,19 @@ async function main(): Promise<void> {
   });
   const bindings = new PgBindingResolver(db, policyFromEnv());
   const runner = new BigQueryRunner({
-    tokens: new ImpersonatingTokenProvider({ source: new AdcTokenProvider() }),
+    // The SOURCE identity needs cloud-platform, not bigquery: its only job is
+    // to call IAM Credentials generateAccessToken, and on Cloud Run the
+    // metadata server issues a token limited to exactly the scopes asked for.
+    // A bigquery-scoped source token is refused by IAM with 403 however
+    // correct the tokenCreator grant is (LOG-0059). The token this mints for
+    // the tenant is still bigquery-only — ImpersonatingTokenProvider sets that
+    // in the request body, so the impersonated principal gains nothing wider.
+    //
+    // Local ADC is a user credential carrying cloud-platform already, which is
+    // why LOG-0052's backstop passed on a laptop and failed once deployed.
+    tokens: new ImpersonatingTokenProvider({
+      source: new AdcTokenProvider(['https://www.googleapis.com/auth/cloud-platform']),
+    }),
   });
   const execute = new ExecuteQuery({ bindings, runner, audit: new PgAuditSink(db) });
   const handler = createExecutorHandler({

--- a/src/modules/executor/infrastructure/bigquery.ts
+++ b/src/modules/executor/infrastructure/bigquery.ts
@@ -107,7 +107,8 @@ export class BigQueryRunner implements QueryRunner {
 
   constructor(options: BigQueryRunnerOptions) {
     this.#o = options;
-    this.#fetch = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    // Bound — see impersonation.ts and LOG-0059.
+    this.#fetch = options.fetchImpl ?? (globalThis.fetch.bind(globalThis) as unknown as FetchLike);
     this.#maxRows = options.maxRows ?? 10_000;
   }
 

--- a/src/modules/executor/infrastructure/impersonation.ts
+++ b/src/modules/executor/infrastructure/impersonation.ts
@@ -52,7 +52,10 @@ export class ImpersonatingTokenProvider implements AccessTokenProvider {
 
   constructor(o: ImpersonatingTokenProviderOptions) {
     this.#source = o.source;
-    this.#fetch = o.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+    // Bound for the same reason as the gate's HTTP adapters (LOG-0059). Node
+    // tolerates a detached fetch, so this is not a live defect here — it keeps
+    // the pattern uniform so the Workers-fatal version cannot reappear.
+    this.#fetch = o.fetchImpl ?? (globalThis.fetch.bind(globalThis) as unknown as FetchLike);
     this.#scopes = o.scopes ?? [BIGQUERY_SCOPE];
     this.#lifetime = o.lifetimeSeconds ?? 300;
   }


### PR DESCRIPTION
## What & why

デプロイ済み executor で、**IAM が正しいのに impersonation が 403 になる**問題の修正です。

`AdcTokenProvider` の既定スコープは BigQuery だけで、`executor-server.ts` はその既定を**なりすましの source** に渡していました。ランタイム自身のトークンの用途は **IAM Credentials の `generateAccessToken` を呼ぶことだけ**なのに、Cloud Run のメタデータサーバは**要求されたスコープちょうど**のトークンを発行するため、IAM 側が 403 で拒否します。`roles/iam.serviceAccountTokenCreator` の付与がどれだけ正しくても通りません。

**なりすまし後のトークンは変わりません。** `ImpersonatingTokenProvider` はリクエストボディで bigquery スコープのみを要求しており、テナント主体の権限は今までどおり据え置きです。広がるのは「発行を依頼する側」の権限だけです。

### なぜローカル実測（LOG-0052）では通っていたか

ローカルADCは `gcloud auth application-default login` の**ユーザー資格情報**で、最初から `cloud-platform` を持っています。**アタッチされたサービスアカウントとして動かして初めて出る差**で、ノートPC上の検証では原理的に踏めませんでした。ライブE2Eをやった価値がここに出ています。

### どうやって特定したか

executor の**監査行**がそのまま理由を持っていました:

```
16:45  query.refused  table-not-allowed: table not in the allowlist: orders
16:51  query.failed   credentials unavailable: impersonation denied for
                      t-alpha-reader@... (HTTP 403)
```

`QUERY_POLICY` を直すまで `table-not-allowed` が 403 を隠していた、という順序です。

## 同梱の小修正

`bigquery.ts` / `impersonation.ts` の `globalThis.fetch` を bind しました。**両方 Node 上でしか動かないので現時点で不具合ではありません**。gate 側で実際に致命傷になった同じ書き方（Workers の `Illegal invocation`）が再発しないよう、形を揃えるだけの2行です。

## Change classification (ARC-020)

- [x] Local — 合成ルートのスコープ指定とアダプタ2箇所。公開契約は不変
- [ ] Contract
- [ ] Architectural

## Breaking change?

- [x] No
- [ ] Yes

## Testing (GR-021 / TST-002)

- How verified: `node --test "tests/**/*.test.ts"` → **157 passed, 0 failed**、`prettier --check` / `tsc --noEmit` クリーン
- Not verified (GR-042): **デプロイして 403 が解消することは未確認**です。これは合成ルートの配線であり、ユニットテストでは Cloud Run のメタデータサーバの挙動を再現できません。確認は live-e2e の 8〜10 が緑になるかどうかで行います

## Dependencies (GR-023 / COD-040)

なし。

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: n/a（LOG-0059 として別途記録予定）

## AI disclosure

- [x] Authored by AI agent: Claude Opus 5 — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] lint / test green
- [x] Diff within size limits (GR-020) — 3ファイル 19行
- [x] No guardrail violated — GR-030 の観点でも、テナント主体の権限は不変で、広がるのはランタイム自身の source トークンのみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
