### PR TITLE
docs: hand off to design-partner validation

### DIFF
--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -20,7 +20,8 @@ updated: 2026-07-29
    [spikes/report-generation/](../spikes/report-generation/README.md)
 
 **現在の作業**は
-[Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)。
+[Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160) /
+[PR #161](https://github.com/Yukihide-Mitsuoka/repchat/pull/161)。
 [ADR-0015](adr/0015-publish-artifacts-through-customer-git.md)の設計はPR #159で完了した。
 次はデザインパートナーへ[5分デモ](demo.md)を見せる。オーナーが対象者を選び、日程を
 確保するまで、GitHub Appまたはartifact pipelineの製品実装を次の作業にしない。

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -19,12 +19,11 @@ updated: 2026-07-29
 5. 実験を再現するなら `spikes/*/README.md`。レポート生成は
    [spikes/report-generation/](../spikes/report-generation/README.md)
 
-**現在のarchitecture follow-up**は
-[Issue #158](https://github.com/Yukihide-Mitsuoka/repchat/issues/158) /
-[PR #159](https://github.com/Yukihide-Mitsuoka/repchat/pull/159)。
-[ADR-0015](adr/0015-publish-artifacts-through-customer-git.md)で、顧客Gitをbuild時だけ使う
-GitHub App接続と共通artifact pipelineを確定した。実装より先に、次はデザインパートナーへ
-[5分デモ](demo.md)を見せる。
+**現在の作業**は
+[Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)。
+[ADR-0015](adr/0015-publish-artifacts-through-customer-git.md)の設計はPR #159で完了した。
+次はデザインパートナーへ[5分デモ](demo.md)を見せる。オーナーが対象者を選び、日程を
+確保するまで、GitHub Appまたはartifact pipelineの製品実装を次の作業にしない。
 
 進行中の作業、ブロッカー、次のアクション、検証済みの基準点が変わった場合は
 `docs/status.md`を更新します。この文書は正本の場所または再開順序が変わった場合だけ更新します。

--- a/docs/status.md
+++ b/docs/status.md
@@ -34,7 +34,8 @@ updated: 2026-07-29
 オーナー承認済み（LOG-0082）。GitHub Appとartifact pipelineの実装は未着手。
 [ADR-0013](adr/0013-metric-definitions-live-in-our-own-layer.md) はオーナー承認済みで、
 **日本語の記述 → SQL生成 → 検証 → Evidenceで実データ描画 → テナント別配信**まで実測済み。
-次は[5分説明](demo.md)をデザインパートナーへ実際に見せ、利用仮説を人間から測る。
+次は[Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)に従い、
+[5分説明](demo.md)をデザインパートナーへ実際に見せ、利用仮説を人間から測る。
 
 **前回立てた3手の現在地:**
 


### PR DESCRIPTION
## What & why

PR #159 and Issue #158 are complete, so the development handoff must no longer present them as active work. This points the handoff and status to Issue #160, whose acceptance criteria cover the design-partner demo and make the owner scheduling dependency explicit.

Refs: #160

## Change classification (ARC-020)

- [x] Local (documentation snapshot only; contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: `make format`, `make lint`, `make test`, and `git diff --check` green
- Not verified (GR-042): no design-partner participant has been nominated or scheduled; that external owner action is the blocker recorded in Issue #160

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: `docs/development-handoff.md`, `docs/status.md`

## AI disclosure

- [x] Authored by AI agent: Codex (GPT-5) — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes: repository owner reported PR #159 merged; Codex verified the merge and closed Issue #158 before updating the handoff.

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff within size limits (GR-020): 15 changed lines across 2 files; no unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)

## Self-review verdict

Approve. The links resolve, completed work is removed from the active slot, and the next action has one authoritative tracking issue.