### PR TITLE
fix(demo): normalize SQL indentation levels

### DIFF
--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -19,8 +19,10 @@ updated: 2026-07-30
 5. 実験を再現するなら `spikes/*/README.md`。レポート生成は
    [spikes/report-generation/](../spikes/report-generation/README.md)
 
-**現在の作業**は[Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)。
-デザインパートナーへ[5分デモ](demo.md)を見せ、末尾の質問で価値仮説と価格感を検証する。
+**現在の作業**は[Issue #190](https://github.com/Yukihide-Mitsuoka/repchat/issues/190)。
+デモのSQL表示を構文階層ごとの0、4、8、12...スペースへ正規化する。完了後は
+[Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)へ戻り、デザインパートナーへ
+[5分デモ](demo.md)を見せて価値仮説と価格感を検証する。
 
 デモ画面の情報配置は[Issue #184](https://github.com/Yukihide-Mitsuoka/repchat/issues/184) /
 [PR #185](https://github.com/Yukihide-Mitsuoka/repchat/pull/185)で、2026-07-30にmerge済み。6設問それぞれの
@@ -39,8 +41,9 @@ updated: 2026-07-30
 分析単位の結果／生成プロセス・SQLタブへ再構成する。購入KPI、リピート率、平均エンゲージメント、
 購入ファネル、日次＋7日移動平均、入口から3ページ目までの主要回遊Sankeyを扱い、SQLはSELECT列・
 主要句単位で整形する。Sankeyを含む6問版は実Vertex AI・BigQueryで6/6、推定¥1.285、
-R17の12 edge materialize、production build・ブラウザ描画、SQLの4スペースインデント／横スクロール、
-error/warning 0まで確認した。ただし公開GA4 schema固有の実測であり、未知nested schemaは未検証。
+R17の12 edge materialize、production build・ブラウザ描画、横スクロール、error/warning 0まで確認した。
+後続調査でSQLに`sqlparse`の予約語幅による1〜3文字等の位置合わせが残ると判明し、Issue #190で是正中。
+ただし公開GA4 schema固有の実測であり、未知nested schemaは未検証。
 製品版の閲覧／SQL面分離、
 目的を分解してKPI・複数グラフ・1画面前後の読順を設計する対話build、AI会議所見はIssue #179〜#181。
 

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -19,7 +19,8 @@ updated: 2026-07-30
 5. 実験を再現するなら `spikes/*/README.md`。レポート生成は
    [spikes/report-generation/](../spikes/report-generation/README.md)
 
-**現在の作業**は[Issue #190](https://github.com/Yukihide-Mitsuoka/repchat/issues/190)。
+**現在の作業**は[Issue #190](https://github.com/Yukihide-Mitsuoka/repchat/issues/190) /
+[PR #191](https://github.com/Yukihide-Mitsuoka/repchat/pull/191)。
 デモのSQL表示を構文階層ごとの0、4、8、12...スペースへ正規化する。完了後は
 [Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)へ戻り、デザインパートナーへ
 [5分デモ](demo.md)を見せて価値仮説と価格感を検証する。

--- a/docs/status.md
+++ b/docs/status.md
@@ -29,8 +29,9 @@ updated: 2026-07-30
    それ以前は設計フェーズの記録で、再開には不要
 4. 進行中の仕事に触れるなら、該当する ADR と `spikes/*/README.md`
 
-**現在の作業スレッド**: [Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)。
-デザインパートナーへ5分デモを見せ、価値仮説と価格感を検証する。
+**現在の作業スレッド**: [Issue #190](https://github.com/Yukihide-Mitsuoka/repchat/issues/190)。
+デモのSQL表示を構文階層ごとの0、4、8、12...スペースへ正規化する。完了後は
+[Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)のデザインパートナー検証へ戻る。
 
 **直前の作業スレッド**: [Issue #178](https://github.com/Yukihide-Mitsuoka/repchat/issues/178) /
 [PR #182](https://github.com/Yukihide-Mitsuoka/repchat/pull/182)（2026-07-30 merge済み）。
@@ -38,7 +39,8 @@ SQLをSELECT列・主要句単位で整形し、各分析内の結果／生成�
 リピート率、平均エンゲージメント、購入ファネル、日次＋7日移動平均へ改修した。さらに、入口から
 3ページ目までの上位12回遊を段階付きで集計するR17とEvidence標準`SankeyDiagram`を追加した。
 R17を含む6問版は実Vertex AI・BigQueryで**6/6**、推定**¥1.285**、R17は12 edgeをmaterializeし、
-production build・ブラウザ描画・SQLの4スペースインデント／横スクロール・error/warning 0まで確認した。
+production build・ブラウザ描画・横スクロール・error/warning 0まで確認した。後続調査で、SQLは
+タブ文字を含まない一方、`sqlparse`の予約語幅による1〜3文字等の位置合わせが残ると判明した（Issue #190）。
 これは公開GA4 schema上の実測であり、未知の独自nested/repeated schemaへの一般化は未検証
 （[Issue #188](https://github.com/Yukihide-Mitsuoka/repchat/issues/188)）。
 製品UX、目的からKPI・複数グラフ・読順を設計する対話型ダッシュボードbuild、AI所見は
@@ -84,7 +86,7 @@ GitHub publisherとmanaged publisherを接続する。build成功後だけcommit
 | **起動を1コマンドに** | `make demo PROJECT=<project>`。隔離venv、Evidence公式テンプレート、生成、照合、materialize、build、ブラウザ起動まで含む | 通常の`npm ci`から実環境でr1〜r12がmaterialize、HTTP 200、ブラウザで検証済みの値と未定義3指標の拒否を確認。ブラウザerror 0（Evidence依存側の非致命warningあり）。完全にキャッシュのない別マシンでは未確認 |
 | **説明資料** | [Looker Studio利用者向け5分説明](demo.md) | 日本語→SQL→照合→ページ、Looker Studioとの差、実測範囲と未統合のgate・認証・executorを5分の順番で分離した。実際の利用者が5分で理解できるかは次の対面検証で測る |
 | **生成経路の画面内表示** | `make demo PROJECT=<project> QUESTION='<日本語>'`。質問、生成BigQuery SQL、理由、照合状態、結果を1ページに表示。BigQueryとEvidence双方で`SELECT *`を使わない | 実Vertex AI・BigQueryで1/1、参照値118,380と一致、Vertex AI推定¥0.154。Evidence buildとブラウザ表示を確認し、error/warning 0。PR #175のCIは12/12成功 |
-| **高度な分析ショーケース** | `make demo PROJECT=<project> SHOWCASE=yes`。6つの分析ごとに分析結果／生成プロセス・SQL／集計データの3タブを持ち、購入KPI、ファネル、日次＋7日移動平均、入口から3ページ目までの回遊Sankeyを表示 | 6/6・¥1.285。R17は12 edgeをmaterializeし、production build・ブラウザ描画・SQL 4スペース／横スクロール・error/warning 0まで確認 |
+| **高度な分析ショーケース** | `make demo PROJECT=<project> SHOWCASE=yes`。6つの分析ごとに分析結果／生成プロセス・SQL／集計データの3タブを持ち、購入KPI、ファネル、日次＋7日移動平均、入口から3ページ目までの回遊Sankeyを表示 | 6/6・¥1.285。R17は12 edgeをmaterializeし、production build・ブラウザ描画・横スクロール・error/warning 0まで確認。厳密な4スペース階層はIssue #190で是正 |
 
 **やらないこと**: 製品機能。Issue #173は既存経路を画面から検証可能にする変更で、
 `src/`を触らず`spikes/`内で完結する。

--- a/docs/status.md
+++ b/docs/status.md
@@ -29,7 +29,8 @@ updated: 2026-07-30
    それ以前は設計フェーズの記録で、再開には不要
 4. 進行中の仕事に触れるなら、該当する ADR と `spikes/*/README.md`
 
-**現在の作業スレッド**: [Issue #190](https://github.com/Yukihide-Mitsuoka/repchat/issues/190)。
+**現在の作業スレッド**: [Issue #190](https://github.com/Yukihide-Mitsuoka/repchat/issues/190) /
+[PR #191](https://github.com/Yukihide-Mitsuoka/repchat/pull/191)。
 デモのSQL表示を構文階層ごとの0、4、8、12...スペースへ正規化する。完了後は
 [Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)のデザインパートナー検証へ戻る。
 

--- a/spikes/report-generation/README.md
+++ b/spikes/report-generation/README.md
@@ -324,8 +324,10 @@ make demo PROJECT=example-project DRY_RUN=yes
 Java/Docker製のツール全体は依存に加えていません。
 
 SQL表示の整形には、Python 3.13対応・BSDライセンスの`sqlparse==0.5.5`をデモ専用venvにpinしています。
-トップレベルのSELECT列を4スペースで分け、主要句を改行し、Evidence標準`CodeBlock`でsyntax highlight、
-コピー、横スクロールを提供します。整形対象は表示文字列だけで、BigQueryへ送るSQLと
+`sqlparse`のaligned modeで主要句を改行した後、予約語幅による位置合わせを構文階層ごとの
+0、4、8、12...スペースへ正規化します。SELECT列は対応するSELECTより4スペース深く配置し、
+Evidence標準`CodeBlock`でsyntax highlight、コピー、横スクロールを提供します。
+整形対象は表示文字列だけで、BigQueryへ送るSQLと
 `out/sources/ga4/*.sql`はモデルの原文です。
 
 ### 1問モードの実環境確認（2026-07-29）

--- a/spikes/report-generation/run_report.py
+++ b/spikes/report-generation/run_report.py
@@ -437,6 +437,113 @@ def break_select_columns(sql: str) -> str:
     return "".join(out)
 
 
+def sql_parenthesis_delta(line: str) -> int:
+    """Count structural parentheses while ignoring quoted SQL content."""
+    delta = 0
+    quote: str | None = None
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if quote:
+            if char == quote:
+                if index + 1 < len(line) and line[index + 1] == quote:
+                    index += 2
+                    continue
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"', "`"}:
+            quote = char
+        elif char == "-" and index + 1 < len(line) and line[index + 1] == "-":
+            break
+        elif char == "(":
+            delta += 1
+        elif char == ")":
+            delta -= 1
+        index += 1
+    return delta
+
+
+def normalize_sql_indentation(formatted: str, width: int = 4) -> str:
+    """Replace visual alignment offsets with structural indentation levels."""
+    lines = formatted.replace("\t", " " * width).splitlines()
+    normalized: list[str] = []
+    depth = 0
+    select_contexts: list[dict[str, int | str]] = []
+    main_clause = re.compile(
+        r"^(FROM|WHERE|GROUP\s+BY|ORDER\s+BY|HAVING|QUALIFY|LIMIT|"
+        r"UNION(?:\s+ALL)?|EXCEPT|INTERSECT)\b",
+        flags=re.I,
+    )
+    join_clause = re.compile(
+        r"^(?:(?:LEFT|RIGHT|FULL|INNER|OUTER|CROSS|NATURAL)\s+)?JOIN\b",
+        flags=re.I,
+    )
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            normalized.append("")
+            continue
+
+        leading_closes = len(stripped) - len(stripped.lstrip(")"))
+        effective_depth = max(0, depth - leading_closes)
+        select_contexts = [
+            context
+            for context in select_contexts
+            if int(context["depth"]) <= effective_depth
+        ]
+        context = select_contexts[-1] if select_contexts else None
+        upper = stripped.upper()
+
+        if re.match(r"^SELECT\b", upper):
+            select_contexts = [
+                existing
+                for existing in select_contexts
+                if int(existing["depth"]) < effective_depth
+            ]
+            context = {"depth": effective_depth, "phase": "select"}
+            select_contexts.append(context)
+            indent_level = effective_depth
+        else:
+            clause = main_clause.match(stripped)
+            if clause and context:
+                indent_level = int(context["depth"])
+                keyword = clause.group(1).upper()
+                if keyword.startswith("GROUP"):
+                    context["phase"] = "group"
+                elif keyword.startswith("ORDER"):
+                    context["phase"] = "order"
+                elif keyword.startswith("FROM"):
+                    context["phase"] = "from"
+                elif keyword.startswith(("WHERE", "HAVING", "QUALIFY")):
+                    context["phase"] = "condition"
+                else:
+                    context["phase"] = "clause"
+            elif join_clause.match(stripped) and context:
+                indent_level = int(context["depth"])
+                context["phase"] = "from"
+            elif re.match(r"^(AND|OR|ON|USING)\b", upper) and context:
+                indent_level = int(context["depth"]) + 1
+            elif stripped.startswith(")"):
+                indent_level = effective_depth
+            elif context and context["phase"] in {
+                "select",
+                "from",
+                "group",
+                "order",
+                "condition",
+            }:
+                indent_level = max(int(context["depth"]) + 1, effective_depth)
+            else:
+                indent_level = effective_depth
+
+        normalized.append(" " * (width * indent_level) + stripped)
+        depth = max(0, depth + sql_parenthesis_delta(stripped))
+
+    return "\n".join(normalized)
+
+
 def format_sql_for_display(sql: str) -> str:
     """Format SQL for the page without changing the executable source text."""
     try:
@@ -452,11 +559,13 @@ def format_sql_for_display(sql: str) -> str:
             flags=re.I,
         )
     else:
+        # AlignedIndentFilter uses keyword-width offsets and does not receive
+        # indent_width in sqlparse 0.5.5. It provides useful line breaks here;
+        # normalize_sql_indentation applies the four-space hierarchy below.
         formatted = sqlparse.format(
             sql.strip(),
             keyword_case="upper",
             reindent_aligned=True,
-            indent_width=4,
             use_space_around_operators=True,
             wrap_after=100,
         ).strip()
@@ -511,7 +620,7 @@ def format_sql_for_display(sql: str) -> str:
             continue
         if select_column_indent is not None and stripped:
             lines[index] = " " * select_column_indent + stripped
-    return "\n".join(lines)
+    return normalize_sql_indentation("\n".join(lines))
 
 
 def evidence_query(result: dict) -> list[str]:

--- a/tests/spikes/report-generation/run-report.test.ts
+++ b/tests/spikes/report-generation/run-report.test.ts
@@ -220,6 +220,70 @@ print(json.dumps(violations, ensure_ascii=False))
   assert.deepEqual(JSON.parse(result.stdout), []);
 });
 
+test('display SQL keeps CTE and UNION structure after aligned indentation is removed', () => {
+  const result = loadRunReport(`
+import sys
+import types
+
+aligned = """WITH first AS (
+        SELECT
+            a,
+            b
+          FROM source
+         WHERE x = 1
+           AND y = 2
+       ),
+       second AS (
+        SELECT
+            a,
+            b
+          FROM first
+     UNION ALL
+     SELECT
+         a,
+         b
+          FROM fallback
+       )
+SELECT
+    a,
+    b
+  FROM second
+ ORDER BY a"""
+sqlparse = types.ModuleType("sqlparse")
+sqlparse.format = lambda *_args, **_kwargs: aligned
+sys.modules["sqlparse"] = sqlparse
+print(module["format_sql_for_display"]("SELECT 1"))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    result.stdout.trim(),
+    `WITH first AS (
+    SELECT
+        a,
+        b
+    FROM source
+    WHERE x = 1
+        AND y = 2
+),
+second AS (
+    SELECT
+        a,
+        b
+    FROM first
+    UNION ALL
+    SELECT
+        a,
+        b
+    FROM fallback
+)
+SELECT
+    a,
+    b
+FROM second
+ORDER BY a`,
+  );
+});
+
 test('generated SQL must be read-only and bounded to the demo dataset', () => {
   const result = loadRunReport(`
 queries = [

--- a/tests/spikes/report-generation/run-report.test.ts
+++ b/tests/spikes/report-generation/run-report.test.ts
@@ -176,6 +176,50 @@ print(module["format_sql_for_display"](section["gold_sql"]))
   assert.doesNotMatch(result.stdout, /\n\s*\n\s*\n/);
 });
 
+test('display SQL indents every non-empty line by a multiple of four spaces', () => {
+  const result = loadRunReport(`
+section = next(section for section in spec["sections"] if section["id"] == "R17")
+formatted = module["format_sql_for_display"](section["gold_sql"])
+violations = [{
+    "line": index + 1,
+    "spaces": len(line) - len(line.lstrip(" ")),
+    "text": line.strip(),
+} for index, line in enumerate(formatted.splitlines())
+  if line.strip() and (len(line) - len(line.lstrip(" "))) % 4 != 0]
+print(json.dumps(violations, ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), []);
+});
+
+test('display SQL normalizes sqlparse aligned output to four-space levels', () => {
+  const result = loadRunReport(`
+import sys
+import types
+
+aligned = """SELECT COUNT(DISTINCT ecommerce.transaction_id) AS purchases,
+       SUM(ecommerce.purchase_revenue) AS revenue
+  FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\u0060
+ WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131'
+   AND event_name = 'purchase'"""
+sqlparse = types.ModuleType("sqlparse")
+sqlparse.format = lambda *_args, **_kwargs: aligned
+sys.modules["sqlparse"] = sqlparse
+
+raw = "SELECT COUNT(DISTINCT ecommerce.transaction_id) AS purchases, SUM(ecommerce.purchase_revenue) AS revenue FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\u0060 WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131' AND event_name = 'purchase'"
+formatted = module["format_sql_for_display"](raw)
+violations = [{
+    "line": index + 1,
+    "spaces": len(line) - len(line.lstrip(" ")),
+    "text": line.strip(),
+} for index, line in enumerate(formatted.splitlines())
+  if line.strip() and (len(line) - len(line.lstrip(" "))) % 4 != 0]
+print(json.dumps(violations, ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), []);
+});
+
 test('generated SQL must be read-only and bounded to the demo dataset', () => {
   const result = loadRunReport(`
 queries = [


### PR DESCRIPTION
## What & why

Fixes the demo SQL display so every structural indentation level uses 0, 4, 8, 12... spaces. Investigation found that sqlparse 0.5.5 aligned mode does not receive indent_width and intentionally aligns by keyword width, so configuration alone cannot guarantee four-space levels; this PR keeps its line breaking and normalizes display-only indentation afterward. Executable SQL and saved source SQL remain unchanged.

Refs: #190

## Change classification (ARC-020)

- [x] Local (inside one module, contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries ! + BREAKING CHANGE: footer

## Testing (GR-021 / TST-002)

- Failing-first regression: 1e64b9c
- How verified: make format, make lint, make test, make test-unit, make doctor, and make build are green. The pinned sqlparse 0.5.5 path formatted all 14 maintained reference queries (179 non-empty lines) and all 6 saved showcase queries (99 non-empty lines) with zero non-multiple indentation, SELECT projection, or tab violations.
- Not verified: the Evidence browser page was not rebuilt because make demo would invoke Vertex AI and BigQuery and incur cost. No cloud SQL was executed.

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: spikes/report-generation/README.md, docs/status.md, docs/development-handoff.md

## AI disclosure

- [x] Authored by AI agent: OpenAI Codex — self-review against .ai/review-checklist.md completed
- [ ] Authored by human
- Prompts/context notes: User explicitly required structural four-space multiples and requested investigation of the formatter limitation before choosing a fix.

## Self-review checklist (WF-090)

- [x] make format && make lint && make test green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (.ai/guardrails.md)