### PR TITLE
docs: resume design-partner validation

### DIFF
--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -19,11 +19,9 @@ updated: 2026-07-30
 5. 実験を再現するなら `spikes/*/README.md`。レポート生成は
    [spikes/report-generation/](../spikes/report-generation/README.md)
 
-**現在の作業**は[Issue #190](https://github.com/Yukihide-Mitsuoka/repchat/issues/190) /
-[PR #191](https://github.com/Yukihide-Mitsuoka/repchat/pull/191)。
-デモのSQL表示を構文階層ごとの0、4、8、12...スペースへ正規化する。完了後は
-[Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)へ戻り、デザインパートナーへ
-[5分デモ](demo.md)を見せて価値仮説と価格感を検証する。
+**現在の作業**は[Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)。
+主要顧客に該当する日本の小規模代理店またはソフトウェアベンダーを1社以上選定・日程調整し、
+[5分デモ](demo.md)で価値仮説と価格感を検証する。参加者の選定と日程調整はリポジトリオーナーが行う。
 
 デモ画面の情報配置は[Issue #184](https://github.com/Yukihide-Mitsuoka/repchat/issues/184) /
 [PR #185](https://github.com/Yukihide-Mitsuoka/repchat/pull/185)で、2026-07-30にmerge済み。6設問それぞれの
@@ -36,14 +34,19 @@ updated: 2026-07-30
 証明しないため、自由質問の実装前に[Issue #188](https://github.com/Yukihide-Mitsuoka/repchat/issues/188)を
 合格させる。検証済みrevisionのlink通知pilotは分離して先行できる。
 
-**直前の作業**は[Issue #178](https://github.com/Yukihide-Mitsuoka/repchat/issues/178) /
-[PR #182](https://github.com/Yukihide-Mitsuoka/repchat/pull/182)で、2026-07-30にmerge済み。
+**直前の作業**は[Issue #190](https://github.com/Yukihide-Mitsuoka/repchat/issues/190) /
+[PR #191](https://github.com/Yukihide-Mitsuoka/repchat/pull/191)で、2026-07-30にmerge済み。
+`sqlparse==0.5.5`のaligned modeによる予約語幅の位置合わせを表示時に正規化し、SQLの字下げを
+構文階層ごとの0、4、8、12...スペースへ揃えた。検証済み基準は[status §0](status.md#0-再開手順新しいaiセッション向け)を参照する。
+
+その前の[Issue #178](https://github.com/Yukihide-Mitsuoka/repchat/issues/178) /
+[PR #182](https://github.com/Yukihide-Mitsuoka/repchat/pull/182)は、2026-07-30にmerge済み。
 生成SQLの実行原文を変えずに表示だけを整形し、対面デモを
 分析単位の結果／生成プロセス・SQLタブへ再構成する。購入KPI、リピート率、平均エンゲージメント、
 購入ファネル、日次＋7日移動平均、入口から3ページ目までの主要回遊Sankeyを扱い、SQLはSELECT列・
 主要句単位で整形する。Sankeyを含む6問版は実Vertex AI・BigQueryで6/6、推定¥1.285、
 R17の12 edge materialize、production build・ブラウザ描画、横スクロール、error/warning 0まで確認した。
-後続調査でSQLに`sqlparse`の予約語幅による1〜3文字等の位置合わせが残ると判明し、Issue #190で是正中。
+後続調査で判明した`sqlparse`の予約語幅による位置合わせはPR #191で是正済み。
 ただし公開GA4 schema固有の実測であり、未知nested schemaは未検証。
 製品版の閲覧／SQL面分離、
 目的を分解してKPI・複数グラフ・1画面前後の読順を設計する対話build、AI会議所見はIssue #179〜#181。

--- a/docs/status.md
+++ b/docs/status.md
@@ -29,19 +29,24 @@ updated: 2026-07-30
    それ以前は設計フェーズの記録で、再開には不要
 4. 進行中の仕事に触れるなら、該当する ADR と `spikes/*/README.md`
 
-**現在の作業スレッド**: [Issue #190](https://github.com/Yukihide-Mitsuoka/repchat/issues/190) /
-[PR #191](https://github.com/Yukihide-Mitsuoka/repchat/pull/191)。
-デモのSQL表示を構文階層ごとの0、4、8、12...スペースへ正規化する。完了後は
-[Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)のデザインパートナー検証へ戻る。
+**現在の作業スレッド**: [Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)。
+主要顧客に該当する日本の小規模代理店またはソフトウェアベンダーを1社以上選定・日程調整し、
+5分デモで価値仮説と価格感を検証する。参加者の選定と日程調整はリポジトリオーナーが行う。
 
-**直前の作業スレッド**: [Issue #178](https://github.com/Yukihide-Mitsuoka/repchat/issues/178) /
-[PR #182](https://github.com/Yukihide-Mitsuoka/repchat/pull/182)（2026-07-30 merge済み）。
+**直前の作業スレッド**: [Issue #190](https://github.com/Yukihide-Mitsuoka/repchat/issues/190) /
+[PR #191](https://github.com/Yukihide-Mitsuoka/repchat/pull/191)（2026-07-30 merge済み）。
+`sqlparse==0.5.5`のaligned modeが`indent_width`を使わず予約語幅で字下げするため、表示時に
+構文階層ごとの0、4、8、12...スペースへ正規化した。保守対象14クエリ179行と保存済みデモ6クエリ99行で、
+4の倍数でない字下げ、SELECT直下の列ずれ、タブがすべて0件であることを確認した。BigQueryは実行していない。
+
+その前の[Issue #178](https://github.com/Yukihide-Mitsuoka/repchat/issues/178) /
+[PR #182](https://github.com/Yukihide-Mitsuoka/repchat/pull/182)は、2026-07-30にmerge済み。
 SQLをSELECT列・主要句単位で整形し、各分析内の結果／生成プロセス・SQLタブ、購入KPI、
 リピート率、平均エンゲージメント、購入ファネル、日次＋7日移動平均へ改修した。さらに、入口から
 3ページ目までの上位12回遊を段階付きで集計するR17とEvidence標準`SankeyDiagram`を追加した。
 R17を含む6問版は実Vertex AI・BigQueryで**6/6**、推定**¥1.285**、R17は12 edgeをmaterializeし、
 production build・ブラウザ描画・横スクロール・error/warning 0まで確認した。後続調査で、SQLは
-タブ文字を含まない一方、`sqlparse`の予約語幅による1〜3文字等の位置合わせが残ると判明した（Issue #190）。
+タブ文字を含まない一方、`sqlparse`の予約語幅による位置合わせが残ると判明し、PR #191で是正した。
 これは公開GA4 schema上の実測であり、未知の独自nested/repeated schemaへの一般化は未検証
 （[Issue #188](https://github.com/Yukihide-Mitsuoka/repchat/issues/188)）。
 製品UX、目的からKPI・複数グラフ・読順を設計する対話型ダッシュボードbuild、AI所見は
@@ -87,7 +92,7 @@ GitHub publisherとmanaged publisherを接続する。build成功後だけcommit
 | **起動を1コマンドに** | `make demo PROJECT=<project>`。隔離venv、Evidence公式テンプレート、生成、照合、materialize、build、ブラウザ起動まで含む | 通常の`npm ci`から実環境でr1〜r12がmaterialize、HTTP 200、ブラウザで検証済みの値と未定義3指標の拒否を確認。ブラウザerror 0（Evidence依存側の非致命warningあり）。完全にキャッシュのない別マシンでは未確認 |
 | **説明資料** | [Looker Studio利用者向け5分説明](demo.md) | 日本語→SQL→照合→ページ、Looker Studioとの差、実測範囲と未統合のgate・認証・executorを5分の順番で分離した。実際の利用者が5分で理解できるかは次の対面検証で測る |
 | **生成経路の画面内表示** | `make demo PROJECT=<project> QUESTION='<日本語>'`。質問、生成BigQuery SQL、理由、照合状態、結果を1ページに表示。BigQueryとEvidence双方で`SELECT *`を使わない | 実Vertex AI・BigQueryで1/1、参照値118,380と一致、Vertex AI推定¥0.154。Evidence buildとブラウザ表示を確認し、error/warning 0。PR #175のCIは12/12成功 |
-| **高度な分析ショーケース** | `make demo PROJECT=<project> SHOWCASE=yes`。6つの分析ごとに分析結果／生成プロセス・SQL／集計データの3タブを持ち、購入KPI、ファネル、日次＋7日移動平均、入口から3ページ目までの回遊Sankeyを表示 | 6/6・¥1.285。R17は12 edgeをmaterializeし、production build・ブラウザ描画・横スクロール・error/warning 0まで確認。厳密な4スペース階層はIssue #190で是正 |
+| **高度な分析ショーケース** | `make demo PROJECT=<project> SHOWCASE=yes`。6つの分析ごとに分析結果／生成プロセス・SQL／集計データの3タブを持ち、購入KPI、ファネル、日次＋7日移動平均、入口から3ページ目までの回遊Sankeyを表示 | 6/6・¥1.285。R17は12 edgeをmaterializeし、production build・ブラウザ描画・横スクロール・error/warning 0まで確認。SQL表示はPR #191で0、4、8、12...スペースの構文階層へ正規化 |
 
 **やらないこと**: 製品機能。Issue #173は既存経路を画面から検証可能にする変更で、
 `src/`を触らず`spikes/`内で完結する。


### PR DESCRIPTION
## What & why

PR #191 has merged and Issue #190 is closed, so the active project snapshot was stale. This updates the handoff and status documents to record the completed SQL indentation work and restore Issue #160 as the active design-partner validation step. The owner action is explicit: nominate and schedule at least one participant in the approved primary-customer segment.

Refs: #160

## Change classification (ARC-020)

- [x] Local (documentation only; contracts unchanged)
- [ ] Contract
- [ ] Architectural

## Breaking change?

- [x] No
- [ ] Yes

## Testing (GR-021 / TST-002)

- How verified: make format, make lint, and make test are green; GitHub confirms PR #191 merged and Issue #190 closed.
- Not verified: no demo or cloud service was executed because this is a state-documentation update.

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: docs/development-handoff.md and docs/status.md

## AI disclosure

- [x] Authored by AI agent: OpenAI Codex — self-review against .ai/review-checklist.md completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] make format && make lint && make test green
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (.ai/guardrails.md)