### PR TITLE
fix(demo): prepare live dependencies before startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ make doctor
 make demo-live PROJECT=<gcp-project>
 ```
 
-`demo-live`は実Vertex AIとBigQueryを使うため、起動時に費用確認を行います。
+`demo-live`は起動時に費用確認を行い、同意後にデモ用venvのpin済みPython依存を
+確認・導入します。実Vertex AIとBigQueryは、日本語の問い合わせを送信したときに使用します。
 
 基盤規約は[ai-dev-foundation](https://github.com/Yukihide-Mitsuoka/ai-dev-foundation)
 からレビューPRで同期します。RepChat固有のREADME、規約、ワークフロー、アプリケーション、

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -2,7 +2,7 @@
 id: development-handoff
 title: 開発引き継ぎ
 status: active
-updated: 2026-07-30
+updated: 2026-08-02
 ---
 
 # 開発引き継ぎ
@@ -16,7 +16,7 @@ updated: 2026-07-30
 | 項目 | 現在地 |
 |------|--------|
 | 作業 | [Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160) — 主要顧客に該当する参加者へ[5分デモ](demo.md)を実施する |
-| デモ準備 | [PR #197](https://github.com/Yukihide-Mitsuoka/repchat/pull/197)は2026-07-30にmerge済み。`make demo-live PROJECT=<project>`で参加者が日本語を入力し、生成SQLとBigQuery結果のグラフを同じ画面で確認できる。実Vertex AI・BigQueryと実ブラウザでの最終表示確認は未実施 |
+| デモ準備 | [PR #197](https://github.com/Yukihide-Mitsuoka/repchat/pull/197)は2026-07-30にmerge済み。`make demo-live PROJECT=<project>`で参加者が日本語を入力し、生成SQLとBigQuery結果のグラフを同じ画面で確認できる。既存venvの依存欠落は[Issue #217](https://github.com/Yukihide-Mitsuoka/repchat/issues/217)で修正中。回帰テストを含むunit test 193件は成功したが、実Vertex AI・BigQueryと実ブラウザでの最終表示確認は未実施 |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
 | AIができること | `make demo-live PROJECT=<project>`のローカル表示確認、説明手順の準備、実施後の匿名化された結果整理 |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -16,7 +16,7 @@ updated: 2026-08-02
 | 項目 | 現在地 |
 |------|--------|
 | 作業 | [Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160) — 主要顧客に該当する参加者へ[5分デモ](demo.md)を実施する |
-| デモ準備 | [PR #197](https://github.com/Yukihide-Mitsuoka/repchat/pull/197)は2026-07-30にmerge済み。`make demo-live PROJECT=<project>`で参加者が日本語を入力し、生成SQLとBigQuery結果のグラフを同じ画面で確認できる。既存venvの依存欠落は[Issue #217](https://github.com/Yukihide-Mitsuoka/repchat/issues/217)で修正中。回帰テストを含むunit test 193件は成功したが、実Vertex AI・BigQueryと実ブラウザでの最終表示確認は未実施 |
+| デモ準備 | [PR #197](https://github.com/Yukihide-Mitsuoka/repchat/pull/197)は2026-07-30にmerge済み。`make demo-live PROJECT=<project>`で参加者が日本語を入力し、生成SQLとBigQuery結果のグラフを同じ画面で確認できる。既存venvの依存欠落は[Issue #217](https://github.com/Yukihide-Mitsuoka/repchat/issues/217) / [PR #218](https://github.com/Yukihide-Mitsuoka/repchat/pull/218)で修正中。回帰テストを含むunit test 193件は成功したが、実Vertex AI・BigQueryと実ブラウザでの最終表示確認は未実施 |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
 | AIができること | `make demo-live PROJECT=<project>`のローカル表示確認、説明手順の準備、実施後の匿名化された結果整理 |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |

--- a/spikes/report-generation/README.md
+++ b/spikes/report-generation/README.md
@@ -1,7 +1,7 @@
 ---
 id: spike-report-generation
 title: レポート1枚を、実データから生成する
-updated: 2026-07-30
+updated: 2026-08-02
 ---
 
 # Spike: レポート生成
@@ -285,7 +285,8 @@ gcloud auth application-default login
 20GiB上限を使用します。生成・検査・実行・描画の段階、生成理由、SQL、結果、Vertex AI推定費用を
 同じ画面に表示します。1列1行はBigValue、日付＋数値は折れ線、カテゴリ＋数値は棒グラフ、
 その他は表として描画します。登録済み設問だけ参照値を照合し、任意設問は既知値未照合と明示します。
-未定義指標ではBigQueryを呼びません。
+未定義指標ではBigQueryを呼びません。起動ごとに`out/.demo/venv`へpin済みrequirementsを確認・導入し、
+現在のPythonとvenv Pythonが異なる場合だけvenvへ再起動します。
 
 `report.json`にある設問と完全一致する場合は登録済みの参照SQLとも値を照合します。それ以外の
 日本語問い合わせは生成SQLをBigQueryで実行して描画しますが、既知値とは照合せず、ページに

--- a/spikes/report-generation/live_demo.py
+++ b/spikes/report-generation/live_demo.py
@@ -15,7 +15,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Callable
 import run_report as report
-from demo import DemoError, prepare_python, require_adc, run, venv_python
+from demo import DemoError, prepare_python, require_adc, run
 HERE = Path(__file__).resolve().parent
 HOST, PORT = "127.0.0.1", 8765
 MAX_BODY_BYTES, MAX_RESULT_ROWS = 4096, 100
@@ -243,9 +243,8 @@ def main() -> int:
         if sys.version_info < (3, 13) or shutil.which("gcloud") is None:
             raise DemoError("Python 3.13 or newer and gcloud are required")
         require_adc()
-        expected_python = venv_python()
-        if not expected_python.exists() or Path(sys.executable).resolve() != expected_python.resolve():
-            python = prepare_python()
+        python = prepare_python()
+        if Path(sys.executable).resolve() != Path(python).resolve():
             command = [str(python), str(Path(__file__).resolve()), "--project", project,
                        "--host", args.host, "--port", str(args.port), "--accept-cost"]
             if args.no_open:

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -31,6 +31,7 @@ from pathlib import Path
 calls=[]
 m.sys.argv=[str(m.Path(m.__file__)),"--project","example-project","--accept-cost","--no-open"]
 m.sys.executable="/usr/bin/python3"
+m.sys.version_info=(3,13,0)
 m.shutil.which=lambda _tool:"/usr/bin/gcloud"
 m.require_adc=lambda:calls.append("adc")
 m.venv_python=lambda:Path(m.sys.executable)

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -25,6 +25,34 @@ test('live dry-run describes the paid localhost workflow', () => {
   assert.match(result.stdout, /call Vertex AI and BigQuery after each submitted prompt/);
   assert.match(result.stdout, /open http:\/\/127\.0\.0\.1:8765\//);
 });
+test('live startup prepares pinned dependencies before creating the engine', () => {
+  const result = python(`
+from pathlib import Path
+calls=[]
+m.sys.argv=[str(m.Path(m.__file__)),"--project","example-project","--accept-cost","--no-open"]
+m.sys.executable="/usr/bin/python3"
+m.shutil.which=lambda _tool:"/usr/bin/gcloud"
+m.require_adc=lambda:calls.append("adc")
+m.venv_python=lambda:Path(m.sys.executable)
+def prepare():
+ calls.append("prepare")
+ return Path(m.sys.executable)
+m.prepare_python=prepare
+m.LiveQueryEngine=lambda _project:(calls.append("engine") or object())
+class Server:
+ server_port=8765
+ def serve_forever(self):calls.append("serve");raise KeyboardInterrupt
+ def server_close(self):calls.append("close")
+m.create_server=lambda _host,_port,_engine:Server()
+status=m.main()
+print(json.dumps({"status":status,"calls":calls}))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout.split('\n').at(-2) ?? ''), {
+    status: 0,
+    calls: ['adc', 'prepare', 'engine', 'serve', 'close'],
+  });
+});
 test('live engine renders safe shapes, refuses undefined metrics, and caps fetched rows', () => {
   const result = python(`
 import threading


### PR DESCRIPTION
## What & why

PR #197のライブデモは、既存venvが存在し、そのPythonで起動している場合にprepare_pythonをスキップしていました。このためpin済み依存が欠けたvenvでは、LiveQueryEngine初期化時にModuleNotFoundError: No module named googleとなります。

起動ごとにrequirements.txtをprepare_pythonで確認・導入し、現在のPythonが準備済みvenv Pythonと異なる場合だけ再起動します。修正はreport-generation spikeの起動処理に限定します。

Refs: #217, #160

## Change classification (ARC-020)

- [x] Local (inside one module, contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries ! + BREAKING CHANGE: footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: failing-first commit af742c6でmake test-unitが192/193となり、呼び出し順にprepareだけが無いことを確認。修正後はmake format、make lint、make test、make build、make doctor、make demo-live PROJECT=example-project DRY_RUN=yesが成功
- Not verified (be honest — GR-042): 実Vertex AI・BigQueryへの問い合わせ、実ブラウザでの描画、デザインパートナー操作は未実施。クラウド費用は発生していません

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: README.md、docs/development-handoff.md、spikes/report-generation/README.md

## AI disclosure

- [x] Authored by AI agent: OpenAI Codex — self-review against .ai/review-checklist.md completed
- [ ] Authored by human
- Prompts/context notes (optional, helps reviewers): PR #197・#200とユーザーの再現ログを照合し、直前AIが示した最小修正を回帰テストで固定しました。

## Self-review checklist (WF-090)

- [x] make format && make lint && make test green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (.ai/guardrails.md)