### PR TITLE
feat(demo): orchestrate dashboard analyses

### DIFF
--- a/spikes/report-generation/live_demo.py
+++ b/spikes/report-generation/live_demo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Serve a localhost-only live Japanese prompt → SQL → graph demonstration."""
+"""Serve a localhost-only Japanese prompt → graph or dashboard demonstration."""
 
 from __future__ import annotations
 import argparse
@@ -23,6 +23,15 @@ HOST, PORT = "127.0.0.1", 8765
 MAX_BODY_BYTES, MAX_RESULT_ROWS = 4096, 100
 SAMPLE_FIRST_DAY = date(2020, 11, 1)
 SAMPLE_LAST_DAY = date(2021, 1, 31)
+DASHBOARD_SECTION_IDS = report.SHOWCASE_IDS
+DASHBOARD_PURPOSES = {
+    "R4": "購入成果の規模を最初に確認する",
+    "R11": "単発訪問だけでなく、ユーザーが定着しているかを確認する",
+    "R12": "訪問中に十分な関与が生まれているかを確認する",
+    "R9": "閲覧から購入までのどこで減少しているかを特定する",
+    "R16": "日々の変動と7日間の基調を分けて確認する",
+    "R17": "主要なページ遷移から回遊上の特徴を確認する",
+}
 
 
 def running_in_demo_venv() -> bool:
@@ -96,6 +105,26 @@ def period_for_question(question: str) -> dict[str, str]:
     }
 
 
+def dashboard_sections(spec: dict, question: str) -> tuple[dict[str, str], list[dict]]:
+    """Expand one concrete dashboard request into the validated showcase analyses."""
+    report.select_sections(spec, question)
+    if "ダッシュボード" not in question:
+        raise LiveDemoError("依頼に「ダッシュボード」を含めてください。")
+    period = period_for_question(question)
+    sections = report.select_sections(spec, None, showcase=True)
+    if tuple(section["id"] for section in sections) != DASHBOARD_SECTION_IDS:
+        raise LiveDemoError("ダッシュボード分析定義の構成が一致しません。")
+    month_pattern = re.compile(r"\d{4}年\s*\d{1,2}月")
+    for section in sections:
+        section["text"] = month_pattern.sub(period["label"], section["text"], count=1)
+        section["purpose"] = DASHBOARD_PURPOSES[section["id"]]
+        # Registered reference SQL is fixed to January 2021. Other available
+        # sample months can execute, but cannot be labelled reference-verified.
+        if period["from"] != "20210101" or period["to"] != "20210131":
+            section["verification"] = "execution"
+    return period, sections
+
+
 def require_sql_period(sql: str, period: dict[str, str]) -> None:
     """Fail closed when generated SQL does not use the requested date shard."""
     ranges = re.findall(
@@ -142,6 +171,53 @@ def visualization_for_result(rows: list[tuple], columns: list[str]) -> str:
     ):
         return "bar"
     return "table"
+
+
+def dashboard_visualization(section: dict, rows: list[tuple], columns: list[str]) -> str:
+    """Validate a planned panel's result shape before choosing its renderer."""
+    component = section["component"]
+    numeric = (int, float, Decimal)
+    valid = True
+    if component == "kpi_pair":
+        valid = (
+            len(rows) == 1
+            and len(columns) == 2
+            and len(rows[0]) == 2
+            and all(isinstance(value, numeric) for value in rows[0])
+        )
+    elif component == "funnel":
+        valid = (
+            len(rows) == 1
+            and len(columns) == 3
+            and len(rows[0]) == 3
+            and all(
+                isinstance(value, numeric) and math.isfinite(float(value)) and value >= 0
+                for value in rows[0]
+            )
+        )
+    elif component == "trend":
+        valid = (
+            bool(rows)
+            and len(columns) == 3
+            and all(
+                len(row) == 3
+                and isinstance(row[0], (date, datetime))
+                and all(
+                    isinstance(value, numeric) and math.isfinite(float(value))
+                    for value in row[1:]
+                )
+                for row in rows
+            )
+        )
+    elif component == "sankey":
+        valid = visualization_for_result(rows, columns) == "sankey"
+    if not valid:
+        raise LiveDemoError(
+            f"{section['title']}の結果形状がダッシュボード仕様と一致しないため描画しません。"
+        )
+    if component in {"kpi_pair", "funnel", "trend", "sankey"}:
+        return component
+    return visualization_for_result(rows, columns)
 class LiveQueryEngine:
     def __init__(self, project: str, model: str = report.DEFAULT_MODEL):
         from google import genai
@@ -152,64 +228,163 @@ class LiveQueryEngine:
         self.client = genai.Client(vertexai=True, project=project, location="global")
         self.bq = bigquery.Client(project=project)
         self.lock = threading.Lock()
+
     def query(self, question: str, emit: Callable[[dict], None]) -> None:
         if not self.lock.acquire(blocking=False):
             raise LiveDemoError("別の問い合わせを処理中です。完了後に再送してください。")
         try:
             section = report.select_sections(self.spec, question)[0]
             period = period_for_question(question)
-            emit({"type": "stage", "stage": "generate", "message": "Vertex AIでSQLを生成中です。"})
-            answer, usage = report.generate(
-                self.client, self.model, section, period, self.rules
-            )
-            cost = (
-                usage["input_tokens"] * report.PRICING[self.model][0]
-                + usage["output_tokens"] * report.PRICING[self.model][1]
-            ) / 1e6 * report.USD_JPY
-            sql, undefined = (answer.get("sql") or "").strip(), answer.get("undefined_terms") or []
-            if not sql and undefined:
-                emit({"type": "refusal", "reason": answer.get("reason", ""),
-                      "undefined_terms": undefined, "cost_jpy": round(cost, 3)})
-                return
-            if not sql:
-                raise LiveDemoError("SQLが返りませんでした。指標定義または質問を確認してください。")
-            normalized, error = report.validate_sql(sql)
-            if error:
-                raise LiveDemoError(f"生成SQLを安全検査で拒否しました: {error}")
-            require_sql_period(normalized, period)
-            emit({"type": "sql", "sql": report.format_sql_for_display(normalized),
-                  "reason": answer.get("reason", "")})
-            emit({"type": "stage", "stage": "execute", "message": "BigQueryで読み取り実行中です。"})
-            result, error = report.exec_bq(self.bq, normalized,
-                                           max_results=MAX_RESULT_ROWS + 1)
-            if error:
-                raise LiveDemoError(f"BigQuery実行に失敗しました: {error}")
-            rows, columns = result
-            if len(rows) > MAX_RESULT_ROWS:
-                raise LiveDemoError(
-                    f"結果が{MAX_RESULT_ROWS}行を超えたため描画しません。集計条件を追加してください。"
-                )
-            verification, label = "unverified", "実行済み・既知値未照合"
-            if section["verification"] == "reference":
-                wanted, error = report.exec_bq(self.bq, section["gold_sql"])
-                if error:
-                    raise LiveDemoError("登録済み参照SQLの実行に失敗しました。")
-                matches, detail = report.compare(section["compare"], rows, wanted[0])
-                verification = "matched" if matches else "mismatch"
-                label = "実行・参照値照合済み" if matches else f"参照値と不一致: {detail}"
+            self._run_section(section, period, emit)
+        finally:
+            self.lock.release()
+
+    def dashboard(self, question: str, emit: Callable[[dict], None]) -> None:
+        """Build all dashboard panels from one concrete Japanese request."""
+        if not self.lock.acquire(blocking=False):
+            raise LiveDemoError("別の問い合わせを処理中です。完了後に再送してください。")
+        try:
+            period, sections = dashboard_sections(self.spec, question)
             emit(
                 {
-                    "type": "result",
-                    "columns": columns,
-                    "rows": [[json_value(value) for value in row] for row in rows],
-                    "visualization": visualization_for_result(rows, columns),
-                    "verification": verification,
-                    "verification_label": label,
-                    "cost_jpy": round(cost, 3),
+                    "type": "dashboard_plan",
+                    "period": period["label"],
+                    "panels": [
+                        {
+                            "id": section["id"],
+                            "title": section["title"],
+                            "purpose": section["purpose"],
+                        }
+                        for section in sections
+                    ],
+                }
+            )
+            total_cost = 0.0
+            for index, section in enumerate(sections, start=1):
+                context = {
+                    "panel_id": section["id"],
+                    "panel_index": index,
+                    "panel_count": len(sections),
+                    "title": section["title"],
+                    "purpose": section["purpose"],
+                }
+                total_cost += self._run_section(section, period, emit, context)
+            emit(
+                {
+                    "type": "dashboard_complete",
+                    "panel_count": len(sections),
+                    "cost_jpy": round(total_cost, 3),
                 }
             )
         finally:
             self.lock.release()
+
+    def _run_section(
+        self,
+        section: dict,
+        period: dict[str, str],
+        emit: Callable[[dict], None],
+        context: dict | None = None,
+    ) -> float:
+        """Generate, validate, execute, and optionally verify one panel."""
+        extra = context or {}
+
+        def send(event: dict) -> None:
+            emit({**event, **extra})
+
+        send(
+            {
+                "type": "stage",
+                "stage": "generate",
+                "message": "Vertex AIでSQLを生成中です。",
+            }
+        )
+        answer, usage = report.generate(
+            self.client, self.model, section, period, self.rules
+        )
+        cost = (
+            usage["input_tokens"] * report.PRICING[self.model][0]
+            + usage["output_tokens"] * report.PRICING[self.model][1]
+        ) / 1e6 * report.USD_JPY
+        sql = (answer.get("sql") or "").strip()
+        undefined = answer.get("undefined_terms") or []
+        if not sql and undefined:
+            send(
+                {
+                    "type": "refusal",
+                    "reason": answer.get("reason", ""),
+                    "undefined_terms": undefined,
+                    "cost_jpy": round(cost, 3),
+                }
+            )
+            return cost
+        if not sql:
+            raise LiveDemoError("SQLが返りませんでした。指標定義または質問を確認してください。")
+        normalized, error = report.validate_sql(sql)
+        if error:
+            raise LiveDemoError(f"生成SQLを安全検査で拒否しました: {error}")
+        assert normalized is not None
+        require_sql_period(normalized, period)
+        send(
+            {
+                "type": "sql",
+                "sql": report.format_sql_for_display(normalized),
+                "reason": answer.get("reason", ""),
+            }
+        )
+        send(
+            {
+                "type": "stage",
+                "stage": "execute",
+                "message": "BigQueryで読み取り実行中です。",
+            }
+        )
+        result, error = report.exec_bq(
+            self.bq, normalized, max_results=MAX_RESULT_ROWS + 1
+        )
+        if error:
+            raise LiveDemoError(f"BigQuery実行に失敗しました: {error}")
+        assert result is not None
+        rows, columns = result
+        if len(rows) > MAX_RESULT_ROWS:
+            raise LiveDemoError(
+                f"結果が{MAX_RESULT_ROWS}行を超えたため描画しません。集計条件を追加してください。"
+            )
+        verification, label = "unverified", "実行済み・既知値未照合"
+        if section["verification"] == "reference":
+            wanted, error = report.exec_bq(self.bq, section["gold_sql"])
+            if error:
+                raise LiveDemoError("登録済み参照SQLの実行に失敗しました。")
+            assert wanted is not None
+            matches, detail = report.compare(section["compare"], rows, wanted[0])
+            verification = "matched" if matches else "mismatch"
+            label = (
+                "実行・参照値照合済み"
+                if matches
+                else f"参照値と不一致: {detail}"
+            )
+        visualization = (
+            dashboard_visualization(section, rows, columns)
+            if context
+            else visualization_for_result(rows, columns)
+        )
+        send(
+            {
+                "type": "result",
+                "columns": (
+                    section.get("shape", {}).get("columns", columns)
+                    if context
+                    else columns
+                ),
+                "source_columns": columns,
+                "rows": [[json_value(value) for value in row] for row in rows],
+                "visualization": visualization,
+                "verification": verification,
+                "verification_label": label,
+                "cost_jpy": round(cost, 3),
+            }
+        )
+        return cost
 class LiveDemoHandler(BaseHTTPRequestHandler):
     engine: LiveQueryEngine
     def do_GET(self) -> None:
@@ -218,7 +393,7 @@ class LiveDemoHandler(BaseHTTPRequestHandler):
         else:
             self._send(204 if self.path == "/favicon.ico" else 404, b"", "text/plain")
     def do_POST(self) -> None:
-        if self.path != "/api/query":
+        if self.path not in {"/api/query", "/api/dashboard"}:
             self._send_json(404, {"error": "not found"})
             return
         content_type = self.headers.get("content-type", "").split(";", 1)[0].strip().lower()
@@ -241,8 +416,11 @@ class LiveDemoHandler(BaseHTTPRequestHandler):
             question = body.get("question") if isinstance(body, dict) else None
             if not isinstance(question, str):
                 raise ValueError("question must be a string")
-            report.select_sections(self.engine.spec, question)
-            period_for_question(question)
+            if self.path == "/api/dashboard":
+                dashboard_sections(self.engine.spec, question)
+            else:
+                report.select_sections(self.engine.spec, question)
+                period_for_question(question)
         except (ValueError, json.JSONDecodeError, LiveDemoError) as error:
             self._send_json(400, {"error": str(error)})
             return
@@ -253,7 +431,10 @@ class LiveDemoHandler(BaseHTTPRequestHandler):
             self.wfile.write((json.dumps(event, ensure_ascii=False) + "\n").encode())
             self.wfile.flush()
         try:
-            self.engine.query(question, emit)
+            if self.path == "/api/dashboard":
+                self.engine.dashboard(question, emit)
+            else:
+                self.engine.query(question, emit)
         except LiveDemoError as error:
             emit({"type": "error", "message": str(error)})
         except Exception as error:  # noqa: BLE001 — details stay server-side

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -279,6 +279,99 @@ print(json.dumps({"values":values,"errors":errors},ensure_ascii=False))
   });
 });
 
+test('one dashboard request expands to the six validated analyses for its month', () => {
+  const result = python(`
+spec=json.loads((m.HERE/"report.json").read_text())
+period,sections=m.dashboard_sections(spec,"2020年12月のECサイト分析ダッシュボードを作って")
+error=""
+try:
+ m.dashboard_sections(spec,"2021年1月のECサイト分析をして")
+except m.LiveDemoError as caught:
+ error=str(caught)
+print(json.dumps({"period":period,"ids":[s["id"] for s in sections],"requested_month":all(period["label"] in s["text"] for s in sections),"verification":[s["verification"] for s in sections],"purposes":[bool(s["purpose"]) for s in sections],"error":error},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    period: { from: '20201201', to: '20201231', label: '2020年12月' },
+    ids: ['R4', 'R11', 'R12', 'R9', 'R16', 'R17'],
+    requested_month: true,
+    verification: Array(6).fill('execution'),
+    purposes: Array(6).fill(true),
+    error: '依頼に「ダッシュボード」を含めてください。',
+  });
+});
+
+test('dashboard engine streams six generated panels without paid dependencies', () => {
+  const result = python(`
+import threading
+from datetime import date
+e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL
+e.spec=json.loads((m.HERE/"report.json").read_text());e.rules="";e.client=e.bq=object();e.lock=threading.Lock()
+generated=[];executed=[]
+results={
+ "R4": ([(895,57350)],["purchases","revenue"]),
+ "R11": ([(14.56,)],["repeat_rate"]),
+ "R12": ([(49.51,)],["engagement_seconds"]),
+ "R9": ([(23105,4537,1115)],["viewed","carted","purchased"]),
+ "R16": ([(date(2020,12,1),100,90.0)],["day","sessions","moving_average"]),
+ "R17": ([("1. 入口: /","2. /shop",20)],["source","target","sessions"]),
+}
+def generate(_client,_model,section,period,_rules):
+ generated.append([section["id"],period["label"]])
+ sql=f"SELECT 1 AS value FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\` WHERE _TABLE_SUFFIX BETWEEN '20201201' AND '20201231' LIMIT 1 /* {section['id']} */"
+ return ({"sql":sql,"reason":"理由","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
+def execute(_bq,sql,**_kwargs):
+ section_id=next(section_id for section_id in m.DASHBOARD_SECTION_IDS if f"/* {section_id} */" in sql)
+ executed.append(section_id)
+ return (results[section_id],None)
+m.report.generate=generate;m.report.exec_bq=execute
+events=[]
+e.dashboard("2020年12月のECサイト分析ダッシュボードを作って",events.append)
+panel_results=[event for event in events if event["type"]=="result"]
+print(json.dumps({"first":events[0]["type"],"last":events[-1]["type"],"generated":generated,"executed":executed,"result_ids":[event["panel_id"] for event in panel_results],"visualizations":[event["visualization"] for event in panel_results],"first_columns":panel_results[0]["columns"],"count":events[-1]["panel_count"]},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    first: 'dashboard_plan',
+    last: 'dashboard_complete',
+    generated: [
+      ['R4', '2020年12月'],
+      ['R11', '2020年12月'],
+      ['R12', '2020年12月'],
+      ['R9', '2020年12月'],
+      ['R16', '2020年12月'],
+      ['R17', '2020年12月'],
+    ],
+    executed: ['R4', 'R11', 'R12', 'R9', 'R16', 'R17'],
+    result_ids: ['R4', 'R11', 'R12', 'R9', 'R16', 'R17'],
+    visualizations: ['kpi_pair', 'scalar', 'scalar', 'funnel', 'trend', 'sankey'],
+    first_columns: ['購入件数', '購入金額'],
+    count: 6,
+  });
+});
+
+test('dashboard result-shape validation fails closed before rendering', () => {
+  const result = python(`
+errors=[]
+for section,rows,columns in [
+ ({"title":"購入KPI","component":"kpi_pair"},[(1,)],["only_one"]),
+ ({"title":"ファネル","component":"funnel"},[(100,-1,2)],["a","b","c"]),
+ ({"title":"回遊","component":"sankey"},[("/","/shop","many")],["source","target","sessions"]),
+]:
+ try:
+  m.dashboard_visualization(section,rows,columns)
+ except m.LiveDemoError as error:
+  errors.append(str(error))
+print(json.dumps(errors,ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [
+    '購入KPIの結果形状がダッシュボード仕様と一致しないため描画しません。',
+    'ファネルの結果形状がダッシュボード仕様と一致しないため描画しません。',
+    '回遊の結果形状がダッシュボード仕様と一致しないため描画しません。',
+  ]);
+});
+
 test('live query passes the requested period to SQL generation', () => {
   const result = python(`
 import threading
@@ -378,21 +471,25 @@ import threading,urllib.error,urllib.request
 class E:
  spec=json.loads((m.HERE/"report.json").read_text())
  def query(self,q,emit):emit({"type":"result","rows":[[118380]],"columns":["sessions"],"visualization":"scalar","verification":"matched","verification_label":"照合済み","cost_jpy":0.1})
+ def dashboard(self,q,emit):emit({"type":"dashboard_complete","panel_count":6,"cost_jpy":1.2})
 s=m.create_server("127.0.0.1",0,E());t=threading.Thread(target=s.serve_forever,daemon=True);t.start();base=f"http://127.0.0.1:{s.server_port}";statuses=[]
 try:
  page=urllib.request.urlopen(base+"/").read().decode()
  req=urllib.request.Request(base+"/api/query",data=json.dumps({"question":"2021年1月のセッション数を出して"}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
  value=json.loads(urllib.request.urlopen(req).read().decode())["rows"][0][0]
+ dashboard_req=urllib.request.Request(base+"/api/dashboard",data=json.dumps({"question":"2021年1月のECサイト分析ダッシュボードを作って"}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
+ dashboard_count=json.loads(urllib.request.urlopen(dashboard_req).read().decode())["panel_count"]
  for ct,origin in [("text/plain",base),("application/json","https://attacker.example")]:
   try:urllib.request.urlopen(urllib.request.Request(base+"/api/query",data=b"{}",headers={"content-type":ct,"origin":origin},method="POST"))
   except urllib.error.HTTPError as e:statuses.append(e.code)
- print(json.dumps({"form":"日本語の問い合わせ" in page,"value":value,"statuses":statuses}))
+ print(json.dumps({"form":"日本語の問い合わせ" in page,"value":value,"dashboard_count":dashboard_count,"statuses":statuses}))
 finally:s.shutdown();s.server_close();t.join()
 `);
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout.split('\n').at(-2) ?? ''), {
     form: true,
     value: 118380,
+    dashboard_count: 6,
     statuses: [415, 403],
   });
   const bind = spawnSync(


### PR DESCRIPTION
## What & why

Adds the local-demo backend contract for turning one concrete Japanese dashboard request into the six validated showcase analyses. It streams a plan, per-panel SQL/reason/result events, and a completion event while reusing the existing SQL policy, period enforcement, row cap, reference verification, and single-request lock. Planned KPI, funnel, trend, and Sankey panels now fail closed when result columns or value types do not match their declared shape.

This is PR 1 of 2 for Issue #236. The stacked UI/documentation PR must be merged after this PR. It does not implement the production planner in #180 or executive commentary in #181.

Refs: #236

## Change classification (ARC-020)

- [x] Local (inside the report-generation spike, product contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer

## Testing (GR-021 / TST-002)

- How verified: `make format`, `make lint`, `make test`, and `make build` all exited 0. Deterministic tests cover month expansion, six-panel orchestration, Japanese display columns, result-shape rejection, the `/api/dashboard` same-origin boundary, and existing single-query behavior.
- Not verified: real Vertex AI and BigQuery execution was not run; no usage cost was incurred. Browser presentation is intentionally handled by stacked PR 2.

## Documentation (DOC-030)

- [x] Doc-update matrix checked; no user-visible UI is exposed by this backend-only PR. Usage and handoff documentation are included in stacked PR 2.

## AI disclosure

- [x] Authored by AI agent: Codex (GPT-5) — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff within size limits (GR-020): 380 changed lines across 2 files
- [x] No unrelated changes
- [x] No guardrail violated
