### PR TITLE
fix(ci): call Scorecard directly

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,4 +19,13 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
-      - uses: ./scripts/actions/scorecard
+      # OpenSSF verifies this literal workflow before accepting OIDC-backed results.
+      # Keep the approved actions direct; a local composite call fails verification.
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: github/codeql-action/upload-sarif@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.28.17
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- call the SHA-pinned OpenSSF Scorecard action directly from the protected workflow
- upload the generated SARIF with the SHA-pinned CodeQL action
- preserve least-privilege job permissions and disabled checkout credential persistence

OpenSSF validates the literal workflow before accepting OIDC-backed results, so this approved action cannot be hidden behind the synchronized local composite action. This ports ai-dev-foundation PR #152 / v1.5.2 across the protected-workflow ownership boundary.

## Validation

- `make format`
- `make lint`
- `make test`
- `make build`
- `make doctor`

## Merge order

Merge this protected-workflow port before Template Sync PR #241. The sync PR then removes the obsolete inherited composite action and installs its regression test without leaving main in an invalid state.

Closes #242