### PR TITLE
docs: refresh handoff after dashboard demo completion

### DIFF
--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -15,10 +15,10 @@ updated: 2026-08-02
 
 | 項目 | 現在地 |
 |------|--------|
-| 作業 | [Issue #248](https://github.com/Yukihide-Mitsuoka/repchat/issues/248) — main pushから作られたReleaseへ生成済みSBOMを明示的に添付する。v1.13.0は手動復旧済み。PR #239、#240、#245のデモ改修はmerge済み |
-| デモ準備 | `make demo-live PROJECT=<project>`は、ダッシュボード生成／単一グラフ生成を切り替える。単一グラフは「グラフ」と「取得データ」を切り替えられる。固定応答だけで検証し、実Vertex AI・BigQueryは再実行しない |
+| 作業 | [Issue #253](https://github.com/Yukihide-Mitsuoka/repchat/issues/253) — ダッシュボードデモ確認後の引き継ぎを更新する。#236は実装・オーナー確認済みでクローズ、v1.13.0のSBOM添付はPR #249で自動化済み |
+| デモ準備 | `make demo-live PROJECT=<project>`は、ダッシュボード生成／単一グラフ生成を切り替える。ダッシュボードは6パネル、単一グラフは「グラフ」と「取得データ」を切り替えられる。起動表示と固定応答を確認済み。質問送信は費用を再提示して承認後だけ行う |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
-| AIができること | Issue #248の回帰テスト、release workflow修正、CI確認、PRを完了する。実データ再実行は費用を再提示してオーナー承認後だけ行う |
+| AIができること | #253の文書更新、#160の検証準備、オーナーが取得した証拠の整理を行う。実データ再実行は費用を再提示してオーナー承認後だけ行う |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |
 | 完了時 | 証拠を`proceed` / `revise` / `reject`に分類し、Issue #160と[status](status.md)を更新する。方向が変わる場合だけpositioning、ADR、decision logを更新する |
 
@@ -38,7 +38,7 @@ updated: 2026-08-02
 
 | 条件 | 次の作業 | 先に読む正本 |
 |------|----------|--------------|
-| 現在 | [#248 ReleaseへのSBOM添付](https://github.com/Yukihide-Mitsuoka/repchat/issues/248)を完了後、[#160 デザインパートナー検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)へ戻る | [release policy](../.ai/release.md)、[demo](demo.md) |
+| 現在 | [#160 デザインパートナー検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)。参加者選定・日程調整はオーナー作業。#253完了後はコード実装を増やさず、この検証結果を`proceed` / `revise` / `reject`に分類する | [demo](demo.md)、[roadmap](roadmap.md) |
 | #160が`proceed` | [#188 未知nested schema品質検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/188)と[#179 閲覧／SQL来歴UX設計](https://github.com/Yukihide-Mitsuoka/repchat/issues/179)を独立した作業として開始できる | ADR-0013、ADR-0015、各Issueの受入条件 |
 | #179と#188が完了 | [#180 対話による分析仕様確定とbuild](https://github.com/Yukihide-Mitsuoka/repchat/issues/180) | #179の設計成果、ADR-0013/0015 |
 | #180でanalysis specification revision契約を確定 | Issue #160が`proceed`なら、適応型分析メモリーPhase 1の実装Issueを作る | [適応型分析メモリー要件](requirements/adaptive-analysis-memory.md)、ADR-0018。初期は手動方針・承認・表示・取消だけ |
@@ -49,6 +49,16 @@ updated: 2026-08-02
 
 `#160`が`revise`または`reject`の場合は、上表の製品タスクへ進まず、観測結果に基づいて
 positioningとroadmapを再評価します。
+
+## 次にやる順序（2026-08-02）
+
+1. **オーナー:** 初期主要顧客の定義に合う日本の小規模代理店またはソフトウェアベンダーから参加者を選び、5分デモの日程を決める。デモは既存のダッシュボードを使い、必要なら実行前に費用を提示する。
+2. **#160の後、`proceed`の場合:** [#188 未知nested schema品質検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/188)と[#179 閲覧／SQL来歴UX設計](https://github.com/Yukihide-Mitsuoka/repchat/issues/179)を独立して進める。前者は生成品質と拒否境界、後者は閲覧面とSQL来歴面の分離を扱う。
+3. **#188と#179の成果後:** [#180 対話による分析仕様確定とbuild](https://github.com/Yukihide-Mitsuoka/repchat/issues/180)で、目的→KPI・比較軸・期間・グラフ候補の提案→ユーザー確認→SQL生成→結果形状検証→非同期build・公開の契約を決める。
+4. **#180のrevision契約後:** [#220 適応型分析メモリー](https://github.com/Yukihide-Mitsuoka/repchat/issues/220)を、候補・scope・承認・期限・取消の手動Phase 1として実装する。
+5. **統制された生成・公開が安定後:** [#181 根拠付き経営報告](https://github.com/Yukihide-Mitsuoka/repchat/issues/181)で、グラフとSQL来歴に基づく会議報告を追加する。
+
+この順序より前に、本番認証・GitHub App・顧客Git配送・Slack自由質問を先行実装しない。[#194](https://github.com/Yukihide-Mitsuoka/repchat/issues/194)の課金区分とエンドユーザー認証は、本番オンボーディングへ進む直前に専用grill-meで確定する。
 
 ## 設計判断の索引
 
@@ -61,6 +71,7 @@ positioningとroadmapを再評価します。
 | Git配送と閲覧 | accepted。Gitはbuild時だけ使用し、閲覧経路へ入れない。GitHub/managedは同じpipelineの保存先adapter | [ADR-0015](adr/0015-publish-artifacts-through-customer-git.md) |
 | Slack | proposed。Webを正本UIとする認可付きadapter案。オーナー承認前は実装禁止 | [ADR-0017](adr/0017-use-slack-as-an-authorized-analysis-interface.md) |
 | 適応型分析メモリー | accepted。生の会話ではなくscope・権限・revision・期限を持つ方針をPostgresの正本で管理し、AIは候補を作るが自動昇格しない | [要件](requirements/adaptive-analysis-memory.md)、[ADR-0018](adr/0018-govern-adaptive-analysis-memory.md) |
+| 接続先・テーブル選択 | 将来設計。ユーザーに任意のdataset/tableを列挙させず、管理者が承認したデータソース・分析領域・テーブルカタログからサーバー側で解決する | [ADR-0005](adr/0005-cache-and-authorization-architecture.md)、[ADR-0010](adr/0010-connection-identity-is-never-a-person.md)、#180 |
 | 課金区分・エンドユーザー認証 | 未決。AIは推測しない | [Issue #194](https://github.com/Yukihide-Mitsuoka/repchat/issues/194) |
 
 ## 誤って前提にしてはいけないこと

--- a/docs/status.md
+++ b/docs/status.md
@@ -30,15 +30,14 @@ updated: 2026-08-02
    それ以前は設計フェーズの記録で、再開には不要
 4. 進行中の仕事に触れるなら、該当する ADR と `spikes/*/README.md`
 
-**現在の作業スレッド**: [Issue #243](https://github.com/Yukihide-Mitsuoka/repchat/issues/243)。
-単一グラフのBigQuery実行結果に、可視化と実際の取得列・行を切り替える表示を追加する。
-[Issue #236](https://github.com/Yukihide-Mitsuoka/repchat/issues/236)のダッシュボード生成は
-PR #239/#240でmerge済みで、固定応答によるブラウザ確認では6/6パネル、横方向overflow 0、
-console error/warning 0、単一グラフモードへの切替を確認した。実Vertex AI・BigQueryは再実行していない。
-Issue #243完了後は[Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)へ戻り、
-主要顧客に該当する参加者で価値仮説を検証する。Issue #160の結果を`proceed` / `revise` / `reject`に
-分類するまで製品実装を開始しない。条件付きの次タスク順と設計判断索引は
-[development-handoff](development-handoff.md)を参照する。
+**現在の作業スレッド**: [Issue #253](https://github.com/Yukihide-Mitsuoka/repchat/issues/253)。
+単一グラフの取得データ表示（PR #245）と、1つの日本語依頼から6パネルを生成するダッシュボード
+（PR #239/#240）は実装・オーナー確認済みで、Issue #236はクローズした。ライブデモはダッシュボード／
+単一グラフの切替、起動表示、費用確認、固定応答のブラウザ確認を完了している。質問送信による実Vertex AI・
+BigQueryはこの確認では行っていない。v1.13.0のSBOM添付はPR #249で自動化済み。
+次は[Issue #160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)で、初期主要顧客に該当する
+参加者へ5分デモを行い、価値仮説を`proceed` / `revise` / `reject`に分類する。結果が出るまで製品実装を
+開始しない。条件付きの次タスク順と設計判断索引は[development-handoff](development-handoff.md)を参照する。
 
 **直近のデモ修正**: [Issue #230](https://github.com/Yukihide-Mitsuoka/repchat/issues/230) /
 [PR #231](https://github.com/Yukihide-Mitsuoka/repchat/pull/231)（2026-08-02 merge済み）で、ライブ画面の


### PR DESCRIPTION
## Summary

- record owner-confirmed completion of the six-panel dashboard demo and close the completed #236
- refresh status and handoff references after PR #245 and PR #249
- make #160 design-partner validation the next human gate
- document the ordered follow-ups: #188/#179, #180, #220, then #181
- record approved data-source/table-catalog direction as future design, not implementation

## Verification

- `make format FILE=docs/development-handoff.md`
- `make format FILE=docs/status.md`
- `make lint`
- `make test`

Closes #253