### PR TITLE
chore(inheritance): accept Foundation v1.5.3

### DIFF
--- a/.github/inheritance/lock.json
+++ b/.github/inheritance/lock.json
@@ -2,6 +2,6 @@
   "schema_version": 1,
   "parent": {
     "repository": "Yukihide-Mitsuoka/ai-dev-foundation",
-    "commit": "74d925550904262860a88dcb011d95f8e0fb6db8"
+    "commit": "65c13a83732e88c5e0d0932a67801a5c6cbf8155"
   }
 }

--- a/.github/inheritance/manifest.json
+++ b/.github/inheritance/manifest.json
@@ -55,6 +55,7 @@
     "scripts/tests/test_github_governance_cli.py",
     "scripts/tests/test_github_governance_comparison.py",
     "scripts/tests/test_github_governance_discovery.py",
+    "scripts/tests/test_local_workflow_actions.py",
     "scripts/tests/test_objective_prose_policy.py",
     "scripts/tests/test_pr_size_policy.py",
     "scripts/tests/test_readme_ownership.py",

--- a/scripts/tests/test_local_workflow_actions.py
+++ b/scripts/tests/test_local_workflow_actions.py
@@ -188,6 +188,23 @@ class LocalWorkflowActionsTest(unittest.TestCase):
         )
         self.assertIn("actions/attest-build-provenance@", release_gates)
 
+    def test_main_push_release_attaches_sbom_to_release_please_tag(self):
+        workflow = (
+            REPOSITORY_ROOT / ".github" / "workflows" / "release.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("name: Attach generated SBOM to GitHub Release", workflow)
+        self.assertIn(
+            "RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}", workflow
+        )
+        self.assertIn("SBOM_PATH: sbom.spdx.json", workflow)
+        self.assertIn('test -n "$RELEASE_TAG"', workflow)
+        self.assertIn('test -s "$SBOM_PATH"', workflow)
+        self.assertIn(
+            'gh release upload "$RELEASE_TAG" "$SBOM_ASSET" --clobber', workflow
+        )
+        self.assertNotIn("RELEASE_TAG: ${{ github.ref_name }}", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What & why

Accept the complete Foundation v1.5.3 parent range through `65c13a8`. The generic workflow test is now explicitly parent-owned and byte-identical to Foundation; RepChat-specific release behavior remains in the existing protected TypeScript test.

Refs: #260

## Change classification (ARC-020)

- [ ] Local (inside one module, contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [x] Architectural (ADR required — link: Foundation ADR-0014 and ADR-0007, both accepted)

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: `make format`, `make lint`, `make test`, `make build`, `make doctor` (177 tests, 4 skipped), and `make security-scan` all exited 0; `npm audit --audit-level=high` reported 0 vulnerabilities.
- Not verified: local gitleaks and Trivy binaries were unavailable; CI remains authoritative for those scanners.

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: n/a — the accepted ADR and manifest already define the ownership boundary.

## AI disclosure

- [x] Authored by AI agent: OpenAI Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)
