### PR TITLE
build(deps): update cryptography to 50.0.0

### DIFF
--- a/.ai/decision-log.md
+++ b/.ai/decision-log.md
@@ -17,6 +17,7 @@ old one. One line per entry. AI agents append entries in the same PR as the chan
 
 | Date | ID | Decision | Link |
 |------|----|----------|------|
+| 2026-08-08 | LOG-0093 | mainの継続的依存スキャンで検出された修正済みhigh advisoryへ対応するため、ローカルデモのpin済み`cryptography`を49.0.0から50.0.0へ更新する。スキャンを抑制せずupgradeで解消し、アプリケーション契約と実行経路は変更しない | [requirements](../spikes/report-generation/requirements.txt) |
 | 2026-08-02 | LOG-0092 | 直接親lockを`ef70594`から最終first-parent commit `74d9255`（ai-dev-foundation release 1.5.2）へ進め、PR #238/#241の継承内容とPR #244の保護workflowに対応する受理来歴を完成させる。子固有CHANGELOG、製品実装、GitHub設定、クラウド状態は変更しない | [Issue #246](https://github.com/Yukihide-Mitsuoka/repchat/issues/246) |
 | 2026-08-02 | LOG-0091 | 直接親lockを`919508c`から次のfirst-parent commit `ef70594`（ai-dev-foundation #152）へ進める。旧Scorecard compositeの削除と回帰テストはPR #241で、保護されたdirect callerはPR #244で受理済みのため、実装を二重化せず受理済み状態の来歴を記録する | [Issue #246](https://github.com/Yukihide-Mitsuoka/repchat/issues/246) |
 | 2026-08-02 | LOG-0090 | 直接親lockを`854b885`から次のfirst-parent commit `919508c`（ai-dev-foundation #149）へ進める。fleet artifactを既存の継承rootへ収める最終内容はPR #238/#241で受理済みであり、保護されたMakefileや中間配置へ戻さず来歴だけを前進させる | [Issue #246](https://github.com/Yukihide-Mitsuoka/repchat/issues/246) |

--- a/spikes/report-generation/requirements.txt
+++ b/spikes/report-generation/requirements.txt
@@ -7,7 +7,7 @@ anyio==4.14.2
 certifi==2026.6.17
 cffi==2.1.0
 charset-normalizer==3.4.9
-cryptography==49.0.0
+cryptography==50.0.0
 distro==1.9.0
 google-api-core==2.31.0
 google-auth==2.55.2


### PR DESCRIPTION
## What & why

mainの継続的依存スキャンを復旧するため、ローカルデモでpinしている`cryptography`を49.0.0から50.0.0へ更新します。スキャンの抑制や例外登録は行わず、Trivyが示した修正版へupgradeします。アプリケーション契約と実行経路は変更しません。

Unblocks: #256

## Change classification (ARC-020)

- [x] Local (inside one module, contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: `make format && make lint && make test` green。`make doctor`と`make build`もgreen。`make security-scan`は`npm audit` 0件。
- Not verified (be honest — GR-042): ローカル環境にTrivyとgitleaksがないため、Python dependency scanとsecret scanの最終確認はCIで行う。構成のみのpin更新なのでアプリケーションテストは追加していない。

## Dependencies (GR-023 / COD-040)

| Package | Purpose | Alternatives considered | License | Maintenance signal |
|---------|---------|------------------------|---------|--------------------|
| `cryptography` 50.0.0 | mainで検出された修正済みhigh advisoryをupgradeで解消する | scanner抑制・VEX・旧版維持は、修正版が公開済みでGR-030/SEC-030に反するため不採用 | Apache-2.0 OR BSD-3-Clause | PyCAがTrusted Publishingで50.0.0を公開。production/stableで、49.0.0も2026-06-12に公開されており継続保守中。CIのTrivyで既知HIGH/CRITICALがないことを確認する |

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: `.ai/decision-log.md`にupgrade判断を記録。利用手順・API・設定契約は不変。

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes (optional, helps reviewers): mainとPR #256で同じdependency-scan failureを確認し、独立した最小PRへ分離。

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)
