### PR TITLE
feat(demo): validate evidence-backed meeting commentary

### DIFF
--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -2,7 +2,7 @@
 id: development-handoff
 title: 開発引き継ぎ
 status: active
-updated: 2026-08-02
+updated: 2026-08-08
 ---
 
 # 開発引き継ぎ
@@ -15,7 +15,7 @@ updated: 2026-08-02
 
 | 項目 | 現在地 |
 |------|--------|
-| 作業 | [Issue #257](https://github.com/Yukihide-Mitsuoka/repchat/issues/257) — 組織コンテキストを分析レシピ・指標定義・個人設定と分離し、#180と#181が同じ承認済みrevisionを参照する要件を明文化する。SQLハイライトはPR #256でレビュー待ち |
+| 作業 | [Issue #181](https://github.com/Yukihide-Mitsuoka/repchat/issues/181) — 保存済み集計bundleだけを根拠に、数値主張をSQL・結果revisionへ結ぶ未承認の会議報告ドラフト契約を小さいPRで準備中。ライブデモへの接続は後続PR |
 | デモ準備 | `make demo-live PROJECT=<project>`は、ダッシュボード生成／単一グラフ生成を切り替える。ダッシュボードは6パネル、単一グラフは「グラフ」と「取得データ」を切り替えられる。起動表示と固定応答を確認済み。質問送信は費用を再提示して承認後だけ行う |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
 | AIができること | オーナーが2026-08-02に優先したデモ／設計検証として、#255、組織コンテキストのメモリー要件、#188の非GA4公開nested dataset 1種類、#180と#181の明示的な未検証プロトタイプを小さいPRに分けて進める。実データ再実行は費用を再提示してオーナー承認後だけ行う |
@@ -56,7 +56,7 @@ positioningとroadmapを再評価します。
 2. **次:** 適応型分析メモリー要件で、承認済みの組織コンテキストを分析レシピと個人設定から明確に分離し、#180と#181が同じrevisionを参照する契約を明文化する。
 3. **レビュー待ち:** [#188 未知nested schema品質検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/188)の最初の縦切りとして、非GA4のBitcoin公開nested/repeated datasetをライブデモへ追加した。基準SQLのdry runは約2.91GiB。実値照合・独立レビュー・2種類評価は未完了なのでIssueは閉じない。
 4. **レビュー待ち:** [#180 対話による分析仕様確定とbuild](https://github.com/Yukihide-Mitsuoka/repchat/issues/180)のローカル未検証プロトタイプとして、目的→最大3確認→仮説・KPI・パネル提案→編集→revision freeze→別費用確認→buildを接続した。候補6件、fixture組織コンテキスト、同期buildの限界を維持する。
-5. **次:** [適応型分析メモリー要件](requirements/adaptive-analysis-memory.md)のrevisionを引き継いで[#181 根拠付き経営報告](https://github.com/Yukihide-Mitsuoka/repchat/issues/181)のローカル未検証プロトタイプへ進む。
+5. **現在:** [#181 根拠付き経営報告](https://github.com/Yukihide-Mitsuoka/repchat/issues/181)のローカル未検証プロトタイプを、純粋な根拠検証契約→ライブ画面接続の順に分割して進める。製品受入条件は閉じない。
 5. **並行するオーナー作業:** 初期主要顧客の定義に合う日本の小規模代理店またはソフトウェアベンダーから参加者を選び、#160の5分デモ日程を決める。#160が`proceed`になるまで、上記プロトタイプを製品実装または検証済み能力とは表明しない。
 この順序より前に、本番認証・GitHub App・顧客Git配送・Slack自由質問を先行実装しない。[#194](https://github.com/Yukihide-Mitsuoka/repchat/issues/194)の課金区分とエンドユーザー認証は、本番オンボーディングへ進む直前に専用grill-meで確定する。
 

--- a/spikes/report-generation/meeting_report.py
+++ b/spikes/report-generation/meeting_report.py
@@ -1,0 +1,274 @@
+"""Evidence-bounded executive commentary for the local dashboard demo."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+
+NUMBER = re.compile(r"(?<![A-Za-z])(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d+)?")
+REPORT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "executive_summary": {"type": "string"},
+        "observations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "panel_ids": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["text", "panel_ids"],
+            },
+        },
+        "interpretations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "uncertainty": {"type": "string"},
+                    "panel_ids": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["text", "uncertainty", "panel_ids"],
+            },
+        },
+        "hypotheses": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "validation": {"type": "string"},
+                    "panel_ids": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["text", "validation", "panel_ids"],
+            },
+        },
+        "actions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "owner": {"type": "string"},
+                    "urgency": {"type": "string"},
+                    "expected_impact": {"type": "string"},
+                    "next_step": {"type": "string"},
+                    "success_metric": {"type": "string"},
+                    "panel_ids": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": [
+                    "text",
+                    "owner",
+                    "urgency",
+                    "expected_impact",
+                    "next_step",
+                    "success_metric",
+                    "panel_ids",
+                ],
+            },
+        },
+        "limitations": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": [
+        "executive_summary", "observations", "interpretations",
+        "hypotheses", "actions", "limitations",
+    ],
+}
+
+
+class ReportError(ValueError):
+    """A report contract violation safe to show in the local UI."""
+
+def report_request(bundle: dict) -> str:
+    """Build a Japanese reporting request from one immutable evidence bundle."""
+    return f"""次の確定済みダッシュボードだけを根拠に、月次会議の報告案を書く。
+
+分析仕様revision: {bundle['plan_revision']}
+build revision: {bundle['build_revision']}
+組織コンテキストrevision: {bundle['organization_context_revision']}
+組織コンテキスト: {json.dumps(bundle['organization_context'], ensure_ascii=False)}
+確定済み分析仕様: {json.dumps(bundle['analysis_specification'], ensure_ascii=False)}
+指標定義: {json.dumps(bundle['metric_definitions'], ensure_ascii=False)}
+根拠パネル: {json.dumps(bundle['panels'], ensure_ascii=False)}
+
+規則:
+- 観測、解釈、未検証の仮説、推奨アクションを混ぜない。
+- 数値は根拠パネルに存在する値だけを使い、必ずpanel_idsを付ける。
+- 相関を因果と断定せず、解釈には不確実性を、仮説には検証方法を付ける。
+- アクションには期待効果、担当、緊急度、次の一歩、成功指標を付ける。
+- 目標値、事業事情、サンプルサイズを推測しない。不足はlimitationsへ書く。
+- limitationsへ根拠リンクのない数値を書かない。
+- 読み手は日本語の月次マーケティング会議参加者。SQL用語は使わない。
+- executive_summaryには数値を書かず、数値を伴う詳細は根拠付き観測へ置く。
+"""
+
+def _text(value, label: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ReportError(f"会議報告の{label}が空です。")
+    return normalized
+
+def _evidence_index(bundle: dict) -> dict[str, dict]:
+    """Validate immutable provenance before any generated claim is accepted."""
+    required_revisions = {
+        "plan_revision": r"plan-[0-9a-f]{12}",
+        "build_revision": r"build-[0-9a-f]{12}",
+        "organization_context_revision": r"[a-z0-9-]+",
+    }
+    for field, pattern in required_revisions.items():
+        if not re.fullmatch(pattern, str(bundle.get(field, ""))):
+            raise ReportError(f"根拠bundleの{field}が不正です。")
+    organization = bundle.get("organization_context")
+    specification = bundle.get("analysis_specification")
+    definitions = bundle.get("metric_definitions")
+    if not isinstance(organization, dict) or organization.get("revision") != bundle[
+        "organization_context_revision"
+    ]:
+        raise ReportError("組織コンテキストrevisionが根拠bundleと一致しません。")
+    if not isinstance(specification, dict) or specification.get("revision") != bundle[
+        "plan_revision"
+    ]:
+        raise ReportError("分析仕様revisionが根拠bundleと一致しません。")
+    if not isinstance(definitions, dict) or not definitions:
+        raise ReportError("根拠bundleに指標定義がありません。")
+    panels = bundle.get("panels")
+    if not isinstance(panels, list) or not panels:
+        raise ReportError("会議報告の根拠パネルがありません。")
+    indexed = {}
+    for panel in panels:
+        panel_id = panel.get("id") if isinstance(panel, dict) else None
+        if not isinstance(panel_id, str) or panel_id in indexed:
+            raise ReportError("根拠パネルIDが不正または重複しています。")
+        if not re.fullmatch(r"[0-9a-f]{16}", str(panel.get("sql_sha256", ""))):
+            raise ReportError(f"根拠パネル{panel_id}のSQL revisionが不正です。")
+        if not re.fullmatch(r"result-[0-9a-f]{12}", str(panel.get("result_revision", ""))):
+            raise ReportError(f"根拠パネル{panel_id}の結果revisionが不正です。")
+        if not isinstance(panel.get("columns"), list) or not isinstance(
+            panel.get("rows"), list
+        ):
+            raise ReportError(f"根拠パネル{panel_id}の結果形状が不正です。")
+        indexed[panel_id] = panel
+    return indexed
+
+def _panel_ids(item: dict, known: set[str]) -> list[str]:
+    ids = item.get("panel_ids") if isinstance(item, dict) else None
+    if not isinstance(ids, list) or not ids or any(panel_id not in known for panel_id in ids):
+        raise ReportError("会議報告の根拠パネルが未登録または空です。")
+    return list(dict.fromkeys(ids))
+
+def _number_tokens(value) -> set[str]:
+    def canonical(token: str) -> str:
+        token = token.replace(",", "")
+        return token.rstrip("0").rstrip(".") if "." in token else token
+
+    return {canonical(match.group()) for match in NUMBER.finditer(str(value))}
+
+def _evidence_numbers(indexed: dict[str, dict], panel_ids: list[str]) -> set[str]:
+    values: set[str] = set()
+    for panel_id in panel_ids:
+        panel = indexed[panel_id]
+        source = [panel.get("period", ""), *panel["columns"], *panel["rows"]]
+        values.update(_number_tokens(source))
+    return values
+
+def _validate_numbers(text: str, indexed: dict[str, dict], panel_ids: list[str]) -> None:
+    stated = _number_tokens(text)
+    # Dates, panel IDs, and numbered prose must not be embedded in claim text;
+    # this keeps the allowlist small and makes unsupported values fail closed.
+    unsupported = stated - _evidence_numbers(indexed, panel_ids)
+    if unsupported:
+        raise ReportError(
+            "会議報告に根拠パネルへ存在しない数値があります: "
+            + "、".join(sorted(unsupported))
+        )
+
+def normalize_report(raw: dict, bundle: dict) -> dict:
+    """Validate citations and reject numerical claims absent from evidence."""
+    if not isinstance(raw, dict) or not isinstance(bundle, dict):
+        raise ReportError("会議報告または根拠bundleがobjectではありません。")
+    indexed = _evidence_index(bundle)
+    known = set(indexed)
+
+    def items(name: str, extra: tuple[str, ...] = ()) -> list[dict]:
+        source = raw.get(name)
+        if not isinstance(source, list) or not source:
+            raise ReportError(f"会議報告の{name}がありません。")
+        normalized = []
+        for item in source:
+            ids = _panel_ids(item, known)
+            text = _text(item.get("text"), name)
+            _validate_numbers(text, indexed, ids)
+            details = {field: _text(item.get(field), field) for field in extra}
+            for value in details.values():
+                _validate_numbers(value, indexed, ids)
+            evidence_refs = [
+                {
+                    "panel_id": panel_id,
+                    "sql_sha256": indexed[panel_id]["sql_sha256"],
+                    "result_revision": indexed[panel_id]["result_revision"],
+                }
+                for panel_id in ids
+            ]
+            normalized.append(
+                {"text": text, **details, "panel_ids": ids, "evidence_refs": evidence_refs}
+            )
+        return normalized
+
+    summary = _text(raw.get("executive_summary"), "要約")
+    if re.search(r"\d", summary):
+        raise ReportError("会議報告の要約には根拠リンクのない数値を書けません。")
+    limitations = raw.get("limitations")
+    if not isinstance(limitations, list):
+        raise ReportError("会議報告のlimitationsが配列ではありません。")
+    report = {
+        "status": "draft_requires_human_approval",
+        "executive_summary": summary,
+        "observations": items("observations"),
+        "interpretations": items("interpretations", ("uncertainty",)),
+        "hypotheses": items("hypotheses", ("validation",)),
+        "actions": items(
+            "actions",
+            (
+                "owner",
+                "urgency",
+                "expected_impact",
+                "next_step",
+                "success_metric",
+            ),
+        ),
+        "limitations": [_text(value, "限界") for value in limitations],
+        "plan_revision": bundle["plan_revision"],
+        "build_revision": bundle["build_revision"],
+        "organization_context_revision": bundle["organization_context_revision"],
+    }
+    if not report["limitations"]:
+        raise ReportError("会議報告には少なくとも1件の限界を明示してください。")
+    if any(NUMBER.search(value) for value in report["limitations"]):
+        raise ReportError("会議報告のlimitationsには根拠リンクのない数値を書けません。")
+    canonical = json.dumps(report, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    report["report_revision"] = "report-" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
+    return report
+
+def generate(client, model: str, bundle: dict):
+    """Generate and validate one report draft without another warehouse query."""
+    from google.genai import types
+
+    _evidence_index(bundle)
+    response = client.models.generate_content(
+        model=model,
+        contents=report_request(bundle),
+        config=types.GenerateContentConfig(
+            system_instruction="あなたは根拠と不確実性を明示する日本語BI報告者。",
+            response_mime_type="application/json",
+            response_schema=REPORT_SCHEMA,
+            temperature=0,
+        ),
+    )
+    usage = response.usage_metadata
+    return normalize_report(json.loads(response.text), bundle), {
+        "input_tokens": usage.prompt_token_count or 0,
+        "output_tokens": usage.candidates_token_count or 0,
+    }

--- a/tests/spikes/report-generation/meeting-report.test.ts
+++ b/tests/spikes/report-generation/meeting-report.test.ts
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const MODULE = path.join(ROOT, 'spikes/report-generation/meeting_report.py');
+
+function python(body: string) {
+  return spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("meeting_report",${JSON.stringify(MODULE)})
+m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m)
+bundle={
+ "plan_revision":"plan-aaaaaaaaaaaa",
+ "build_revision":"build-bbbbbbbbbbbb",
+ "organization_context_revision":"demo-org-ec-v1",
+ "organization_context":{"revision":"demo-org-ec-v1","goal":"購入成果を改善する","target":None},
+ "analysis_specification":{"revision":"plan-aaaaaaaaaaaa","objective":"購入成果の課題を判断する","comparison":"月内推移","period":{"label":"2021年1月"}},
+ "metric_definitions":{"購入件数":"取引IDの異なり数","購入金額":"purchase revenueの合計"},
+ "panels":[
+  {"id":"R4","title":"購入件数と売上","period":"2021年1月","sql_sha256":"1111111111111111","result_revision":"result-222222222222","columns":["購入件数","購入金額"],"rows":[[895,123456.0]],"verification":"matched"},
+  {"id":"R16","title":"日別推移","period":"2021年1月","sql_sha256":"3333333333333333","result_revision":"result-444444444444","columns":["日付","セッション数","7日移動平均"],"rows":[["2021-01-31",118380,117000.5]],"verification":"matched"},
+ ],
+}
+${body}`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+}
+
+test('normalizes a draft into immutable evidence-linked meeting commentary', () => {
+  const result = python(`
+raw={
+ "executive_summary":"購入成果には追加診断が必要です。",
+ "observations":[{"text":"購入金額は123,456.00円です。","panel_ids":["R4"]}],
+ "interpretations":[{"text":"日次推移には変動があります。","uncertainty":"施策履歴が無いため原因は不明です。","panel_ids":["R16"]}],
+ "hypotheses":[{"text":"導線に改善余地がある可能性があります。","validation":"流入別に追加検証します。","panel_ids":["R4","R16"]}],
+ "actions":[{"text":"購入導線を確認します。","owner":"マーケティング責任者","urgency":"次回会議まで","expected_impact":"阻害箇所を特定できます。","next_step":"流入別に比較します。","success_metric":"購入件数","panel_ids":["R4"]}],
+ "limitations":["目標値と施策履歴が未登録です。"],
+}
+first=m.normalize_report(raw,bundle);second=m.normalize_report(raw,bundle)
+print(json.dumps({
+ "status":first["status"],"stable":first["report_revision"]==second["report_revision"],
+ "revision":first["report_revision"],"refs":first["observations"][0]["evidence_refs"],
+ "impact":first["actions"][0]["expected_impact"],"build":first["build_revision"],
+},ensure_ascii=False))`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    status: 'draft_requires_human_approval',
+    stable: true,
+    revision: JSON.parse(result.stdout).revision,
+    refs: [
+      {
+        panel_id: 'R4',
+        sql_sha256: '1111111111111111',
+        result_revision: 'result-222222222222',
+      },
+    ],
+    impact: '阻害箇所を特定できます。',
+    build: 'build-bbbbbbbbbbbb',
+  });
+  assert.match(JSON.parse(result.stdout).revision, /^report-[0-9a-f]{12}$/);
+});
+
+test('rejects unsupported numbers, unknown evidence, and revision mismatches', () => {
+  const result = python(`
+base={
+ "executive_summary":"要約です。",
+ "observations":[{"text":"購入件数は895件です。","panel_ids":["R4"]}],
+ "interpretations":[{"text":"解釈です。","uncertainty":"不確実です。","panel_ids":["R4"]}],
+ "hypotheses":[{"text":"仮説です。","validation":"検証します。","panel_ids":["R4"]}],
+ "actions":[{"text":"確認します。","owner":"担当者","urgency":"次回会議まで","expected_impact":"判断材料を増やします。","next_step":"分解します。","success_metric":"購入件数","panel_ids":["R4"]}],
+ "limitations":["目標値がありません。"],
+}
+cases=[]
+bad_number={**base,"observations":[{"text":"購入件数は999件です。","panel_ids":["R4"]}]}
+unknown={**base,"observations":[{"text":"観測です。","panel_ids":["R99"]}]}
+bad_bundle={**bundle,"organization_context_revision":"other-v1"}
+for raw,current in [(bad_number,bundle),(unknown,bundle),(base,bad_bundle),({**base,"limitations":None},bundle),({**base,"limitations":["30件未満です。"]},bundle)]:
+ try:m.normalize_report(raw,current)
+ except m.ReportError as error:cases.append(str(error))
+print(json.dumps(cases,ensure_ascii=False))`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [
+    '会議報告に根拠パネルへ存在しない数値があります: 999',
+    '会議報告の根拠パネルが未登録または空です。',
+    '組織コンテキストrevisionが根拠bundleと一致しません。',
+    '会議報告のlimitationsが配列ではありません。',
+    '会議報告のlimitationsには根拠リンクのない数値を書けません。',
+  ]);
+});
+
+test('request carries declared context and the schema requires accountable actions', () => {
+  const result = python(`
+request=m.report_request(bundle)
+required=m.REPORT_SCHEMA["properties"]["actions"]["items"]["required"]
+print(json.dumps({
+ "context":"購入成果を改善する" in request,
+ "specification":"月内推移" in request,
+ "metrics":"取引IDの異なり数" in request,
+ "evidence":"result-222222222222" in request,
+ "impact":"expected_impact" in required,
+ "no_warehouse":"BigQuery" not in request,
+},ensure_ascii=False))`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    context: true,
+    specification: true,
+    metrics: true,
+    evidence: true,
+    impact: true,
+    no_warehouse: true,
+  });
+});


### PR DESCRIPTION
## What & why

Issue #181の最初の小さい縦切りとして、確定済みの組織コンテキスト・分析仕様・指標定義・集計結果だけを入力にする会議報告契約を追加します。モデル出力の根拠IDをそのまま信用せず、検証後にサーバー側で各主張をpanel ID、SQL hash、result revisionへ結び直し、未対応の数値とrevision不一致をfail closedで拒否します。ライブ画面とVertex AIへの接続は、GR-020を守る後続PRに分離します。

Refs: #181

## Change classification (ARC-020)

- [x] Local (local demo prototype; product public contract unchanged)
- [ ] Contract
- [ ] Architectural

## Breaking change?

- [x] No
- [ ] Yes

## Testing (GR-021 / TST-002)

- How verified: `make format && make lint && make test` — exit 0。新規unit test 3件で、正常な根拠付与、カンマ区切り／小数表記、未登録数値、未知panel、revision不一致、不正limitationsを検証。
- Not verified (GR-042): ライブ画面接続、実Vertex AI、実BigQuery、ブラウザ目視は後続PR。今回、有料APIは呼び出していません。

## Documentation (DOC-030)

- [x] `docs/development-handoff.md`を#181の分割実装へ更新。利用手順はユーザー向け動作を追加する後続UI PRで更新します。

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green
- [x] 399 changed lines / 3 filesでGR-020 soft limit内
- [x] 新規依存、env var、本番認証・公開経路の変更なし
- [x] No guardrail violated

## Known limits

- 出力は`draft_requires_human_approval`であり、承認履歴の永続化や外部配信は未実装です。
- #181の製品受入条件は閉じません。今回の契約はローカル未検証プロトタイプの準備です。