### PR TITLE
fix(demo): constrain planner clarification fields

### DIFF
--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -15,7 +15,7 @@ updated: 2026-08-08
 
 | 項目 | 現在地 |
 |------|--------|
-| 作業 | [Issue #273](https://github.com/Yukihide-Mitsuoka/repchat/issues/273) / [PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275) — response schemaを未回答の許可fieldへ制約し、不正固定応答を実field付きでfail closedにする修正を提出済み。CIは全check成功し、merge待ち。引き継ぎ更新の[PR #274](https://github.com/Yukihide-Mitsuoka/repchat/pull/274)もレビュー待ち |
+| 作業 | [Issue #273](https://github.com/Yukihide-Mitsuoka/repchat/issues/273) / [PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275) — response schemaを未回答の許可fieldへ制約し、不正固定応答を実field付きでfail closedにする修正を提出済み。CIは全check成功し、merge待ち。引き継ぎ更新の[PR #274](https://github.com/Yukihide-Mitsuoka/repchat/pull/274)はマージ済み |
 | デモ実行状態 | `http://127.0.0.1:8765/`はHTTP 200だが、`fix/188-bitcoin-hash`のcommit `4967f27`から起動中で最新mainではない。PR #272のSankey修正確認には使わず、#273修正後に最新mainから再起動する |
 | 直近完了 | PR #275の固定応答回帰では初回・一部回答後・全回答後を検証し、`make format`、`make lint`、`make test-unit`、`make test`、`make build`が成功した。実Vertex AI・BigQueryは未実行。PR #269とPR #272、Release PR #270はmerge済み |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -15,11 +15,11 @@ updated: 2026-08-08
 
 | 項目 | 現在地 |
 |------|--------|
-| 作業 | [Issue #273](https://github.com/Yukihide-Mitsuoka/repchat/issues/273) — ダッシュボード相談でVertex AIが許可外の確認fieldを返し、後段検証がfail closedした。引き継ぎ更新の[PR #274](https://github.com/Yukihide-Mitsuoka/repchat/pull/274)はレビュー待ちで、コード修正PRは未作成 |
+| 作業 | [Issue #273](https://github.com/Yukihide-Mitsuoka/repchat/issues/273) / [PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275) — response schemaを未回答の許可fieldへ制約し、不正固定応答を実field付きでfail closedにする修正を提出済み。引き継ぎ更新の[PR #274](https://github.com/Yukihide-Mitsuoka/repchat/pull/274)もレビュー待ち |
 | デモ実行状態 | `http://127.0.0.1:8765/`はHTTP 200だが、`fix/188-bitcoin-hash`のcommit `4967f27`から起動中で最新mainではない。PR #272のSankey修正確認には使わず、#273修正後に最新mainから再起動する |
-| 直近完了 | PR #269とPR #272はmerge済み。Release PR #270もmergeされ、`v1.15.1`とSPDX SBOMの公開まで確認済み。PR #272後の実Vertex AI・BigQueryとSankey参照値は未測定 |
+| 直近完了 | PR #275の固定応答回帰では初回・一部回答後・全回答後を検証し、`make format`、`make lint`、`make test-unit`、`make test`、`make build`が成功した。実Vertex AI・BigQueryは未実行。PR #269とPR #272、Release PR #270はmerge済み |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
-| AIができること | #273を固定応答で修正し、最新mainの起動とHTTP表示を無料で確認する。実Vertex AI相談とBigQuery buildは別々に費用を提示し、オーナー承認後だけ実行する |
+| AIができること | PR #275のCI成功を確認し、merge後の最新mainからデモを再起動してHTTP表示を無料で確認する。実Vertex AI相談とBigQuery buildは別々に費用を提示し、オーナー承認後だけ実行する |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |
 | 完了時 | 証拠を`proceed` / `revise` / `reject`に分類し、Issue #160と[status](status.md)を更新する。方向が変わる場合だけpositioning、ADR、decision logを更新する |
 
@@ -51,7 +51,7 @@ updated: 2026-08-08
 
 | 条件 | 次の作業 | 先に読む正本 |
 |------|----------|--------------|
-| 現在のデモ阻害 | [#273 planner確認field制約](https://github.com/Yukihide-Mitsuoka/repchat/issues/273)。固定応答のfailing-first testで直し、自動再試行を追加しない | #273、`analysis_planner.py`、planner/live-demo tests |
+| 現在のデモ阻害 | [#273 planner確認field制約](https://github.com/Yukihide-Mitsuoka/repchat/issues/273) / [PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275)。固定応答のfailing-first testと修正は完了し、自動再試行は追加していない。CI成功とmergeを待つ | #273、`analysis_planner.py`、planner/live-demo tests |
 | #273 merge後 | 古い`fix/188-bitcoin-hash`サーバーを終了し、最新mainから`make demo-live PROJECT=<project>`で再起動する。まずHTTP 200と画面commit表示の改善要否を無料で確認する | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md) |
 | 固定応答確認後 | 実Vertex AI相談の費用を提示して承認を得てから同じ依頼を1回実行する。相談成功後のBigQuery buildは別の費用確認とし、同時に承認された扱いにしない | #273、#180 |
 | デモ阻害解消後 | [#160 デザインパートナー検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)。参加者選定・日程調整はオーナー作業。5分デモ後に結果を`proceed` / `revise` / `reject`へ分類する | [demo](demo.md)、[roadmap](roadmap.md) |
@@ -68,8 +68,8 @@ positioningとroadmapを再評価します。
 
 ## 次にやる順序（2026-08-08）
 
-1. **現在:** [#273](https://github.com/Yukihide-Mitsuoka/repchat/issues/273)でplannerのresponse schemaと後段検証を一致させる。固定応答で初回と回答反映後を検証し、Vertex AIを自動再試行しない。
-2. **次:** 最新mainからデモを再起動し、HTTP 200、planner固定応答、PR #272のSankey意味検証を無料の回帰テストで確認する。
+1. **現在:** [PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275)のCI成功とmergeを確認する。plannerのresponse schemaと後段検証は固定応答で一致を確認済みで、Vertex AIの自動再試行は追加していない。
+2. **次:** PR #275 merge後の最新mainからデモを再起動し、HTTP 200、planner固定応答、PR #272のSankey意味検証を無料の回帰テストで確認する。
 3. **オーナー承認後:** 実Vertex AI相談を1回確認する。成功後、別の費用確認を経てダッシュボードbuildを実行し、連続同一ページ統合後のR17参照値、色、取得データを確認する。
 4. **並行するオーナー作業:** [#160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)の参加者を選定して日程を決める。デモ阻害を解消後に5分デモを行い、`proceed` / `revise` / `reject`へ分類する。
 5. **未完の検証:** [#188](https://github.com/Yukihide-Mitsuoka/repchat/issues/188)はBitcoin 1種類の縦切りと予約語修正まで完了したが、実値照合、独立レビュー、未知・非公開相当2種類の評価が残る。

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -15,11 +15,11 @@ updated: 2026-08-08
 
 | 項目 | 現在地 |
 |------|--------|
-| 作業 | [Issue #273](https://github.com/Yukihide-Mitsuoka/repchat/issues/273) / [PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275) — response schemaを未回答の許可fieldへ制約し、不正固定応答を実field付きでfail closedにする修正を提出済み。引き継ぎ更新の[PR #274](https://github.com/Yukihide-Mitsuoka/repchat/pull/274)もレビュー待ち |
+| 作業 | [Issue #273](https://github.com/Yukihide-Mitsuoka/repchat/issues/273) / [PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275) — response schemaを未回答の許可fieldへ制約し、不正固定応答を実field付きでfail closedにする修正を提出済み。CIは全check成功し、merge待ち。引き継ぎ更新の[PR #274](https://github.com/Yukihide-Mitsuoka/repchat/pull/274)もレビュー待ち |
 | デモ実行状態 | `http://127.0.0.1:8765/`はHTTP 200だが、`fix/188-bitcoin-hash`のcommit `4967f27`から起動中で最新mainではない。PR #272のSankey修正確認には使わず、#273修正後に最新mainから再起動する |
 | 直近完了 | PR #275の固定応答回帰では初回・一部回答後・全回答後を検証し、`make format`、`make lint`、`make test-unit`、`make test`、`make build`が成功した。実Vertex AI・BigQueryは未実行。PR #269とPR #272、Release PR #270はmerge済み |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
-| AIができること | PR #275のCI成功を確認し、merge後の最新mainからデモを再起動してHTTP表示を無料で確認する。実Vertex AI相談とBigQuery buildは別々に費用を提示し、オーナー承認後だけ実行する |
+| AIができること | PR #275 merge後の最新mainからデモを再起動してHTTP表示を無料で確認する。実Vertex AI相談とBigQuery buildは別々に費用を提示し、オーナー承認後だけ実行する |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |
 | 完了時 | 証拠を`proceed` / `revise` / `reject`に分類し、Issue #160と[status](status.md)を更新する。方向が変わる場合だけpositioning、ADR、decision logを更新する |
 
@@ -51,7 +51,7 @@ updated: 2026-08-08
 
 | 条件 | 次の作業 | 先に読む正本 |
 |------|----------|--------------|
-| 現在のデモ阻害 | [#273 planner確認field制約](https://github.com/Yukihide-Mitsuoka/repchat/issues/273) / [PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275)。固定応答のfailing-first testと修正は完了し、自動再試行は追加していない。CI成功とmergeを待つ | #273、`analysis_planner.py`、planner/live-demo tests |
+| 現在のデモ阻害 | [#273 planner確認field制約](https://github.com/Yukihide-Mitsuoka/repchat/issues/273) / [PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275)。固定応答のfailing-first testと修正は完了し、自動再試行は追加していない。CIは全check成功し、mergeを待つ | #273、`analysis_planner.py`、planner/live-demo tests |
 | #273 merge後 | 古い`fix/188-bitcoin-hash`サーバーを終了し、最新mainから`make demo-live PROJECT=<project>`で再起動する。まずHTTP 200と画面commit表示の改善要否を無料で確認する | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md) |
 | 固定応答確認後 | 実Vertex AI相談の費用を提示して承認を得てから同じ依頼を1回実行する。相談成功後のBigQuery buildは別の費用確認とし、同時に承認された扱いにしない | #273、#180 |
 | デモ阻害解消後 | [#160 デザインパートナー検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)。参加者選定・日程調整はオーナー作業。5分デモ後に結果を`proceed` / `revise` / `reject`へ分類する | [demo](demo.md)、[roadmap](roadmap.md) |
@@ -68,7 +68,7 @@ positioningとroadmapを再評価します。
 
 ## 次にやる順序（2026-08-08）
 
-1. **現在:** [PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275)のCI成功とmergeを確認する。plannerのresponse schemaと後段検証は固定応答で一致を確認済みで、Vertex AIの自動再試行は追加していない。
+1. **現在:** [PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275)はCI全check成功。review/mergeを待つ。plannerのresponse schemaと後段検証は固定応答で一致を確認済みで、Vertex AIの自動再試行は追加していない。
 2. **次:** PR #275 merge後の最新mainからデモを再起動し、HTTP 200、planner固定応答、PR #272のSankey意味検証を無料の回帰テストで確認する。
 3. **オーナー承認後:** 実Vertex AI相談を1回確認する。成功後、別の費用確認を経てダッシュボードbuildを実行し、連続同一ページ統合後のR17参照値、色、取得データを確認する。
 4. **並行するオーナー作業:** [#160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)の参加者を選定して日程を決める。デモ阻害を解消後に5分デモを行い、`proceed` / `revise` / `reject`へ分類する。

--- a/docs/status.md
+++ b/docs/status.md
@@ -34,7 +34,7 @@ updated: 2026-08-08
 [PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275)。2026-08-08の実Vertex AI相談で、
 plannerが許可外の確認fieldを返し、後段検証がfail closedした。BigQueryは未実行。PR #275は
 response schemaを未回答の許可fieldへ制約し、固定応答で初回・一部回答後・全回答後と実field付き
-fail-closedを検証する。CI成功とmerge後に最新mainからデモを再起動する。費用を伴う再確認は、
+fail-closedを検証し、CIは全check成功した。merge後に最新mainからデモを再起動する。費用を伴う再確認は、
 Vertex AI相談とBigQuery buildを分けてオーナー承認を得る。
 
 PR #269とPR #272はmerge済みで、Release PR #270から`v1.15.1`タグ、GitHub Release、SPDX SBOMが

--- a/docs/status.md
+++ b/docs/status.md
@@ -30,10 +30,12 @@ updated: 2026-08-08
    それ以前は設計フェーズの記録で、再開には不要
 4. 進行中の仕事に触れるなら、該当する ADR と `spikes/*/README.md`
 
-**現在の作業スレッド**: [Issue #273](https://github.com/Yukihide-Mitsuoka/repchat/issues/273)。
-2026-08-08の実Vertex AI相談で、plannerが許可外の確認fieldを返し、後段検証がfail closedした。
-BigQueryは未実行。response schemaと後段の許可集合を一致させる固定応答の回帰修正後、最新mainから
-デモを再起動する。費用を伴う再確認は、Vertex AI相談とBigQuery buildを分けてオーナー承認を得る。
+**現在の作業スレッド**: [Issue #273](https://github.com/Yukihide-Mitsuoka/repchat/issues/273) /
+[PR #275](https://github.com/Yukihide-Mitsuoka/repchat/pull/275)。2026-08-08の実Vertex AI相談で、
+plannerが許可外の確認fieldを返し、後段検証がfail closedした。BigQueryは未実行。PR #275は
+response schemaを未回答の許可fieldへ制約し、固定応答で初回・一部回答後・全回答後と実field付き
+fail-closedを検証する。CI成功とmerge後に最新mainからデモを再起動する。費用を伴う再確認は、
+Vertex AI相談とBigQuery buildを分けてオーナー承認を得る。
 
 PR #269とPR #272はmerge済みで、Release PR #270から`v1.15.1`タグ、GitHub Release、SPDX SBOMが
 公開された。PR #272で連続する同一ページを統合する回遊契約と意味検証を追加したが、修正後の実Vertex AI・

--- a/docs/troubleshooting/live-demo.md
+++ b/docs/troubleshooting/live-demo.md
@@ -10,6 +10,16 @@ updated: 2026-08-08
 この文書は、`make demo-live`が結果の描画を停止した場合の確認方法を示します。実Vertex AIまたは
 BigQueryを再実行する前に、画面のエラーと生成済みSQLを確認してください。
 
+## 分析計画の確認fieldが拒否される
+
+plannerの確認fieldは`audience`、`comparison`、`business_goal`だけです。response schemaは回答済みfieldを
+候補から除外し、後段検証もschema制約に反する応答を拒否します。エラーに表示されたfieldが許可外または
+回答済みの場合、同じ有料相談を自動再試行しません。
+
+このエラーが固定応答テスト以外で発生した場合は、表示されたfieldと回答済みfieldを記録してIssueへ
+添付してください。モデル応答の全文、認証情報、環境変数は記録しないでください。再実行は、修正後に
+Vertex AI費用を改めて確認してから行います。分析計画中はBigQueryを実行しません。
+
 ## 回遊Sankeyが意味検証で停止する
 
 通常の回遊は`page_navigation`モードです。セッション内で連続する同一`page_path`を1回の滞在へ

--- a/spikes/report-generation/README.md
+++ b/spikes/report-generation/README.md
@@ -1,7 +1,7 @@
 ---
 id: spike-report-generation
 title: レポート1枚を、実データから生成する
-updated: 2026-08-02
+updated: 2026-08-08
 ---
 
 # Spike: レポート生成
@@ -310,6 +310,10 @@ dry runはデータ取得を実行せず、クエリ料金も発生しません�
 パネルを編集した後に仕様revisionをfreezeします。相談中はBigQueryを呼ばず、確定後の別費用確認で
 初めてSQL生成とbuildへ進みます。仕様revisionと`demo-org-ec-v1`組織コンテキストrevisionは
 生成ダッシュボードに表示します。生の会話をメモリーや認可判定には使用しません。
+plannerのresponse schemaは`audience`、`comparison`、`business_goal`のうち未回答fieldだけを許可し、
+全fieldが回答済みなら確認事項を0件へ制約します。schema制約に反する固定応答は後段でも拒否し、
+エラーには実際のfieldを含めます。同じ相談を自動再試行しないため、Vertex AI呼出しは1回の操作につき
+1回です。
 
 候補は`SHOWCASE_IDS`の6分析です。
 上段に購入成果・定着・エンゲージメントKPI、中段に購入ファネルと日次＋7日移動平均、下段に主要回遊

--- a/spikes/report-generation/analysis_planner.py
+++ b/spikes/report-generation/analysis_planner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 
@@ -53,6 +54,8 @@ PANEL_CATALOG = {
     },
 }
 
+CLARIFICATION_FIELDS = ("audience", "comparison", "business_goal")
+
 PLAN_SCHEMA = {
     "type": "object",
     "properties": {
@@ -97,6 +100,21 @@ PLAN_SCHEMA = {
 
 class PlannerError(ValueError):
     """A planner contract violation safe to show in the local UI."""
+
+
+def _response_schema(answers: dict[str, str]) -> dict:
+    """Constrain clarification output to fields that still need an answer."""
+    unanswered = [field for field in CLARIFICATION_FIELDS if field not in answers]
+    schema = copy.deepcopy(PLAN_SCHEMA)
+    clarifications = schema["properties"]["clarifications"]
+    clarifications["maxItems"] = len(unanswered)
+    if len(unanswered) == len(CLARIFICATION_FIELDS):
+        clarifications["minItems"] = 1
+    if unanswered:
+        field_schema = clarifications["items"]["properties"]["field"]
+        field_schema["format"] = "enum"
+        field_schema["enum"] = unanswered
+    return schema
 
 
 def planning_request(
@@ -156,11 +174,14 @@ def normalize_plan(
     if not 1 <= len(hypotheses) <= 3:
         raise PlannerError("分析計画の仮説は1〜3件にしてください。")
     clarifications = []
-    allowed_fields = {"audience", "comparison", "business_goal"}
+    allowed_fields = set(CLARIFICATION_FIELDS)
     for item in raw.get("clarifications", []):
         field = item.get("field") if isinstance(item, dict) else None
-        if field not in allowed_fields or field in answers:
-            raise PlannerError("確認事項のfieldが許可範囲外または回答済みです。")
+        diagnostic = json.dumps(field, ensure_ascii=False)
+        if field not in allowed_fields:
+            raise PlannerError(f"確認事項のfieldが許可範囲外です: {diagnostic}")
+        if field in answers:
+            raise PlannerError(f"確認事項のfieldは回答済みです: {diagnostic}")
         clarifications.append(
             {
                 "field": field,
@@ -214,7 +235,7 @@ def propose(client, model: str, objective: str, period: dict, metrics: str, answ
         config=types.GenerateContentConfig(
             system_instruction="あなたは意思決定から分析仕様を設計する日本語BIプランナー。",
             response_mime_type="application/json",
-            response_schema=PLAN_SCHEMA,
+            response_schema=_response_schema(answers),
             temperature=0,
         ),
     )

--- a/tests/spikes/report-generation/analysis-planner.test.ts
+++ b/tests/spikes/report-generation/analysis-planner.test.ts
@@ -82,3 +82,84 @@ print(json.dumps({"context":p.ORGANIZATION_CONTEXT["revision"] in request,"metri
     questions: true,
   });
 });
+
+test('planner constrains each response schema to unanswered clarification fields', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json,sys,types
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+google=types.ModuleType("google");genai=types.ModuleType("google.genai")
+class GenerateContentConfig:
+ def __init__(self,**kwargs):self.__dict__.update(kwargs)
+genai.types=types.SimpleNamespace(GenerateContentConfig=GenerateContentConfig)
+google.genai=genai;sys.modules["google"]=google;sys.modules["google.genai"]=genai
+period={"from":"20210101","to":"20210131","label":"2021年1月"}
+base={
+ "objective_summary":"購入成果の阻害箇所を特定して優先施策を決める",
+ "audience":"月次マーケティング会議",
+ "comparison":"月内の日次推移とファネル段階",
+ "hypotheses":["商品閲覧からカート追加への減少が大きい"],
+ "panels":[{"id":panel_id,"reason":"目的に必要"} for panel_id in ["R4","R9","R16","R17"]],
+}
+responses=[
+ {**base,"clarifications":[{"field":"channel","question":"流入は","recommended_answer":"organic"}]},
+ {**base,"clarifications":[{"field":"audience","question":"主な読者は","recommended_answer":"責任者"}]},
+ {**base,"clarifications":[]},
+]
+schemas=[];calls=0
+class Models:
+ def generate_content(self,**kwargs):
+  global calls
+  response=responses[calls];calls+=1
+  clarifications=kwargs["config"].response_schema["properties"]["clarifications"]
+  schemas.append({
+   "enum":clarifications["items"]["properties"]["field"].get("enum"),
+   "min_items":clarifications.get("minItems"),
+   "max_items":clarifications.get("maxItems"),
+  })
+  return types.SimpleNamespace(
+   text=json.dumps(response,ensure_ascii=False),
+   usage_metadata=types.SimpleNamespace(prompt_token_count=1,candidates_token_count=1),
+  )
+client=types.SimpleNamespace(models=Models());errors=[]
+answer_sets=[
+ {},
+ {"audience":"月次マーケティング会議"},
+ {"audience":"月次マーケティング会議","comparison":"前月","business_goal":"購入成果改善"},
+]
+for answers in answer_sets:
+ try:p.propose(client,"test-model","目的",period,"指標定義",answers)
+ except p.PlannerError as error:errors.append(str(error))
+print(json.dumps({"calls":calls,"schemas":schemas,"errors":errors},ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    calls: 3,
+    schemas: [
+      {
+        enum: ['audience', 'comparison', 'business_goal'],
+        min_items: 1,
+        max_items: 3,
+      },
+      {
+        enum: ['comparison', 'business_goal'],
+        min_items: null,
+        max_items: 2,
+      },
+      {
+        enum: null,
+        min_items: null,
+        max_items: 0,
+      },
+    ],
+    errors: [
+      '確認事項のfieldが許可範囲外です: "channel"',
+      '確認事項のfieldは回答済みです: "audience"',
+    ],
+  });
+});


### PR DESCRIPTION
## What & why

Fixes #273. The planner prompt and downstream validator allowed only
`audience`, `comparison`, and `business_goal`, but the Vertex AI response schema
accepted any string. This change builds a fresh schema for each consultation,
limits clarification fields to unanswered supported values, and keeps
schema-violating output fail closed with the actual rejected field in the error.
It does not add an automatic retry, so each consultation still makes one Vertex
AI call.

Refs: #273

## Change classification (ARC-020)

- [x] Local (inside one module, contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- Failing-first regression: `d5e4001` made `make test-unit` fail with 225
  passing and 1 failing test because the schema had no field enum or item bounds
  and the diagnostic omitted the rejected field.
- Covered behavior: initial consultation permits the three supported fields;
  partial answers remove answered fields; complete answers require zero
  clarifications; fixed invalid responses remain fail closed; three
  consultations make exactly three model calls.
- How verified: `make format`, `make lint`, `make test-unit`, `make test`, and
  `make build` exited successfully.
- Robustness/idempotence: each call deep-copies the base schema, so prior answers
  cannot mutate later calls. No state-changing operation is involved.
- Not verified (be honest — GR-042): no paid Vertex AI or BigQuery request was
  executed. Browser verification and restart from the latest `main` remain
  pending until this fix is merged to `main`.

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated:
  `spikes/report-generation/README.md` and
  `docs/troubleshooting/live-demo.md`

## AI disclosure

- [x] Authored by AI agent: OpenAI Codex — self-review against
  `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes: Followed Issue #273 and the repository handoff. Used
  fixed local responses only; no real Vertex AI or BigQuery calls.

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)
