### PR TITLE
fix(demo): explain expired application-default credentials

### DIFF
--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -15,11 +15,11 @@ updated: 2026-08-10
 
 | 項目 | 現在地 |
 |------|--------|
-| 作業 | [Issue #319](https://github.com/Yukihide-Mitsuoka/repchat/issues/319)／[PR #320](https://github.com/Yukihide-Mitsuoka/repchat/pull/320) — 同じdocumentに共存する複数の回遊SankeyでSVG paint-server IDが衝突し、遷移線が消える不具合を固定データで修正する |
+| 作業 | [Issue #321](https://github.com/Yukihide-Mitsuoka/repchat/issues/321) — 期限切れADCを汎用エラーへ潰さず、安全な再認証・デモ再起動手順を画面へ表示する |
 | デモ実行状態 | 2026-08-10にPR #316 merge後の`main`から`kotonoha-bi-dev`向けローカルデモを再起動し、`http://127.0.0.1:8765/`のHTTP 200とブラウザerror/warning 0を確認した。起動だけではVertex AI・BigQueryを呼んでいない。画面操作による実生成は従来どおり個別の費用確認を必要とする |
-| 直近完了 | [PR #318](https://github.com/Yukihide-Mitsuoka/repchat/pull/318)はmerge済みで、会議報告を意思決定、担当付きアクション、次回の効果検証へ接続する将来要件を記録した |
+| 直近完了 | [PR #320](https://github.com/Yukihide-Mitsuoka/repchat/pull/320)はmerge済みで、同一document内に共存する複数のSankey SVGでpaint-server IDを分離した |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
-| AIができること | Issue #319を固定データで再現し、SankeyごとのSVG ID名前空間、same-SVG参照テスト、トラブルシューティングを修正する。実Vertex AI、実BigQuery、有料契約は今回行わない |
+| AIができること | Issue #321を固定例外で再現し、期限切れADCだけを安全な復旧手順へ分類する。実Vertex AI、実BigQuery、有料契約は今回行わない |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |
 | 完了時 | 証拠を`proceed` / `revise` / `reject`に分類し、Issue #160と[status](status.md)を更新する。方向が変わる場合だけpositioning、ADR、decision logを更新する |
 
@@ -50,7 +50,8 @@ updated: 2026-08-10
 
 | 条件 | 次の作業 | 先に読む正本 |
 |------|----------|--------------|
-| 現在のデモ阻害 | [#319 Sankey SVG ID分離](https://github.com/Yukihide-Mitsuoka/repchat/issues/319)／[PR #320](https://github.com/Yukihide-Mitsuoka/repchat/pull/320)。複数workspaceのSVG ID衝突を修正し、固定データで二つ同時描画を検証する | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md)、`live_demo.py` |
+| 現在のデモ阻害 | [#321 ADC再認証エラー](https://github.com/Yukihide-Mitsuoka/repchat/issues/321)。`RefreshError`を安全な復旧手順へ変換し、ADC再認証後にデモを再起動する。実問い合わせは費用再確認後だけ行う | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md)、`live_demo.py` |
+| 直近のデモ修正 | [#319 Sankey SVG ID分離](https://github.com/Yukihide-Mitsuoka/repchat/issues/319)／[PR #320](https://github.com/Yukihide-Mitsuoka/repchat/pull/320)。複数workspaceのSVG ID衝突を修正し、固定データで二つ同時描画を検証済み | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md)、`live_demo.py` |
 | 現在の要件記録 | [#317 会議意思決定ループ](https://github.com/Yukihide-Mitsuoka/repchat/issues/317)／[PR #318](https://github.com/Yukihide-Mitsuoka/repchat/pull/318)。会議報告を最大3件の意思決定、担当付きアクション、次回の効果検証へ接続する将来要件を記録する。Issue #160判定前に実装しない | [会議意思決定ループ要件](requirements/meeting-decision-loop.md)、[適応型分析メモリー要件](requirements/adaptive-analysis-memory.md)、Issue #181 |
 | Vertex AI費用表示の横断修正 | [#311 thought token accounting](https://github.com/Yukihide-Mitsuoka/repchat/issues/311)。分析計画とSQL生成もthought tokensを費用へ含める。#310へ混ぜず、固定応答で別途修正する | [demo](demo.md)、`analysis_planner.py`、`run_report.py` |
 | doctorの基盤テストtimeout | [#315 setup-github wrapper timeout](https://github.com/Yukihide-Mitsuoka/repchat/issues/315)。`make doctor`の`setup-github.sh` wrapper testが5秒timeoutした。再実行で成功扱いにせず、Gemini切替とは別に原因を調査する | `scripts/setup-github.sh`、`scripts/tests/test_setup_github_wrapper.py` |
@@ -74,7 +75,7 @@ positioningとroadmapを再評価します。
 
 ## 次にやる順序（2026-08-10）
 
-1. **現在:** [Issue #319](https://github.com/Yukihide-Mitsuoka/repchat/issues/319)でSankey SVGごとのpaint-server IDを分離し、ダッシュボードと単一グラフの共存時も遷移線を描画できることを固定データで確認する。実Vertex AI、実BigQueryは行わない。
+1. **現在:** [Issue #321](https://github.com/Yukihide-Mitsuoka/repchat/issues/321)で期限切れADCを安全な再認証・デモ再起動手順へ変換し、固定例外で確認する。実Vertex AI、実BigQueryは行わない。
 2. **デモ確認:** PR #297 merge後のローカルデモはHTTP 200を確認済み。会議報告の実再生成はVertex AI費用（Gemini 3.6 Flashの画面上限目安約¥25）を再提示し、承認後に1回だけ確認する。
 3. **オーナー承認後:** 実Vertex AI相談を1回確認する。成功後、別の費用確認を経てダッシュボードbuildを実行し、連続同一ページ統合後のR17参照値、色、リンク値、2ページ目終了注記、取得データを確認する。
 4. **並行するオーナー作業:** [#160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)の参加者を選定して日程を決める。デモ阻害を解消後に5分デモを行い、`proceed` / `revise` / `reject`へ分類する。

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -15,7 +15,7 @@ updated: 2026-08-10
 
 | 項目 | 現在地 |
 |------|--------|
-| 作業 | [Issue #321](https://github.com/Yukihide-Mitsuoka/repchat/issues/321) — 期限切れADCを汎用エラーへ潰さず、安全な再認証・デモ再起動手順を画面へ表示する |
+| 作業 | [Issue #321](https://github.com/Yukihide-Mitsuoka/repchat/issues/321)／[PR #322](https://github.com/Yukihide-Mitsuoka/repchat/pull/322) — 期限切れADCを汎用エラーへ潰さず、安全な再認証・デモ再起動手順を画面へ表示する |
 | デモ実行状態 | 2026-08-10にPR #316 merge後の`main`から`kotonoha-bi-dev`向けローカルデモを再起動し、`http://127.0.0.1:8765/`のHTTP 200とブラウザerror/warning 0を確認した。起動だけではVertex AI・BigQueryを呼んでいない。画面操作による実生成は従来どおり個別の費用確認を必要とする |
 | 直近完了 | [PR #320](https://github.com/Yukihide-Mitsuoka/repchat/pull/320)はmerge済みで、同一document内に共存する複数のSankey SVGでpaint-server IDを分離した |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
@@ -50,7 +50,7 @@ updated: 2026-08-10
 
 | 条件 | 次の作業 | 先に読む正本 |
 |------|----------|--------------|
-| 現在のデモ阻害 | [#321 ADC再認証エラー](https://github.com/Yukihide-Mitsuoka/repchat/issues/321)。`RefreshError`を安全な復旧手順へ変換し、ADC再認証後にデモを再起動する。実問い合わせは費用再確認後だけ行う | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md)、`live_demo.py` |
+| 現在のデモ阻害 | [#321 ADC再認証エラー](https://github.com/Yukihide-Mitsuoka/repchat/issues/321)／[PR #322](https://github.com/Yukihide-Mitsuoka/repchat/pull/322)。`RefreshError`を安全な復旧手順へ変換し、ADC再認証後にデモを再起動する。実問い合わせは費用再確認後だけ行う | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md)、`live_demo.py` |
 | 直近のデモ修正 | [#319 Sankey SVG ID分離](https://github.com/Yukihide-Mitsuoka/repchat/issues/319)／[PR #320](https://github.com/Yukihide-Mitsuoka/repchat/pull/320)。複数workspaceのSVG ID衝突を修正し、固定データで二つ同時描画を検証済み | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md)、`live_demo.py` |
 | 現在の要件記録 | [#317 会議意思決定ループ](https://github.com/Yukihide-Mitsuoka/repchat/issues/317)／[PR #318](https://github.com/Yukihide-Mitsuoka/repchat/pull/318)。会議報告を最大3件の意思決定、担当付きアクション、次回の効果検証へ接続する将来要件を記録する。Issue #160判定前に実装しない | [会議意思決定ループ要件](requirements/meeting-decision-loop.md)、[適応型分析メモリー要件](requirements/adaptive-analysis-memory.md)、Issue #181 |
 | Vertex AI費用表示の横断修正 | [#311 thought token accounting](https://github.com/Yukihide-Mitsuoka/repchat/issues/311)。分析計画とSQL生成もthought tokensを費用へ含める。#310へ混ぜず、固定応答で別途修正する | [demo](demo.md)、`analysis_planner.py`、`run_report.py` |

--- a/docs/troubleshooting/live-demo.md
+++ b/docs/troubleshooting/live-demo.md
@@ -10,6 +10,28 @@ updated: 2026-08-10
 この文書は、`make demo-live`が結果の描画を停止した場合の確認方法を示します。実Vertex AIまたは
 BigQueryを再実行する前に、画面のエラーと生成済みSQLを確認してください。
 
+## 「Google Cloudの認証期限が切れています」で停止する
+
+**Affects:** Issue #321修正前は、ADCのrefresh tokenが再認証を要求すると「生成または実行に失敗しました。
+端末ログを確認してください。」という汎用エラーだけを表示していました。
+
+**Cause:** Vertex AIまたはBigQueryへの接続時に`google.auth.exceptions.RefreshError`が発生しましたが、
+認証期限切れを安全な利用者向けエラーへ分類していませんでした。SQL生成やSankey描画の不具合ではありません。
+
+**Fix:** 次を実行してブラウザでADCを再認証し、古いcredential objectを破棄するためデモを再起動します。
+
+```bash
+gcloud auth application-default login
+make demo-live PROJECT=<project>
+```
+
+修正版は認証期限切れを画面へ明示し、認証情報やGoogle SDKの例外本文は表示しません。失敗した問い合わせを
+自動再実行しないため、再認証後も画面の費用確認を経て利用者が明示的に実行します。
+
+**Prevention:** 固定例外を使うHTTP回帰テストで復旧手順と機密な例外本文の非表示を検証します。
+
+**Refs:** [Issue #321](https://github.com/Yukihide-Mitsuoka/repchat/issues/321)
+
 ## 会議報告が出力上限までに完了しない
 
 **Affects:** Issue #310修正前の会議報告アシスト。

--- a/spikes/report-generation/live_demo.py
+++ b/spikes/report-generation/live_demo.py
@@ -137,6 +137,26 @@ class LiveDemoError(RuntimeError):
     """A local-demo failure that is safe to show in the browser."""
 
 
+def google_auth_recovery_message(error: Exception) -> str | None:
+    """Return a bounded recovery instruction for an expired Google ADC chain."""
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        error_type = type(current)
+        if (
+            error_type.__module__ == "google.auth.exceptions"
+            and error_type.__name__ == "RefreshError"
+        ):
+            return (
+                "Google Cloudの認証期限が切れています。"
+                "gcloud auth application-default loginを実行し、デモを再起動してください。"
+                "今回の処理は自動再実行していません。"
+            )
+        current = current.__cause__ or current.__context__
+    return None
+
+
 def period_for_question(question: str) -> dict[str, str]:
     """Return the explicit month in a question, bounded by the demo dataset."""
     match = re.search(r"(?P<year>\d{4})年\s*(?P<month>\d{1,2})月", question)
@@ -820,6 +840,11 @@ class LiveDemoHandler(BaseHTTPRequestHandler):
         except LiveDemoError as error:
             emit({"type": "error", "message": str(error)})
         except Exception as error:  # noqa: BLE001 — details stay server-side
+            recovery_message = google_auth_recovery_message(error)
+            if recovery_message:
+                print("live query failed: Google authentication expired", flush=True)
+                emit({"type": "error", "message": recovery_message})
+                return
             print(f"live query failed: {type(error).__name__}", flush=True)
             emit({"type": "error", "message": "生成または実行に失敗しました。端末ログを確認してください。"})
     def _headers(self, content_type: str) -> None:

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -907,6 +907,31 @@ finally:s.shutdown();s.server_close();t.join()
   assert.match(bind.stderr, /host must remain localhost-only/);
 });
 
+test('expired application-default credentials return a safe recovery instruction', () => {
+  const result = python(`
+import threading,urllib.request
+RefreshError=type("RefreshError",(Exception,),{})
+RefreshError.__module__="google.auth.exceptions"
+class E:
+ spec=json.loads((m.HERE/"report.json").read_text())
+ def query(self,_question,_emit):raise RefreshError("sensitive credential detail")
+s=m.create_server("127.0.0.1",0,E());t=threading.Thread(target=s.serve_forever,daemon=True);t.start();base=f"http://127.0.0.1:{s.server_port}"
+try:
+ req=urllib.request.Request(base+"/api/query",data=json.dumps({"question":"2021年1月のセッション数を出して"}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
+ event=json.loads(urllib.request.urlopen(req).read().decode())
+ print(json.dumps(event,ensure_ascii=False))
+finally:s.shutdown();s.server_close();t.join()
+`);
+  assert.equal(result.status, 0, result.stderr);
+  const event = JSON.parse(result.stdout.split('\n').find((line) => line.startsWith('{')) ?? '');
+  assert.deepEqual(event, {
+    type: 'error',
+    message:
+      'Google Cloudの認証期限が切れています。gcloud auth application-default loginを実行し、デモを再起動してください。今回の処理は自動再実行していません。',
+  });
+  assert.doesNotMatch(result.stdout, /sensitive credential detail/);
+});
+
 test('dashboard HTTP boundary accepts a bounded confirmed plan larger than a simple query', () => {
   const result = python(`
 import threading,urllib.error,urllib.request


### PR DESCRIPTION
## What & why

単一グラフ生成時のADC期限切れが予期しない例外として扱われ、画面には復旧不能な汎用エラーだけが表示されていました。Google ADCの`RefreshError`だけを例外チェーンから限定分類し、`gcloud auth application-default login`とデモ再起動を案内します。SDKの例外本文や認証情報はブラウザへ出さず、自動再実行もしません。

Closes: #321

## Change classification (ARC-020)

- [x] Local (inside one module, contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- Failing-first regression: 4ad065e（汎用エラーと期待する再認証案内の差で失敗）
- How verified: `make format`、`make lint`、`make test-unit`（240 pass）、`make test`（240 pass）、実`google.auth.exceptions.RefreshError`固定インスタンスで案内文を確認
- Not verified (be honest — GR-042): ADC再認証と実Vertex AI・BigQuery再実行は未実施。追加料金は発生させていない。

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: `docs/development-handoff.md`、`docs/troubleshooting/live-demo.md`

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes: サンキー実行の汎用エラーを、追加クエリなしのADC認証確認でRefreshErrorと特定。

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)