### PR TITLE
docs: compare Evidence Cloud and RepChat product strengths

### DIFF
--- a/docs/competitive-landscape.md
+++ b/docs/competitive-landscape.md
@@ -1,16 +1,16 @@
 ---
 id: competitive-landscape
-title: 競合比較 — 構想と既存製品の重なり（2026-07-30 時点）
-updated: 2026-07-30
+title: 競合比較 — 構想と既存製品の重なり
+updated: 2026-08-11
 ---
 
 # 競合比較
 
 ## この文書の役割と限界
 
-**2026-07-27 に各社の公開ページを取得して作成しました。** 記憶ではなく当日の記述に基づきます。
-ただし**この領域は動きが速く、価格も機能も変わります**。半年後にそのまま信じないでください。
-再確認するときは、同じ7項目で各社のトップページと料金ページを取り直すのが最短です。
+各社比較の基礎は2026-07-27の公開情報です。Evidence Cloudだけは2026-08-11に公式製品ページと
+Evidence Studio公式文書で再確認しました。価格と機能は変わるため、導入判断時には同じ項目を
+公式製品ページ、公式文書、見積で再確認します。
 
 比較対象は「[discovery-log](discovery-log.md) の構想 ＝ Git管理・安全な権限管理・複数DWH接続・
 自然言語SQL生成・自動ダッシュボード生成・チャットUI」と重なる製品に限定しています。
@@ -21,15 +21,15 @@ updated: 2026-07-30
 |---|---|---|---|---|---|---|
 | **コード管理・Git** | ✅ SQL＋markdown、バージョン管理 | ✅ Git連携＋dbt | ✅ **AML で定義、PRでレビュー・ロールバック** | ✅ **セマンティック層がGit、PRでレビュー** | ✅ dbtネイティブ、CI/CD | ❌ アプリDB |
 | **セマンティック層** | △ | ✅ | ✅ AML / AQL | ✅ | ✅ dbt由来 | △ |
-| **自然言語・AI** | ✅ AIエージェント（markdown生成） | ✅ チャット | ✅ 平易な言葉で質問、要約、**曖昧なら聞き返す** | ✅ **NL第一。回答に出典** | ✅ AIエージェント＋MCP | ✅ 全プランでAI質問 |
+| **自然言語・AI** | ✅ page／filterを理解するAnalytics Agent、Insight保存、Slack／MCP | ✅ チャット | ✅ 平易な言葉で質問、要約、**曖昧なら聞き返す** | ✅ **NL第一。回答に出典** | ✅ AIエージェント＋MCP | ✅ 全プランでAI質問 |
 | **BigQuery** | ✅ | ✅ | ✅ | ✅ | 記載なし（要確認） | ✅ |
-| **行レベル権限** | ✅ **Team以上** | ✅ アクセスフィルタ | ✅ **行・列** | ✅ ロールベース | 記載なし（要確認） | ✅ **Proのみ** |
-| **埋め込み・マルチテナント** | ✅ Enterprise | ✅ ホワイトラベル＋SSO | ✅ **同じ層でテナント別セキュリティ** | — | ✅ 従量課金の別枠 | ✅ Proのみ |
-| **価格** | **$15/人/月**（Team）<br>$25/人/月（Pro） | 非公開 | 非公開 | 非公開 | **$3,000/月 定額・席数無制限**<br>OSS版は無料 | $100/月＋$6/人<br>**Pro $575/月＋$12/人** |
+| **行レベル権限** | ✅ **Enterprise**。Team／Proは非対応 | ✅ アクセスフィルタ | ✅ **行・列** | ✅ ロールベース | 記載なし（要確認） | ✅ **Proのみ** |
+| **埋め込み・マルチテナント** | ✅ Enterprise。公開済みpageをAPI＋iframeで配信 | ✅ ホワイトラベル＋SSO | ✅ **同じ層でテナント別セキュリティ** | — | ✅ 従量課金の別枠 | ✅ Proのみ |
+| **価格** | Team **$15/人・月**、Pro **$25/人・月**、Enterpriseは個別見積 | 非公開 | 非公開 | 非公開 | **$3,000/月 定額・席数無制限**<br>OSS版は無料 | $100/月＋$6/人<br>**Pro $575/月＋$12/人** |
 | **対象** | — | スタートアップ〜大企業 | データチーム全般 | **大企業**（Verizon等） | データチーム | 全般 |
-| **「何を見ればいいか分からない人」への対応** | ❌ | ❌ | ❌ | △ AIアナリストを標榜 | ❌ | ❌ |
-| **日本語・国内対応** | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **請求書払い** | ❌ 自己申込（カード） | 不明 | 不明 | 不明 | 不明 | ❌ 自己申込（カード） |
+| **「何を見ればいいか分からない人」への対応** | △ custom skillsで確認質問・分析手順を定義可能 | ❌ | ❌ | △ AIアナリストを標榜 | ❌ | ❌ |
+| **日本語・国内対応** | 埋め込みはlanguage指定可。日本語の導入支援・契約実務は未確認 | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **請求書払い** | 未確認 | 不明 | 不明 | 不明 | 不明 | ❌ 自己申込（カード） |
 | **実質的な競合か**（日本のSMB視点） | **◎ 本命** | ✕ 土俵が違う | ✕ 土俵が違う | ✕ 土俵が違う | △ 定額が重い／OSSは要運用 | **◎** |
 
 ## 実際に置き換える相手 — 上の表には載っていません
@@ -89,33 +89,55 @@ Amplitude は**変数を切り分ける自然実験**になっており、残る
 **Zenlytic** は自然言語を第一の入口に置き、その精度をGit管理のセマンティック層で担保しています。
 **「AIの出力をPRでレビューする」という構想の中核は、既に実装されています。**
 
-### 2. Evidence Cloud が最大の問題です
+### 2. Evidence Cloudは機能の直接競合です
 
-**$15/人/月（Team）に、行レベルセキュリティ・ページ単位のアクセス制御・AIクレジットが含まれます。**
+2026-08-11時点の公式情報では、EvidenceはRepChatが検討している主要な機構を既に製品化しています。
 
-構想していた月3,000〜6,000円は、**土台にしている製品の商用版より高い**ことになります。
-しかも向こうは既に、こちらが未実装の機能（行レベル権限、ページ単位制御、SSO）を売っています。
+| 領域 | Evidenceの公式仕様 | RepChatへの含意 |
+|------|--------------------|-----------------|
+| 分析agent | 現在のpageとfilterを文脈にし、chart、query、source付き回答を作り、Insightとして保存する | 自然言語質問と根拠表示だけでは差別化にならない |
+| channel | SlackとMCP client（Claude Desktop、ChatGPTを含む）から利用できる | SlackをUIにすること自体は差別化にならない |
+| context | custom context、skills、evals、observabilityを提供する | 顧客固有contextや分析手順の保存だけでは差別化にならない |
+| authoring | Evidence Studioのeditor、AI差分提案、live preview、Git branch、review、publishを提供する | SQL／Markdown、Git、AI編集、branch previewだけでは差別化にならない |
+| embedded delivery | Enterprise Planで、公開済みpageをbackend APIから取得したsingle-use URLでiframe表示し、JWE、RLS、theme、language、session TTLを適用する | 埋め込み、white-label、RLSだけでは差別化にならない |
 
-「Evidenceを土台に、権限管理を足して売る」という形は、**提供元が同じことを安くやっている**
-という構図です。
+#### Embedded Analyticsは編集機能ではない
 
-#### 2026-07-30追記：SlackをUIにしても単独では差別化にならない
+EvidenceのEmbedded Analyticsは、**作成済み・公開済みのpageを顧客の製品内へ安全に配信する機能**です。
+顧客側backendが認証済み利用者のembed URLを発行し、frontendがiframeで表示します。URLは一回限りで
+2分以内に使用し、開いた後のsessionは指定TTLに従います。利用者属性はJWEで暗号化され、RLSへ渡されます。
 
-Evidenceの現行公開ページには、dashboard/data app、AI Chat、AI支援開発、RLS、page access、埋め込みが
-掲載されている。公開情報から、end userがSlackで自然言語質問を行う同等機能までは確認できなかったが、
-**未掲載であることは持続的な優位を意味しない**。Slack通知やbotは各社が追加できるinterfaceである。
+レポートを作成・修正する場所はEvidence StudioまたはGit／CLIです。閲覧者はfilterやinputを操作できますが、
+Embedded Analytics自体がSQL editor、自由layout editor、またはGit branch操作を顧客製品へ埋め込むわけでは
+ありません。したがって、RepChatで検討しているWeb SQL workspaceとversioned panel compositionは
+**authoring**、顧客製品内表示は**delivery**であり、補完関係にあります。
 
-RepChatが検証すべき差は、Slackそのものではなく次の一連のworkflowである。
+#### SQL Consoleとcustom reportは別の面です
 
-- 日本語の会話から「何を分析するか」を分解し、複数KPIとdashboardへまとめる
-- 代理店workspace内の複数顧客をchannel単位で分離し、Webと同じ認可・監査を通す
-- 指標定義、生成SQL、検証結果、immutable revisionを一つの来歴として残す
-- Slackは要約・graph・linkの入口、Webはdashboard・SQL・定義の正本として役割分担する
+SQL Consoleは、接続済みdataを任意SQLで探索するself-service面です。RepChatで提案済みの
+Web SQL workspaceに最も近い機能ですが、SQL Console単体をcustom report editorとは扱いません。
+2026-08-11に確認した公式文書からは、Consoleのqueryを一操作でreportへ昇格する契約までは確認できません。
 
-ただし、このworkflowもSQLが正しくなければ価値にならない。公開GA4 schemaでの成功は、未知の独自
-nested schemaへの一般化を証明しないため、Issue #188を自由質問機能の実装gateにする。
+custom reportの作成面はEvidence StudioのReport Editorです。pageはMarkdown、SQL、componentで構成され、
+Evidence Agentが生成または編集する場合もdiffを利用者がaccept／rejectします。accept後のreport sourceは
+Developer／AdminがeditorまたはGit／CLIで編集できます。Viewer／Org Viewerはeditorへアクセスできません。
 
-参照: [Evidence](https://evidence.dev/)、[Evidence documentation](https://docs.evidence.dev/)、
+ただし「全graphに編集可能な生成SQLが一つずつ存在する」とは限りません。Evidence Studioのcomponentは
+data sourceと集計式を直接参照でき、page内inline SQLやstandalone SQL fileを使う構成もあります。
+編集可能なのはreport source全体であり、必ずしも各graph専用の明示SQL fileではありません。
+
+公式料金ページの2026-08-11表示では、Teamは$15/人・月、Proは$25/人・月、Enterpriseは個別見積です。
+Embedded、white labeling、RLS、multi-regionはEnterpriseです。価格と機能表は契約時に再確認します。
+
+参照: [Evidence](https://evidence.dev/)、
+[Analytics Agent](https://evidence.dev/product/analytics-agent)、
+[Pricing](https://evidence.dev/pricing)、
+[Evidence Studio editing](https://docs.evidence.studio/editing)、
+[Markdown](https://docs.evidence.studio/core-concepts/markdown)、
+[Publishing and roles](https://docs.evidence.studio/publishing)、
+[Studio migration guide](https://docs.evidence.studio/migration-guide)、
+[Version control](https://docs.evidence.studio/features/version-control)、
+[Embedded Analytics](https://docs.evidence.studio/features/embedded)、
 [Slack分析インターフェース要件](requirements/slack-analysis-interface.md)
 
 ### 3. 席数課金そのものへの逆風
@@ -125,30 +147,28 @@ nested schemaへの一般化を証明しないため、Issue #188を自由質問
 
 ユーザー単位課金は、**ある規模を超えると必ず定額製品と比較されます**。
 
-### 4. 既存製品が解いているのは「SQLが書けない」であって「何を見ればいいか分からない」ではない
+### 4. 「何を見ればいいか」の支援も機能名だけでは差になりません
 
-**この表で唯一、どの列も埋まっていない行**がこれです。
+Evidenceはcustom skillsで確認質問や分析手順を定義でき、公式ページはhealth check、churn調査、board prep
+などを利用例に挙げています。したがって「何を見ればよいか分からない人への対応が競合にない」という
+旧仮説は、2026-08-11時点では事実として使えません。
 
-各社が競っているのは**質問を投げる手段**（自然言語、チャット、セマンティック層による精度担保）です。
-しかしこれは**利用者が「何を聞くべきか」を分かっていること**を前提にしています。BIの席が
-導入後に使われなくなる典型的な理由は、SQLが書けないことではなく、**何を見ればよいか分からない**
-ことです。**チャットUIを足しても、この前提は解消しません。**
+残る検証対象は、**日本語の代理店業務で、利用者が目的だけを伝えた後に、KPI、比較軸、期間、panel構成、
+根拠、会議で決めるべきactionまでを少ない確認回数で合意できるか**です。機能の有無ではなく、対象業務での
+完了率、正確性、所要時間で比較します。
 
 | | 利用者に要求されるもの | 使える人 |
 |---|---|---|
 | チャット | **何を聞くべきか分かっていること** | 分析ができる少数 |
 | ダッシュボード | 見るだけ | **全員** |
 
-したがって「自動でダッシュボード生成」は**出力形式の話ではありません**。
-**「質問できない人」を利用者に含めるための手段**です。チャットは**作る側の入口**、
-ダッシュボードは**使う側の入口**で、役割が違います。
+「自動でダッシュボード生成」は、質問を一つのchartへ変える機能ではありません。RepChatで検証する対象は、
+分析目的を複数の判断可能なKPIとpanelへ分解し、利用者の確認を経て固定成果物へ変える一連の操作です。
+チャットは作成時の入口、ダッシュボードは継続利用の入口として役割を分けます。
 
-これは土台の選択とも整合します。Evidence は**永続するページを生成する**ので固定物が自然に残りますが、
-チャット中心の製品では回答が流れて消えます。
-
-**ただし、正確に言う必要があります。** ダッシュボード機能はどの製品にもあります。差になりうるのは
-**「誰がダッシュボードの中身を決めるか」**です。既存製品では**何を見るべきか分かっている人間**が
-作ります。ここを埋められるかどうかが論点であって、ダッシュボードの有無ではありません。
+Evidenceも回答をInsightへ保存し、管理対象pageへ昇格できます。永続する成果物、Insight保存、
+dashboardへの追加もRepChat固有ではありません。比較すべき対象は、成果物の有無ではなく、分析計画の
+合意、費用確認、根拠検証、顧客別の認可、会議actionまでのworkflowです。
 
 #### この仮説に対する反証材料
 
@@ -160,25 +180,23 @@ nested schemaへの一般化を証明しないため、Issue #188を自由質問
 業務文脈であり、それは業種ごとに異なります。**横断的に薄く当てるより、業種を絞る方が成立しやすい**
 可能性がありますが、これも未検証です。
 
-**Zenlytic が最も近い位置にいます。**「レポート・プレゼン資料・Excelモデルを生成するAIデータアナリスト」
-を標榜しており、定期配信のAIダイジェストを各社が足すのは技術的に容易です。
-**数ヶ月で埋まりうる差**と見るべきで、恒久的な優位ではありません。
+EvidenceとZenlyticはいずれも近い位置にいます。定期配信、会議用要約、確認質問、分析playbookは
+競合が追加できるため、個別機能を恒久的な優位として扱いません。
 
 ## それでも残りうる差別化
 
-技術ではなく、**市場と言語**の側にあります。
+候補は個別技術ではなく、対象顧客とworkflowの組合せです。
 
-- **「質問できない人」を利用者に含めること**（上記4）— どの列も埋まっていない唯一の行。
-  ただし**未検証の仮説**であり、Zenlyticの方向と競合し、数ヶ月で埋まりうる
-- **日本語・日本市場** — 上記はすべて英語圏の製品で、日本のSMBに対する言語・サポート・
-  請求書払い・商習慣への対応は薄い。**個人事業主が現実に守れる領域**はここ
-- **接続が退職で壊れない** — 正面から売っている製品を見ない
-  （[ADR-0010](adr/0010-connection-identity-is-never-a-person.md) D1）
-- **価格帯と対象規模** — Zenlyticは大企業向け、Lightdashは月$3,000。
-  **「エンジニア1人の小さな会社」という帯は、上位製品が降りてこない**
+| 差別化候補 | 現在の根拠 | 現在の判定 |
+|------------|------------|------------|
+| 日本の小規模代理店が複数顧客を安全に扱う運用 | 主要顧客は確定。製品統合は未完了 | 検証対象 |
+| 日本語で目的を分解し、KPI・panel・費用を確認してから実行 | ローカルデモにprototypeあり | 実顧客比較が必要 |
+| 根拠外数値を拒否する会議報告と、決定・owner・次回検証のloop | strict validatorはprototype、意思決定loopは将来要件 | 現在の製品優位とは主張しない |
+| 接続主体を人から分離し、担当者退職で壊れない | ADR-0010で設計確定 | 運用価値をデザインパートナーで確認 |
+| 日本語の導入支援、請求、説明責任 | 提供方針。競合の国内契約実務は未確認 | 営業比較が必要 |
 
-**逆に、技術的な差別化として当てにできないもの**: 自然言語SQL、セマンティック層、Git管理、
-行レベル権限。**すべて既に複数社が持っています。**
+自然言語SQL、セマンティック層、Git管理、Insight保存、Slack／MCP、custom context／skills、RLS、
+埋め込みはEvidenceを含む競合が提供しているため、単独の差別化として使いません。
 
 ## この文書が示唆する行動
 
@@ -198,8 +216,13 @@ Metabase を使っていないのか」**です。これは机上では答えが
 
 補助として「何を使っていますか」「なぜそれを選びましたか」。**説明ではなく質問だけで済みます。**
 
+Evidenceとの機能比較は公開ページの読解で終えません。同じ日本語の分析目的、同じschema、同じ既知値を使い、
+分析計画の確認回数、正答率、dashboard完成時間、根拠追跡、会議actionの採用率を測定します。RepChatが
+Evidenceを上回ったと主張できるのは、この比較で差が再現された後です。
+
 ## 関連
 
 - [.ai/decision-log.md](../.ai/decision-log.md) — LOG-0062
 - [ai-governance-requirements.md](ai-governance-requirements.md) — 上位層の前提条件
+- [analysis-workspace-ui.md](requirements/analysis-workspace-ui.md) — authoring、publish、embedのUI境界
 - [status.md](status.md) — 実装状況

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -15,11 +15,11 @@ updated: 2026-08-11
 
 | 項目 | 現在地 |
 |------|--------|
-| 作業 | [Issue #179](https://github.com/Yukihide-Mitsuoka/repchat/issues/179)の情報設計 — merge済み[PR #334](https://github.com/Yukihide-Mitsuoka/repchat/pull/334)を基礎に、[PR #336](https://github.com/Yukihide-Mitsuoka/repchat/pull/336)でEvidence公式競合資料との対応、可視context、Insight／publish lifecycle、embedded previewを追加する |
+| 作業 | [Issue #338](https://github.com/Yukihide-Mitsuoka/repchat/issues/338) — Evidenceの現行公式仕様に合わせて競合比較、ポジショニング、authoring／publishing／embedded deliveryのUI境界を更新する |
 | デモ実行状態 | v1.16.0で左右paneを持つローカルprototypeまで実装済み。新しい要件文書は製品UIの設計成果であり、実装済み能力を増やさない。実Vertex AIとBigQueryは再実行しない |
-| 直近完了 | [PR #329](https://github.com/Yukihide-Mitsuoka/repchat/pull/329)のtemplate同期と[PR #327](https://github.com/Yukihide-Mitsuoka/repchat/pull/327)のv1.16.0 releaseはmerge済み |
+| 直近完了 | [PR #336](https://github.com/Yukihide-Mitsuoka/repchat/pull/336)のEvidence UI mappingと[PR #335](https://github.com/Yukihide-Mitsuoka/repchat/pull/335)のthought token費用計上はmerge済み |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
-| AIができること | Issue #179の要件文書をreview可能にし、出典、機能mapping、UI inventory、状態行列、受入条件、既存要件とのlinkを検証する。製品実装は開始しない |
+| AIができること | Issue #338の文書をreview可能にし、Evidence公式料金・製品・Studio文書の出典、競合比較、RepChatの実装／設計／将来構想の区分、埋め込みと編集の権限境界を検証する。製品実装は開始しない |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |
 | 完了時 | 証拠を`proceed` / `revise` / `reject`に分類し、Issue #160と[status](status.md)を更新する。方向が変わる場合だけpositioning、ADR、decision logを更新する |
 
@@ -28,7 +28,7 @@ updated: 2026-08-11
 1. [status §0](status.md#0-再開手順新しいaiセッション向け)と
    [§1](status.md#1-一行でいうと)で、実装済み範囲、費用、未検証事項を確認する。
 2. [positioning §0](positioning.md#0-前提の確認--勝負の土俵)、
-   [§2.7〜2.9](positioning.md#27-入口は既存の手作業レポートにする)、
+   [§2.7〜2.10](positioning.md#27-入口は既存の手作業レポートにする)、
    [§5](positioning.md#5-未検証の仮説と検証方法)で、対象顧客、差別化、検証対象を確認する。
 3. [roadmap](roadmap.md)で実施順序を確認する。
 4. 下の設計判断索引から、変更対象に関係するADRを全文読む。
@@ -49,6 +49,7 @@ strict validatorを維持し、生成経路だけで妥当な項目を保持、�
 
 | 条件 | 次の作業 | 先に読む正本 |
 |------|----------|--------------|
+| 現在の競合・配信境界整理 | [#338 Evidence positioning and embedded delivery](https://github.com/Yukihide-Mitsuoka/repchat/issues/338)。Evidence公式仕様を事実側へ置き、RepChatの差別化仮説とauthoring／publishing／embedded deliveryのroute・permission分離を記録する | [競合比較](competitive-landscape.md)、[ポジショニング](positioning.md)、[分析ワークスペースUI要件](requirements/analysis-workspace-ui.md) |
 | 現在のUI情報設計 | [#179 dashboard／SQL来歴UX](https://github.com/Yukihide-Mitsuoka/repchat/issues/179)。外部UIは情報構造の参考に限定し、RepChat機能mapping、左右pane、responsive、keyboard、可視context、Insight保存／昇格、review／publish、embedded previewを再現可能な要件として固定する。Issue #160判定前に製品実装しない | [分析ワークスペースUI要件](requirements/analysis-workspace-ui.md)、[デモ手順](demo.md)、Issue #179 |
 | 完了した会議報告修正 | [#295 evidence validation](https://github.com/Yukihide-Mitsuoka/repchat/issues/295)／[PR #333](https://github.com/Yukihide-Mitsuoka/repchat/pull/333)。strict validatorを維持し、生成経路では根拠外数値を含む項目だけを除外する | [トラブルシューティング](troubleshooting/live-demo.md)、`meeting_report.py` |
 | 直近のデモUX | [#328 analysis workspace shell](https://github.com/Yukihide-Mitsuoka/repchat/issues/328)／[PR #330](https://github.com/Yukihide-Mitsuoka/repchat/pull/330)。ダッシュボード、作成・編集、会議報告、単一グラフを分離し、左右ペインを個別に開閉・リサイズ可能にする。永続対話履歴とGit連携は将来機能と明記する | [デモ手順](demo.md)、`live_demo.py`、`live-demo.test.ts` |
@@ -56,7 +57,7 @@ strict validatorを維持し、生成経路だけで妥当な項目を保持、�
 | 直近の認証修正 | [#321 ADC再認証エラー](https://github.com/Yukihide-Mitsuoka/repchat/issues/321)／[PR #322](https://github.com/Yukihide-Mitsuoka/repchat/pull/322)。`RefreshError`を安全な復旧手順へ変換し、ADC再認証とデモ再起動を確認済み。実問い合わせは費用再確認後だけ行う | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md)、`live_demo.py` |
 | 直近のデモ修正 | [#319 Sankey SVG ID分離](https://github.com/Yukihide-Mitsuoka/repchat/issues/319)／[PR #320](https://github.com/Yukihide-Mitsuoka/repchat/pull/320)。複数workspaceのSVG ID衝突を修正し、固定データで二つ同時描画を検証済み | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md)、`live_demo.py` |
 | 現在の要件記録 | [#317 会議意思決定ループ](https://github.com/Yukihide-Mitsuoka/repchat/issues/317)／[PR #318](https://github.com/Yukihide-Mitsuoka/repchat/pull/318)。会議報告を最大3件の意思決定、担当付きアクション、次回の効果検証へ接続する将来要件を記録する。Issue #160判定前に実装しない | [会議意思決定ループ要件](requirements/meeting-decision-loop.md)、[適応型分析メモリー要件](requirements/adaptive-analysis-memory.md)、Issue #181 |
-| Vertex AI費用表示の横断修正 | [#311 thought token accounting](https://github.com/Yukihide-Mitsuoka/repchat/issues/311)。分析計画とSQL生成もthought tokensを費用へ含める。#310へ混ぜず、固定応答で別途修正する | [demo](demo.md)、`analysis_planner.py`、`run_report.py` |
+| 完了したVertex AI費用表示修正 | [#311 thought token accounting](https://github.com/Yukihide-Mitsuoka/repchat/issues/311)／[PR #335](https://github.com/Yukihide-Mitsuoka/repchat/pull/335)。分析計画とSQL生成のthought tokensを費用へ含める | [demo](demo.md)、`analysis_planner.py`、`run_report.py` |
 | doctorの基盤テストtimeout | [#315 setup-github wrapper timeout](https://github.com/Yukihide-Mitsuoka/repchat/issues/315)。`make doctor`の`setup-github.sh` wrapper testが5秒timeoutした。再実行で成功扱いにせず、Gemini切替とは別に原因を調査する | `scripts/setup-github.sh`、`scripts/tests/test_setup_github_wrapper.py` |
 | 現在のpanel合成設計 | [#308 versioned panel composition](https://github.com/Yukihide-Mitsuoka/repchat/issues/308)。AI生成原本を上書きせず、参照追加・fork・利用者作成panelを派生dashboard revisionで合成するproposed ADRをreviewする | ADR-0013/0014/0015、ADR-0022、Issue #179/#180 |
 | 現在のbuild費用設計 | [#306 cost-gated shared intermediates](https://github.com/Yukihide-Mitsuoka/repchat/issues/306)。direct実行を既定とし、実測thresholdを満たすbuildだけに共有中間結果を提案するproposed ADRをreviewする | ADR-0013/0014/0015、ADR-0021、Issue #180 |
@@ -76,9 +77,9 @@ strict validatorを維持し、生成経路だけで妥当な項目を保持、�
 `#160`が`revise`または`reject`の場合は、上表の製品タスクへ進まず、観測結果に基づいて
 positioningとroadmapを再評価します。
 
-## 次にやる順序（2026-08-10）
+## 次にやる順序（2026-08-11）
 
-1. **現在:** [Issue #179](https://github.com/Yukihide-Mitsuoka/repchat/issues/179)の情報設計として、[分析ワークスペースUI要件](requirements/analysis-workspace-ui.md)をreviewし、外部資料の事実、公開画面観測、オーナー要望、RepChat固有判断の区分と、機能mapping、pane状態、受入条件を確定する。製品実装は開始しない。
+1. **現在:** [Issue #338](https://github.com/Yukihide-Mitsuoka/repchat/issues/338)で、Evidenceの機能を競合事実として更新し、RepChatの差別化仮説とauthoring／publishing／embedded deliveryの境界をreviewする。製品実装は開始しない。
 2. **デモ確認:** PR #297 merge後のローカルデモはHTTP 200を確認済み。会議報告の実再生成はVertex AI費用（Gemini 3.6 Flashの画面上限目安約¥25）を再提示し、承認後に1回だけ確認する。
 3. **オーナー承認後:** 実Vertex AI相談を1回確認する。成功後、別の費用確認を経てダッシュボードbuildを実行し、連続同一ページ統合後のR17参照値、色、リンク値、2ページ目終了注記、取得データを確認する。
 4. **並行するオーナー作業:** [#160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)の参加者を選定して日程を決める。デモ阻害を解消後に5分デモを行い、`proceed` / `revise` / `reject`へ分類する。

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,7 +1,7 @@
 ---
 id: positioning
 title: ポジショニング — 何で戦い、何で戦わないか
-updated: 2026-07-29
+updated: 2026-08-11
 ---
 
 # ポジショニング
@@ -129,9 +129,9 @@ AIが**正しい**ダッシュボードを作れる必要があり、スキー�
 
 ### 2.2 日本語ドキュメント
 
-海外製品は英語で、かつ dbt やウェアハウスの知識を前提にしています。
-**「日本語で、自社のBigQueryに繋ぐ手順が最初から最後まで書いてある」**は、
-エンジニア1人の会社には実質的な差です。
+Evidence Studioの公式文書は英語が中心ですが、Embedded Analyticsは表示languageを指定できます。
+したがって「画面が日本語である」だけを差別化にしません。**日本語で、自社のBigQuery接続、権限、
+AIへ渡す情報、費用、失敗時の復旧まで説明できること**を提供範囲にします。
 
 **追加コストがほぼゼロの差別化は稀**なので、優先度は高い。
 
@@ -147,10 +147,10 @@ AIが**正しい**ダッシュボードを作れる必要があり、スキー�
 
 ### 2.4 請求書払い・銀行振込
 
-Evidence Cloud も Metabase も**クレジットカードの自己申込**です。日本のSMBには、
-業務ソフトをカード決済する稟議が通らない会社が実在します。
+Evidence Cloudの現在の契約・請求方法は営業確認が必要です。日本のSMBには、業務ソフトを
+カード決済できない会社が実在するため、RepChatは請求書払い・銀行振込へ対応します。
 
-**個人事業主なら明日から対応でき、海外SaaSには当面できません。** 地味ですが決定的な場面があります。
+請求方法が選定条件になるかはデザインパートナーへ確認し、Evidenceの対応可否は営業見積で比較します。
 
 ### 2.5 接続作業をサービスに含める
 
@@ -162,8 +162,8 @@ Evidence Cloud も Metabase も**クレジットカードの自己申込**です
 
 ### 2.6 価格（単独では堀にならない）
 
-Gemini Flash が1問約¥0.1、インフラも数千円規模なので、**Evidence Cloud の $15/人・月を下回っても
-十分黒字**です。
+[競合比較 §2](competitive-landscape.md#2-evidence-cloudは機能の直接競合です)の公開価格だけに合わせず、
+RepChatは利用量と運用工数から価格を決めます。競合価格は契約時に再確認します。
 
 ただし**価格は真似されます**。下げるなら 2.1〜2.5 のいずれかとセットにすること。
 **価格だけを理由に選ばれた顧客は、価格だけを理由に離れます。**
@@ -255,6 +255,50 @@ LookMLのGit連携と共通し、LookMLのモデル開発やbranch運用その�
 顧客数に比例させないためこちら側に置きます。Gitはbuild時だけ使い、閲覧時には参照しません。
 repositoryを持たない顧客には、同じpipelineを使うmanaged fallbackを用意します。
 
+### 2.10 Evidence Cloudと競う境界（2026-08-11）
+
+Evidenceは、SQL／Markdown authoring、AI差分編集、Git branch、review／publish、Analytics Agent、
+Insight保存、Slack／MCP、custom context／skills、RLS、embedded deliveryを既に提供しています。
+RepChatはこれらの機能名や画面構造を差別化として主張しません。
+
+Evidence Embedded Analyticsは、Enterprise Planで公開済みpageを顧客製品へ安全に配信する機能です。
+レポート編集はEvidence StudioまたはGit／CLIで行います。これはRepChatで検討している機能を次のように
+分離すべきことを示します。
+
+| 責務 | RepChatの将来機能 | Evidenceで対応する面 |
+|------|-------------------|----------------------|
+| Authoring | AI対話、Web SQL workspace、versioned panel composition、branch／review | SQL Console、Report Editor、AI diff、Git／CLI |
+| Publishing | 検証済みrevisionを公開対象へ切り替え、rollback可能にする | publishとGit commit |
+| Delivery | tenant identity、RLS、brand、locale、有効期限を束縛して顧客へ表示する | Embedded API＋iframe |
+
+SQL Consoleは任意SQLの探索面、Report EditorはMarkdown／SQL／componentでcustom reportを作る面です。
+AI生成reportもaccept後はDeveloper／Adminがsourceを編集できます。したがって、Web SQL workspaceや
+AI生成SQLの手動調整も機能名だけでは差別化になりません。RepChatで残す判断は、
+[ADR-0022](adr/0022-compose-derived-dashboards-from-versioned-panels.md)のとおり、AI生成原本を上書きせず、
+利用者の変更をforkしたpanel revisionとして検証・合成することです。
+
+通常のembedded閲覧画面へSQL編集、layout編集、branch操作を出しません。エンジニアが調整する場合は、
+別のauthoring権限とrouteで編集し、review済みrevisionだけを配信します。
+
+RepChatが検証する差は次の組合せです。実装状態を超えて優位と表現しません。
+
+| 候補 | 状態 | 検証する差 |
+|------|------|------------|
+| 日本語の目的分解→KPI・比較・panel提案→利用者確認 | ローカルデモprototype | Evidenceと同じ課題で完成率、確認回数、所要時間を比較 |
+| Vertex AI／BigQueryの実行前費用確認 | ローカルデモに実装 | 費用予測の理解率と実行取消率を測定 |
+| 根拠外数値を拒否する会議報告 | ローカルデモprototype | 根拠追跡率、誤った数値claim、会議での採用率を比較 |
+| 決定、owner付きaction、次回検証までの会議loop | 将来要件 | 会議後にactionが登録・再確認された割合を測定 |
+| 代理店が複数顧客を扱う日本語運用と導入支援 | 提供方針 | デザインパートナーの導入完了率と支援工数を測定 |
+| scope付き適応メモリー | accepted設計、未実装 | 二回目以降の確認削減と訂正率を測定 |
+
+推奨する説明は次の一文です。
+
+> 日本の代理店が、顧客ごとの業務文脈と権限を混ぜず、日本語で分析目的とKPIを合意し、費用を確認してから
+> 実行し、根拠付きダッシュボードと会議で決めるべき施策まで作る。
+
+この説明もデザインパートナー比較で実証するまではポジショニング仮説です。競合事実と出典は
+[競合比較](competitive-landscape.md)を正本とします。
+
 ## 3. 採らない — 時間を使わないもの
 
 **明示しておかないと、機能表の空欄を埋めたくなります。**
@@ -289,8 +333,8 @@ repositoryを持たない顧客には、同じpipelineを使うmanaged fallback�
 | ~~所有権・権限管理が実在する痛み~~ | **1.5 で裏付け済み** — Looker Studio の共有アカウント廃止と、接続者・作成者の退職 | — |
 | **今レポートを作っている人が、明日も作れるか** | **最大の関門。** Looker Studio はドラッグ&ドロップで非エンジニアが作れる。こちらは「自然言語→PR→承認」で**同じ人が同じようには作れない**。今 Looker Studio でレポートを作っている人に、2.7の流れで1枚作ってもらう | **他が全部揃っても売れません。** 唯一かつ最大の判定条件 |
 | 生成された数値が正しい | 2.7 の**既知の数値照合**を組み込み、実データで確認 | 見た目が正しく数字が違うレポートは無いより悪い |
-| 日本語のNL→SQLで海外製品に差をつけられる | **日本語スキーマ・日本語質問20問のベンチマーク**を作り、自社／Evidence Cloud／Metabase の試用で同じ問題を流して正答率を比較 | 2.1・2.2の価値が下がる。逆に差が出れば測定された差別化になる |
-| 日本のSMBが海外SaaSを使わない理由が言語・支払い・サポートにある | 同じヒアリングで「Evidence Cloud を知っていますか／なぜ使わないのですか」 | 2.2・2.4が崩れる |
+| 日本語の分析目的から価値ある成果物までのworkflowでEvidenceより良い結果を出せる | 同じschema、既知値、日本語の目的を使い、分析計画の確認回数、正答率、dashboard完成時間、根拠追跡、会議actionの採用率を比較 | 2.10の製品差が崩れ、日本語支援と運用サービスだけが残る |
+| 日本のSMBがEvidence等を採用しない理由が言語・支払い・サポートにある | 同じヒアリングで「Evidence Cloudを知っていますか。採用しない場合はなぜですか」と確認し、Evidenceの契約条件は営業見積で確認 | 2.2・2.4が崩れる |
 
 **判定条件は先に決めておくこと。** 決めずに聞くと都合よく解釈します。
 

--- a/docs/requirements/analysis-workspace-ui.md
+++ b/docs/requirements/analysis-workspace-ui.md
@@ -26,6 +26,9 @@ SQL来歴確認、会議報告を一つの再現可能なワークスペース�
 | 分析スレッド | 一つの分析目的について、質問、回答、分析仕様revision、buildを結ぶ対話単位 |
 | インサイト | 一つの質問への回答、可視化、query、source、filter、prompt、実装メモを固定revisionとして保存した再利用可能な成果物 |
 | 分析コレクション | 関連するダッシュボードと分析スレッドを整理する利用者向けディレクトリ。GCP projectやtenantではない |
+| authoring | AI対話、SQL、panel構成、差分、branch、reviewを使って成果物revisionを作成・修正する操作。閲覧・埋め込みとは別permissionとrouteを持つ |
+| publishing | review済みの固定revisionを閲覧対象へ切り替え、rollback可能な来歴を残す操作 |
+| embedded delivery | published revisionを顧客製品内へ表示する配信形態。brand、locale、利用者identity、RLS、有効期限を束縛するが、authoring権限を付与しない |
 | push | 左右領域がメインサーフェスの幅を縮めて同じgrid内へ表示される配置 |
 | overlay | 左右領域がメインサーフェスの上へ重なり、背後の操作を一時的に制限する配置 |
 | 出典区分 | `Official`、`Observed`、`Owner intent`、`RepChat decision`のいずれか。外部製品の事実と本製品の判断を分離する |
@@ -42,6 +45,7 @@ SQL来歴確認、会議報告を一つの再現可能なワークスペース�
 | C-3 | 制約 | SQL、取得データ、来歴は権限を持つ利用者だけへ表示する | Issue #179の認可要件を守る |
 | C-4 | 制約 | Issue #160が`proceed`になるまで、この文書を根拠に製品UIを先行実装しない | デモ検証前の過剰実装を防ぐ |
 | C-5 | 制約 | 永続履歴、Git branch操作、アカウント設定をローカルデモで実装済みと表示しない | デモ能力と製品要件を区別する |
+| C-6 | 制約 | authoring、publishing、embedded deliveryを別のroute、permission、audit eventとして扱う | 顧客向け閲覧経路からSQL編集や未承認revisionへ到達することを防ぐ |
 
 ## 3. 目的と範囲
 
@@ -88,7 +92,12 @@ SQL来歴確認、会議報告を一つの再現可能なワークスペース�
 | SRC-08 | RepChat decision | 現行デモは左右pane、4 workspace、panel inspector、費用確認を実装済み。製品要件は現行コードから独立して理想を定義する | [Issue #328](https://github.com/Yukihide-Mitsuoka/repchat/issues/328)、[PR #330](https://github.com/Yukihide-Mitsuoka/repchat/pull/330) |
 | SRC-09 | Official competitor | Evidence Analytics Agentは、現在のpageとfilterを文脈にし、回答へchart、query、sourceを結び付ける。回答をpromptと実装メモ付きInsightへ保存し、維持管理するpageへ昇格できると説明する | [Analytics Agent](https://evidence.dev/product/analytics-agent) |
 | SRC-10 | Official competitor | Evidence Internal Analyticsは、SQL／Markdown、version control、test、review-before-publish、page access、row-level securityを中心とし、自由なdrag-and-dropを採らないと説明する | [Internal Analytics](https://evidence.dev/product/internal-reporting) |
-| SRC-11 | Official competitor | Evidence Embedded Analyticsは、themeの即時preview、API＋iframe、single-use URL、session length、database RLS、multi-languageを顧客向け配信面として説明する | [Embedded Analytics](https://evidence.dev/product/embedded-analytics) |
+| SRC-11 | Official competitor | Evidence Embedded AnalyticsはEnterprise Plan向けで、公開済みpageをbackend API＋iframeで表示する。single-use URL、JWE、RLS、theme、language、session TTLを持つが、report authoringは提供しない | [Embedded Analytics](https://docs.evidence.studio/features/embedded) |
+| SRC-12 | Official competitor | Evidence Studioは左editorでMarkdown／SQLを編集し、右previewを更新する。AIはdiffを提案し、利用者がaccept／rejectする | [Editing](https://docs.evidence.studio/editing) |
+| SRC-13 | Official competitor | Evidence projectはGit repositoryに対応し、managed repoまたはGitHub repo、branch、commit、review、publishをauthoring lifecycleとして扱う | [Version control](https://docs.evidence.studio/features/version-control) |
+| SRC-14 | Official competitor | Evidence料金ページはTeam $15/人・月、Pro $25/人・月、Enterprise個別見積を示し、Embedded、white labeling、RLSをEnterpriseに含める | [Pricing](https://evidence.dev/pricing) |
+| SRC-15 | Official competitor | Evidence StudioはReport、Explore、SQL Console、AI Chatをself-service面として分ける。pageはMarkdown、SQL、componentで構成できる | [Migration guide](https://docs.evidence.studio/migration-guide)、[Markdown](https://docs.evidence.studio/core-concepts/markdown) |
+| SRC-16 | Official competitor | Viewer／Org Viewerはeditorへアクセスできず、Developer／Adminはreportを編集できる | [Publishing](https://docs.evidence.studio/publishing) |
 
 ### 4.2 証拠の扱い
 
@@ -125,9 +134,11 @@ SQL来歴確認、会議報告を一つの再現可能なワークスペース�
 | Save as Insight | prompt、methodology、filter、query／result revisionを不変なInsight revisionへ保存する | 生の会話全体をそのまま正式成果物にする | MAIN-011、OVR-006 |
 | Insightをpageへ昇格 | 元Insightを変更せず、派生dashboard revisionから参照する | AI生成原本の上書きや無断再query | MAIN-012、Issue #308 |
 | Custom context／skills | 適用中contextと分析手順をscope付きchipとして表示し、利用者が確認・解除する | 全memoryを毎回promptへ投入する | MAIN-013、ADR-0018 |
-| Version control／review／publish | draft、review、preview、published、supersededを成果物statusとして分離する | 編集中revisionの即時公開 | MAIN-014、OVR-007 |
+| SQL Console／inline SQL editor | 将来のSQL workspaceで任意SQLの探索、preview、panel revision作成を行い、dashboard authoringとは分ける | SQL Consoleをpublished custom reportまたはembedded editorとみなす | ADR-0022、別実装Issue |
+| Studio editor／AI diff／live preview | AI対話と構造化panel compositionをauthoring routeへ置き、差分確認と固定previewを分ける | Embedded customer viewへeditorやAI差分承認を出す | MAIN-014、MAIN-017、OVR-007 |
+| Version control／review／publish | draft、review、preview、published、supersededを成果物statusとして分離する | 編集中revisionの即時公開 | MAIN-014、OVR-007、SRC-13 |
 | Code-first、no drag-and-drop | AI対話と構造化panel compositionを主経路にし、自由配置editorを初期範囲にしない | 汎用BI canvasの先行実装 | MAIN-016、Issue #308 |
-| Embedded delivery | authoringから分離した顧客preview／配信modeでbrand、locale、identity、expiryを確認する | iframe URLを通常dashboard共有linkとして流用する | MAIN-015、OVR-008 |
+| Embedded delivery | published revisionだけをauthoringから分離した顧客preview／配信modeで表示し、brand、locale、identity、RLS、expiryを確認する | iframe URLを通常dashboard共有linkとして流用する、または埋め込みをcustom dashboard editorとみなす | MAIN-015、MAIN-017、OVR-008、SRC-11 |
 | Slack／MCP | Web成果物revisionを正本とし、他channelは同じ認可・来歴へ接続するadapterとする | channelごとの独立成果物 | INS-010、ADR-0017 |
 
 ## 6. UIインベントリと機能要件
@@ -208,6 +219,7 @@ AppShell
 | MAIN-014 | dashboard、insight、reportは`draft`→`review`→`published`→`superseded`のstatusを持ち、previewは公開予定の固定revision、公開後の既定閲覧はpublished revisionを表示する | Must |
 | MAIN-015 | embedded customer previewは通常のauthoring routeと分離し、brand、locale、viewport、authorized customer identity、session expiryをtoolbarで確認する。identity切替はadminだけに許可し、server発行preview sessionを必須にする | Should |
 | MAIN-016 | 初期authoringはAI対話、構造化template、panel参照追加、順序変更に限定し、任意座標drag-and-drop、任意HTML／code、自由layout canvasを提供しない | Must |
+| MAIN-017 | embedded customer viewはpublished revisionのfilter、input、drilldownだけを許可し、SQL編集、panel構成変更、AI差分承認、branch、publish操作を表示しない。編集権限を持つ利用者が修正する場合も、別のauthoring routeへ移動する | Must |
 
 ### 6.4 右セカンダリpane
 
@@ -260,6 +272,8 @@ flowchart LR
   それぞれ別操作・別permission・別audit eventとする。
 - Internal viewとEmbedded customer viewは同じpublished revisionを参照できるが、identity、theme、locale、
   session契約を共有しない。
+- Embedded customer viewのfilter、input、drilldownはpublished revisionの許可されたparameterを変更する
+  閲覧操作であり、authoring revisionを作成しない。
 
 ### 6.7 surface mode別の配置
 
@@ -270,7 +284,7 @@ flowchart LR
 | Insight閲覧 | Insight選択 | 保存済みInsightの回答と可視化 | methodology／SQL／data／来歴Inspector | ダッシュボードへ追加 |
 | 会議報告 | report選択 | report本文、決定、action | 根拠panel／来歴Inspector | reviewまたはpublish |
 | Publish preview | artifact選択 | 公開予定の固定revision | diff、検証、権限、公開先 | publish |
-| Embedded preview | artifact選択 | customer viewの固定revision | brand、locale、identity、expiry | preview終了 |
+| Embedded preview | artifact選択 | customer viewの固定published revision | brand、locale、identity、RLS、expiry。authoring controlは置かない | preview終了 |
 
 desktopの分析対話では中央を会話、右をArtifact Previewとし、回答cardを縦方向に二重表示しません。
 tablet以下ではArtifact Previewをoverlay／全幅sheetへ変え、閉じると同じ会話位置へ戻します。
@@ -413,6 +427,7 @@ separatorは`role="separator"`、`aria-orientation="vertical"`、`aria-valuemin`
 | SQL／取得データ | 個別permission | 個別permission | 可 |
 | publish／fork | 不可 | permission次第 | 可 |
 | customer identity付きpreview | 不可 | 個別permission | 可 |
+| embedded published view | 許可されたidentityで可 | 許可されたidentityで可 | 可 |
 | data source／member／Git設定 | 不可 | 不可 | 可 |
 
 本番role・認証方式の最終決定はIssue #194を正本とし、この表はUIのfail-closed既定です。
@@ -508,6 +523,7 @@ app shell自体に新しい有料infraや外部UI libraryを必須としませ�
 | AC-19 | customer previewがbrand、locale、identity、expiryを表示し、期限切れ／越境identity／通常共有linkへの流用を拒否する | MAIN-015、OVR-008、NFR-004 | authorization E2E |
 | AC-20 | 製品主ナビに単一グラフと自由layout canvasがなく、検索、分析対話、Insight、管理済み成果物の責務が混在しない | NAV-004、MAIN-016 | navigation review |
 | AC-21 | 分析対話で右paneをArtifact PreviewからInspectorへ切り替えても会話位置とdraft revisionを維持し、tablet以下ではoverlay／sheetとして復帰できる | APP-006、INS-012、§6.7 | viewport E2E |
+| AC-22 | embedded customer viewはpublished revisionだけを表示し、URL直打ちを含めSQL編集、panel構成、branch、publishへ到達できない。編集者は別authoring routeでのみ修正できる | C-6、MAIN-017、NFR-004 | role別authorization E2E |
 
 ## 15. リスク
 
@@ -523,6 +539,7 @@ app shell自体に新しい有料infraや外部UI libraryを必須としませ�
 | R-8 | page-aware AIが不可視のfilterやmemoryを使い、利用者が回答条件を誤認する | 中 | 高 | MAIN-009、MAIN-013、INS-011で送信文脈を明示する |
 | R-9 | quick answerを無制限に保存してInsightが検索不能になる | 中 | 中 | collection、status、archive、参照先を必須metadataにし、retentionをQ-2で決める |
 | R-10 | customer previewがtenant impersonationまたは共有linkの抜け道になる | 低 | 高 | admin限定identity切替、短期server session、通常共有linkとの分離 |
+| R-11 | 埋め込みをcustom dashboard editorと誤認し、顧客向け閲覧経路へauthoring権限を混在させる | 中 | 高 | C-6、MAIN-017、AC-22でrouteとpermissionを分離する |
 
 ## 16. milestone
 


### PR DESCRIPTION
## What & why

Update the Evidence Cloud comparison from current official pricing, product, and Evidence Studio documentation. Clarify that SQL Console is an exploratory authoring surface, Report Editor is the custom-report authoring surface, and Embedded Analytics securely delivers a published report rather than exposing an editor. Separate RepChat authoring, publishing, and embedded delivery requirements so future implementation does not mix permissions or routes.

Fixes: #338

## Change classification (ARC-020)

- [x] Local (documentation only; module contracts unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries ! + BREAKING CHANGE footer; migration notes:

## Testing (GR-021 / TST-002)

Documentation-only change; no behavior test was added.

- How verified: make format, make lint, and make test completed successfully.
- Not verified (be honest — GR-042): Evidence product behavior was not exercised in a paid account; claims are limited to the linked official pages and docs.

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: docs/competitive-landscape.md, docs/positioning.md, docs/requirements/analysis-workspace-ui.md, docs/development-handoff.md

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against .ai/review-checklist.md completed
- [ ] Authored by human
- Prompts/context notes: Repository owner supplied the current Evidence pricing page and asked to preserve the comparison and embedded-report interpretation.

## Self-review checklist (WF-090)

- [x] make format && make lint && make test green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (.ai/guardrails.md)