### PR TITLE
docs: make Evidence Cloud comparison explicit

### DIFF
--- a/docs/competitive-landscape.md
+++ b/docs/competitive-landscape.md
@@ -91,9 +91,9 @@ Amplitude は**変数を切り分ける自然実験**になっており、残る
 
 ### 2. Evidence Cloudは機能の直接競合です
 
-2026-08-11時点の公式情報では、EvidenceはRepChatが検討している主要な機構を既に製品化しています。
+2026-08-11時点の公式情報では、Evidence CloudはRepChatが検討している主要な機構を既に製品化しています。
 
-| 領域 | Evidenceの公式仕様 | RepChatへの含意 |
+| 領域 | Evidence Cloudの公式仕様 | RepChatへの含意 |
 |------|--------------------|-----------------|
 | 分析agent | 現在のpageとfilterを文脈にし、chart、query、source付き回答を作り、Insightとして保存する | 自然言語質問と根拠表示だけでは差別化にならない |
 | channel | SlackとMCP client（Claude Desktop、ChatGPTを含む）から利用できる | SlackをUIにすること自体は差別化にならない |
@@ -103,7 +103,7 @@ Amplitude は**変数を切り分ける自然実験**になっており、残る
 
 #### Embedded Analyticsは編集機能ではない
 
-EvidenceのEmbedded Analyticsは、**作成済み・公開済みのpageを顧客の製品内へ安全に配信する機能**です。
+Evidence CloudのEmbedded Analyticsは、**作成済み・公開済みのpageを顧客の製品内へ安全に配信する機能**です。
 顧客側backendが認証済み利用者のembed URLを発行し、frontendがiframeで表示します。URLは一回限りで
 2分以内に使用し、開いた後のsessionは指定TTLに従います。利用者属性はJWEで暗号化され、RLSへ渡されます。
 
@@ -119,7 +119,7 @@ Web SQL workspaceに最も近い機能ですが、SQL Console単体をcustom rep
 2026-08-11に確認した公式文書からは、Consoleのqueryを一操作でreportへ昇格する契約までは確認できません。
 
 custom reportの作成面はEvidence StudioのReport Editorです。pageはMarkdown、SQL、componentで構成され、
-Evidence Agentが生成または編集する場合もdiffを利用者がaccept／rejectします。accept後のreport sourceは
+Evidence StudioのAgentが生成または編集する場合もdiffを利用者がaccept／rejectします。accept後のreport sourceは
 Developer／AdminがeditorまたはGit／CLIで編集できます。Viewer／Org Viewerはeditorへアクセスできません。
 
 ただし「全graphに編集可能な生成SQLが一つずつ存在する」とは限りません。Evidence Studioのcomponentは
@@ -129,7 +129,7 @@ data sourceと集計式を直接参照でき、page内inline SQLやstandalone SQ
 公式料金ページの2026-08-11表示では、Teamは$15/人・月、Proは$25/人・月、Enterpriseは個別見積です。
 Embedded、white labeling、RLS、multi-regionはEnterpriseです。価格と機能表は契約時に再確認します。
 
-参照: [Evidence](https://evidence.dev/)、
+参照: [Evidence Cloud](https://evidence.dev/)、
 [Analytics Agent](https://evidence.dev/product/analytics-agent)、
 [Pricing](https://evidence.dev/pricing)、
 [Evidence Studio editing](https://docs.evidence.studio/editing)、
@@ -140,6 +140,27 @@ Embedded、white labeling、RLS、multi-regionはEnterpriseです。価格と機
 [Embedded Analytics](https://docs.evidence.studio/features/embedded)、
 [Slack分析インターフェース要件](requirements/slack-analysis-interface.md)
 
+#### Evidence CloudとRepChatの現在の優位性
+
+結論は、**2026-08-11時点の製品完成度と機能範囲はEvidence Cloudが優位**です。RepChatに固有の候補はありますが、
+ローカルデモまたは設計段階であり、顧客比較による製品優位はまだ実証されていません。
+
+| 比較軸 | Evidence Cloud | RepChat | 現在の判定 |
+|--------|----------------|---------|------------|
+| report authoring | Studio editor、AI diff、SQL Console、inline SQL、Git branchを提供 | AI対話とSQL workspace／panel合成を設計。製品未実装 | Evidence Cloud優位 |
+| Analytics Agent | page／filter context、Insight保存、custom context／skills、Slack／MCPを提供 | 各要件とADRはあるが、製品channel／memoryは未実装 | Evidence Cloud優位 |
+| publish／embed／security product | page access、SSO、RLS、white label、Embedded APIをplan別に提供 | security coreは実装中、artifact配信と本番認証は未統合 | Evidence Cloud優位 |
+| 日本語の分析計画 | 公式にはskillsで確認質問・分析手順を構成可能 | 目的分解→KPI・比較軸・panel提案→利用者確認のローカルデモあり | RepChat固有workflowだが優位未検証 |
+| 実行前費用確認 | 公式資料でqueryごとの事前確認は確認できない | Vertex AI見積とBigQuery上限を実行前に表示するローカルデモあり | RepChatの現在の具体的な差。購買価値は未検証 |
+| 根拠付き会議報告 | source付き回答とboard prepを提供 | 根拠外数値を拒否するstrict validatorのローカルデモあり | RepChatの検証方式に差がある。品質優位は未検証 |
+| 会議後の意思決定loop | 公式資料で同等の決定・owner・次回検証loopは確認できない | 将来要件のみ | 現在の優位ではない |
+| 日本の代理店向け運用 | 横断的BI、multi-tenancy、Enterprise supportを提供 | 小規模代理店の複数顧客運用、日本語導入支援、接続主体の退職耐性に集中 | 市場特化の候補。デザインパートナー検証前 |
+| 顧客成果物の所有 | managed repoまたは利用者のGitHub repoでversion管理可能 | 顧客Git配送をaccepted設計としたが製品未実装 | 現在はEvidence Cloud優位。顧客所有だけでは差別化にならない |
+
+RepChatが「Evidence Cloudより優れている」と説明できる条件は、日本語の同一課題を両製品で実行し、分析計画の
+確認回数、既知値の正答率、dashboard完成時間、根拠追跡率、会議action採用率で再現可能な差が出ることです。
+現状の説明は「日本の代理店workflowへ特化して検証中」であり、「総合的に優位」ではありません。
+
 ### 3. 席数課金そのものへの逆風
 
 **Lightdash は $3,000/月の定額で席数無制限**、OSS版は無料。**Metabaseも定額＋従量の混合**です。
@@ -149,7 +170,7 @@ Embedded、white labeling、RLS、multi-regionはEnterpriseです。価格と機
 
 ### 4. 「何を見ればいいか」の支援も機能名だけでは差になりません
 
-Evidenceはcustom skillsで確認質問や分析手順を定義でき、公式ページはhealth check、churn調査、board prep
+Evidence Cloudはcustom skillsで確認質問や分析手順を定義でき、公式ページはhealth check、churn調査、board prep
 などを利用例に挙げています。したがって「何を見ればよいか分からない人への対応が競合にない」という
 旧仮説は、2026-08-11時点では事実として使えません。
 
@@ -166,7 +187,7 @@ Evidenceはcustom skillsで確認質問や分析手順を定義でき、公式�
 分析目的を複数の判断可能なKPIとpanelへ分解し、利用者の確認を経て固定成果物へ変える一連の操作です。
 チャットは作成時の入口、ダッシュボードは継続利用の入口として役割を分けます。
 
-Evidenceも回答をInsightへ保存し、管理対象pageへ昇格できます。永続する成果物、Insight保存、
+Evidence Cloudも回答をInsightへ保存し、管理対象pageへ昇格できます。永続する成果物、Insight保存、
 dashboardへの追加もRepChat固有ではありません。比較すべき対象は、成果物の有無ではなく、分析計画の
 合意、費用確認、根拠検証、顧客別の認可、会議actionまでのworkflowです。
 
@@ -180,7 +201,7 @@ dashboardへの追加もRepChat固有ではありません。比較すべき対�
 業務文脈であり、それは業種ごとに異なります。**横断的に薄く当てるより、業種を絞る方が成立しやすい**
 可能性がありますが、これも未検証です。
 
-EvidenceとZenlyticはいずれも近い位置にいます。定期配信、会議用要約、確認質問、分析playbookは
+Evidence CloudとZenlyticはいずれも近い位置にいます。定期配信、会議用要約、確認質問、分析playbookは
 競合が追加できるため、個別機能を恒久的な優位として扱いません。
 
 ## それでも残りうる差別化
@@ -196,7 +217,7 @@ EvidenceとZenlyticはいずれも近い位置にいます。定期配信、会�
 | 日本語の導入支援、請求、説明責任 | 提供方針。競合の国内契約実務は未確認 | 営業比較が必要 |
 
 自然言語SQL、セマンティック層、Git管理、Insight保存、Slack／MCP、custom context／skills、RLS、
-埋め込みはEvidenceを含む競合が提供しているため、単独の差別化として使いません。
+埋め込みはEvidence Cloudを含む競合が提供しているため、単独の差別化として使いません。
 
 ## この文書が示唆する行動
 
@@ -216,9 +237,9 @@ Metabase を使っていないのか」**です。これは机上では答えが
 
 補助として「何を使っていますか」「なぜそれを選びましたか」。**説明ではなく質問だけで済みます。**
 
-Evidenceとの機能比較は公開ページの読解で終えません。同じ日本語の分析目的、同じschema、同じ既知値を使い、
+Evidence Cloudとの機能比較は公開ページの読解で終えません。同じ日本語の分析目的、同じschema、同じ既知値を使い、
 分析計画の確認回数、正答率、dashboard完成時間、根拠追跡、会議actionの採用率を測定します。RepChatが
-Evidenceを上回ったと主張できるのは、この比較で差が再現された後です。
+Evidence Cloudを上回ったと主張できるのは、この比較で差が再現された後です。
 
 ## 関連
 

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -15,9 +15,9 @@ updated: 2026-08-11
 
 | 項目 | 現在地 |
 |------|--------|
-| 作業 | [Issue #338](https://github.com/Yukihide-Mitsuoka/repchat/issues/338)／[PR #339](https://github.com/Yukihide-Mitsuoka/repchat/pull/339) — Evidence Cloudの現行公式仕様に合わせて競合比較、ポジショニング、authoring／publishing／embedded deliveryのUI境界を更新する |
+| 作業 | [Issue #338](https://github.com/Yukihide-Mitsuoka/repchat/issues/338)／[PR #340](https://github.com/Yukihide-Mitsuoka/repchat/pull/340) — Evidence CloudとRepChatの現在の優位性を明示し、競合製品名とauthoring／publishing／embedded deliveryの境界表記を統一する |
 | デモ実行状態 | v1.16.0で左右paneを持つローカルprototypeまで実装済み。新しい要件文書は製品UIの設計成果であり、実装済み能力を増やさない。実Vertex AIとBigQueryは再実行しない |
-| 直近完了 | [PR #336](https://github.com/Yukihide-Mitsuoka/repchat/pull/336)のEvidence Cloud UI mappingと[PR #335](https://github.com/Yukihide-Mitsuoka/repchat/pull/335)のthought token費用計上はmerge済み |
+| 直近完了 | [PR #339](https://github.com/Yukihide-Mitsuoka/repchat/pull/339)の競合資料更新、[PR #336](https://github.com/Yukihide-Mitsuoka/repchat/pull/336)のEvidence Cloud UI mapping、[PR #335](https://github.com/Yukihide-Mitsuoka/repchat/pull/335)のthought token費用計上はmerge済み |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
 | AIができること | Issue #338の文書をreview可能にし、Evidence Cloud公式料金・製品・Evidence Studio文書の出典、競合比較、RepChatの実装／設計／将来構想の区分、埋め込みと編集の権限境界を検証する。製品実装は開始しない |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -15,11 +15,11 @@ updated: 2026-08-11
 
 | 項目 | 現在地 |
 |------|--------|
-| 作業 | [Issue #338](https://github.com/Yukihide-Mitsuoka/repchat/issues/338) — Evidenceの現行公式仕様に合わせて競合比較、ポジショニング、authoring／publishing／embedded deliveryのUI境界を更新する |
+| 作業 | [Issue #338](https://github.com/Yukihide-Mitsuoka/repchat/issues/338)／[PR #339](https://github.com/Yukihide-Mitsuoka/repchat/pull/339) — Evidence Cloudの現行公式仕様に合わせて競合比較、ポジショニング、authoring／publishing／embedded deliveryのUI境界を更新する |
 | デモ実行状態 | v1.16.0で左右paneを持つローカルprototypeまで実装済み。新しい要件文書は製品UIの設計成果であり、実装済み能力を増やさない。実Vertex AIとBigQueryは再実行しない |
-| 直近完了 | [PR #336](https://github.com/Yukihide-Mitsuoka/repchat/pull/336)のEvidence UI mappingと[PR #335](https://github.com/Yukihide-Mitsuoka/repchat/pull/335)のthought token費用計上はmerge済み |
+| 直近完了 | [PR #336](https://github.com/Yukihide-Mitsuoka/repchat/pull/336)のEvidence Cloud UI mappingと[PR #335](https://github.com/Yukihide-Mitsuoka/repchat/pull/335)のthought token費用計上はmerge済み |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
-| AIができること | Issue #338の文書をreview可能にし、Evidence公式料金・製品・Studio文書の出典、競合比較、RepChatの実装／設計／将来構想の区分、埋め込みと編集の権限境界を検証する。製品実装は開始しない |
+| AIができること | Issue #338の文書をreview可能にし、Evidence Cloud公式料金・製品・Evidence Studio文書の出典、競合比較、RepChatの実装／設計／将来構想の区分、埋め込みと編集の権限境界を検証する。製品実装は開始しない |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |
 | 完了時 | 証拠を`proceed` / `revise` / `reject`に分類し、Issue #160と[status](status.md)を更新する。方向が変わる場合だけpositioning、ADR、decision logを更新する |
 
@@ -49,7 +49,7 @@ strict validatorを維持し、生成経路だけで妥当な項目を保持、�
 
 | 条件 | 次の作業 | 先に読む正本 |
 |------|----------|--------------|
-| 現在の競合・配信境界整理 | [#338 Evidence positioning and embedded delivery](https://github.com/Yukihide-Mitsuoka/repchat/issues/338)。Evidence公式仕様を事実側へ置き、RepChatの差別化仮説とauthoring／publishing／embedded deliveryのroute・permission分離を記録する | [競合比較](competitive-landscape.md)、[ポジショニング](positioning.md)、[分析ワークスペースUI要件](requirements/analysis-workspace-ui.md) |
+| 現在の競合・配信境界整理 | [#338 Evidence Cloud positioning and embedded delivery](https://github.com/Yukihide-Mitsuoka/repchat/issues/338)。Evidence Cloud公式仕様を事実側へ置き、RepChatの差別化仮説とauthoring／publishing／embedded deliveryのroute・permission分離を記録する | [競合比較](competitive-landscape.md)、[ポジショニング](positioning.md)、[分析ワークスペースUI要件](requirements/analysis-workspace-ui.md) |
 | 現在のUI情報設計 | [#179 dashboard／SQL来歴UX](https://github.com/Yukihide-Mitsuoka/repchat/issues/179)。外部UIは情報構造の参考に限定し、RepChat機能mapping、左右pane、responsive、keyboard、可視context、Insight保存／昇格、review／publish、embedded previewを再現可能な要件として固定する。Issue #160判定前に製品実装しない | [分析ワークスペースUI要件](requirements/analysis-workspace-ui.md)、[デモ手順](demo.md)、Issue #179 |
 | 完了した会議報告修正 | [#295 evidence validation](https://github.com/Yukihide-Mitsuoka/repchat/issues/295)／[PR #333](https://github.com/Yukihide-Mitsuoka/repchat/pull/333)。strict validatorを維持し、生成経路では根拠外数値を含む項目だけを除外する | [トラブルシューティング](troubleshooting/live-demo.md)、`meeting_report.py` |
 | 直近のデモUX | [#328 analysis workspace shell](https://github.com/Yukihide-Mitsuoka/repchat/issues/328)／[PR #330](https://github.com/Yukihide-Mitsuoka/repchat/pull/330)。ダッシュボード、作成・編集、会議報告、単一グラフを分離し、左右ペインを個別に開閉・リサイズ可能にする。永続対話履歴とGit連携は将来機能と明記する | [デモ手順](demo.md)、`live_demo.py`、`live-demo.test.ts` |
@@ -79,7 +79,7 @@ positioningとroadmapを再評価します。
 
 ## 次にやる順序（2026-08-11）
 
-1. **現在:** [Issue #338](https://github.com/Yukihide-Mitsuoka/repchat/issues/338)で、Evidenceの機能を競合事実として更新し、RepChatの差別化仮説とauthoring／publishing／embedded deliveryの境界をreviewする。製品実装は開始しない。
+1. **現在:** [Issue #338](https://github.com/Yukihide-Mitsuoka/repchat/issues/338)で、Evidence Cloudの機能を競合事実として更新し、RepChatの差別化仮説とauthoring／publishing／embedded deliveryの境界をreviewする。製品実装は開始しない。
 2. **デモ確認:** PR #297 merge後のローカルデモはHTTP 200を確認済み。会議報告の実再生成はVertex AI費用（Gemini 3.6 Flashの画面上限目安約¥25）を再提示し、承認後に1回だけ確認する。
 3. **オーナー承認後:** 実Vertex AI相談を1回確認する。成功後、別の費用確認を経てダッシュボードbuildを実行し、連続同一ページ統合後のR17参照値、色、リンク値、2ページ目終了注記、取得データを確認する。
 4. **並行するオーナー作業:** [#160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)の参加者を選定して日程を決める。デモ阻害を解消後に5分デモを行い、`proceed` / `revise` / `reject`へ分類する。

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -150,7 +150,7 @@ AIへ渡す情報、費用、失敗時の復旧まで説明できること**を�
 Evidence Cloudの現在の契約・請求方法は営業確認が必要です。日本のSMBには、業務ソフトを
 カード決済できない会社が実在するため、RepChatは請求書払い・銀行振込へ対応します。
 
-請求方法が選定条件になるかはデザインパートナーへ確認し、Evidenceの対応可否は営業見積で比較します。
+請求方法が選定条件になるかはデザインパートナーへ確認し、Evidence Cloudの対応可否は営業見積で比較します。
 
 ### 2.5 接続作業をサービスに含める
 
@@ -257,15 +257,15 @@ repositoryを持たない顧客には、同じpipelineを使うmanaged fallback�
 
 ### 2.10 Evidence Cloudと競う境界（2026-08-11）
 
-Evidenceは、SQL／Markdown authoring、AI差分編集、Git branch、review／publish、Analytics Agent、
+Evidence Cloudは、SQL／Markdown authoring、AI差分編集、Git branch、review／publish、Analytics Agent、
 Insight保存、Slack／MCP、custom context／skills、RLS、embedded deliveryを既に提供しています。
 RepChatはこれらの機能名や画面構造を差別化として主張しません。
 
-Evidence Embedded Analyticsは、Enterprise Planで公開済みpageを顧客製品へ安全に配信する機能です。
+Evidence CloudのEmbedded Analyticsは、Enterprise Planで公開済みpageを顧客製品へ安全に配信する機能です。
 レポート編集はEvidence StudioまたはGit／CLIで行います。これはRepChatで検討している機能を次のように
 分離すべきことを示します。
 
-| 責務 | RepChatの将来機能 | Evidenceで対応する面 |
+| 責務 | RepChatの将来機能 | Evidence Cloudで対応する面 |
 |------|-------------------|----------------------|
 | Authoring | AI対話、Web SQL workspace、versioned panel composition、branch／review | SQL Console、Report Editor、AI diff、Git／CLI |
 | Publishing | 検証済みrevisionを公開対象へ切り替え、rollback可能にする | publishとGit commit |
@@ -284,7 +284,7 @@ RepChatが検証する差は次の組合せです。実装状態を超えて優�
 
 | 候補 | 状態 | 検証する差 |
 |------|------|------------|
-| 日本語の目的分解→KPI・比較・panel提案→利用者確認 | ローカルデモprototype | Evidenceと同じ課題で完成率、確認回数、所要時間を比較 |
+| 日本語の目的分解→KPI・比較・panel提案→利用者確認 | ローカルデモprototype | Evidence Cloudと同じ課題で完成率、確認回数、所要時間を比較 |
 | Vertex AI／BigQueryの実行前費用確認 | ローカルデモに実装 | 費用予測の理解率と実行取消率を測定 |
 | 根拠外数値を拒否する会議報告 | ローカルデモprototype | 根拠追跡率、誤った数値claim、会議での採用率を比較 |
 | 決定、owner付きaction、次回検証までの会議loop | 将来要件 | 会議後にactionが登録・再確認された割合を測定 |
@@ -333,8 +333,8 @@ RepChatが検証する差は次の組合せです。実装状態を超えて優�
 | ~~所有権・権限管理が実在する痛み~~ | **1.5 で裏付け済み** — Looker Studio の共有アカウント廃止と、接続者・作成者の退職 | — |
 | **今レポートを作っている人が、明日も作れるか** | **最大の関門。** Looker Studio はドラッグ&ドロップで非エンジニアが作れる。こちらは「自然言語→PR→承認」で**同じ人が同じようには作れない**。今 Looker Studio でレポートを作っている人に、2.7の流れで1枚作ってもらう | **他が全部揃っても売れません。** 唯一かつ最大の判定条件 |
 | 生成された数値が正しい | 2.7 の**既知の数値照合**を組み込み、実データで確認 | 見た目が正しく数字が違うレポートは無いより悪い |
-| 日本語の分析目的から価値ある成果物までのworkflowでEvidenceより良い結果を出せる | 同じschema、既知値、日本語の目的を使い、分析計画の確認回数、正答率、dashboard完成時間、根拠追跡、会議actionの採用率を比較 | 2.10の製品差が崩れ、日本語支援と運用サービスだけが残る |
-| 日本のSMBがEvidence等を採用しない理由が言語・支払い・サポートにある | 同じヒアリングで「Evidence Cloudを知っていますか。採用しない場合はなぜですか」と確認し、Evidenceの契約条件は営業見積で確認 | 2.2・2.4が崩れる |
+| 日本語の分析目的から価値ある成果物までのworkflowでEvidence Cloudより良い結果を出せる | 同じschema、既知値、日本語の目的を使い、分析計画の確認回数、正答率、dashboard完成時間、根拠追跡、会議actionの採用率を比較 | 2.10の製品差が崩れ、日本語支援と運用サービスだけが残る |
+| 日本のSMBがEvidence Cloud等を採用しない理由が言語・支払い・サポートにある | 同じヒアリングで「Evidence Cloudを知っていますか。採用しない場合はなぜですか」と確認し、Evidence Cloudの契約条件は営業見積で確認 | 2.2・2.4が崩れる |
 
 **判定条件は先に決めておくこと。** 決めずに聞くと都合よく解釈します。
 

--- a/docs/requirements/analysis-workspace-ui.md
+++ b/docs/requirements/analysis-workspace-ui.md
@@ -40,7 +40,7 @@ SQL来歴確認、会議報告を一つの再現可能なワークスペース�
 | A-1 | 前提 | 初期利用者は、複数顧客へ分析を提供する日本の小規模代理店・ソフトウェアベンダーの担当者である | 左ナビゲーションの顧客・分析整理単位を再設計する |
 | A-2 | 前提 | 利用者はダッシュボード閲覧を最頻操作とし、SQL編集より先に結論と根拠を確認する | メインサーフェスの既定画面を再評価する |
 | A-3 | 前提 | デスクトップまたは横長Webが編集者の主端末で、モバイルは閲覧・確認が中心である | モバイル編集要件を別途追加する |
-| C-1 | 制約 | ChatGPT／Evidenceの商標、文章、アイコン、非公開design token、DOM/CSSを複製しない。公開情報から得た情報構造だけを参考にする | ブランド混同と継続的な追随負債を避ける |
+| C-1 | 制約 | ChatGPT／Evidence Cloud／Evidence Studioの商標、文章、アイコン、非公開design token、DOM/CSSを複製しない。公開情報から得た情報構造だけを参考にする | ブランド混同と継続的な追随負債を避ける |
 | C-2 | 制約 | テナント、分析コレクション、GCP project、顧客Git repositoryを同一概念として扱わない | 認可境界と保存先の混同を防ぐ |
 | C-3 | 制約 | SQL、取得データ、来歴は権限を持つ利用者だけへ表示する | Issue #179の認可要件を守る |
 | C-4 | 制約 | Issue #160が`proceed`になるまで、この文書を根拠に製品UIを先行実装しない | デモ検証前の過剰実装を防ぐ |
@@ -90,11 +90,11 @@ SQL来歴確認、会議報告を一つの再現可能なワークスペース�
 | SRC-06 | Observed | 公開・未ログインのChatGPT日本語画面に、sidebar開閉、新しいチャット、チャット検索、画像、Plugins、Deep Research、設定、Help、composerが存在する | [ChatGPT公開画面](https://chatgpt.com/) |
 | SRC-07 | Owner intent | 左右paneの開閉・drag、左上の検索・menu、中段のproject・履歴、左下のaccount・settings、中央との重なりを要件化する | この依頼 |
 | SRC-08 | RepChat decision | 現行デモは左右pane、4 workspace、panel inspector、費用確認を実装済み。製品要件は現行コードから独立して理想を定義する | [Issue #328](https://github.com/Yukihide-Mitsuoka/repchat/issues/328)、[PR #330](https://github.com/Yukihide-Mitsuoka/repchat/pull/330) |
-| SRC-09 | Official competitor | Evidence Analytics Agentは、現在のpageとfilterを文脈にし、回答へchart、query、sourceを結び付ける。回答をpromptと実装メモ付きInsightへ保存し、維持管理するpageへ昇格できると説明する | [Analytics Agent](https://evidence.dev/product/analytics-agent) |
-| SRC-10 | Official competitor | Evidence Internal Analyticsは、SQL／Markdown、version control、test、review-before-publish、page access、row-level securityを中心とし、自由なdrag-and-dropを採らないと説明する | [Internal Analytics](https://evidence.dev/product/internal-reporting) |
-| SRC-11 | Official competitor | Evidence Embedded AnalyticsはEnterprise Plan向けで、公開済みpageをbackend API＋iframeで表示する。single-use URL、JWE、RLS、theme、language、session TTLを持つが、report authoringは提供しない | [Embedded Analytics](https://docs.evidence.studio/features/embedded) |
+| SRC-09 | Official competitor | Evidence CloudのAnalytics Agentは、現在のpageとfilterを文脈にし、回答へchart、query、sourceを結び付ける。回答をpromptと実装メモ付きInsightへ保存し、維持管理するpageへ昇格できると説明する | [Analytics Agent](https://evidence.dev/product/analytics-agent) |
+| SRC-10 | Official competitor | Evidence CloudのInternal Analyticsは、SQL／Markdown、version control、test、review-before-publish、page access、row-level securityを中心とし、自由なdrag-and-dropを採らないと説明する | [Internal Analytics](https://evidence.dev/product/internal-reporting) |
+| SRC-11 | Official competitor | Evidence CloudのEmbedded AnalyticsはEnterprise Plan向けで、公開済みpageをbackend API＋iframeで表示する。single-use URL、JWE、RLS、theme、language、session TTLを持つが、report authoringは提供しない | [Embedded Analytics](https://docs.evidence.studio/features/embedded) |
 | SRC-12 | Official competitor | Evidence Studioは左editorでMarkdown／SQLを編集し、右previewを更新する。AIはdiffを提案し、利用者がaccept／rejectする | [Editing](https://docs.evidence.studio/editing) |
-| SRC-13 | Official competitor | Evidence projectはGit repositoryに対応し、managed repoまたはGitHub repo、branch、commit、review、publishをauthoring lifecycleとして扱う | [Version control](https://docs.evidence.studio/features/version-control) |
+| SRC-13 | Official competitor | Evidence Studio projectはGit repositoryに対応し、managed repoまたはGitHub repo、branch、commit、review、publishをauthoring lifecycleとして扱う | [Version control](https://docs.evidence.studio/features/version-control) |
 | SRC-14 | Official competitor | Evidence料金ページはTeam $15/人・月、Pro $25/人・月、Enterprise個別見積を示し、Embedded、white labeling、RLSをEnterpriseに含める | [Pricing](https://evidence.dev/pricing) |
 | SRC-15 | Official competitor | Evidence StudioはReport、Explore、SQL Console、AI Chatをself-service面として分ける。pageはMarkdown、SQL、componentで構成できる | [Migration guide](https://docs.evidence.studio/migration-guide)、[Markdown](https://docs.evidence.studio/core-concepts/markdown) |
 | SRC-16 | Official competitor | Viewer／Org Viewerはeditorへアクセスできず、Developer／Adminはreportを編集できる | [Publishing](https://docs.evidence.studio/publishing) |
@@ -124,9 +124,9 @@ SQL来歴確認、会議報告を一つの再現可能なワークスペース�
 | KPI root-cause brief | 観測、解釈、仮説、反証、次の検証を分ける | 会議報告prototypeの一部 | MAIN-003、SRC-04 |
 | Business review | 根拠付き会議報告とowner action | 未承認案を生成 | MAIN-003、SRC-05、Issue #181 |
 
-### 5.1 Evidenceとの機能対応
+### 5.1 Evidence Cloudとの機能対応
 
-| Evidence公式ページ上の責務 | RepChatで採用する責務 | 採用しない短絡 | 製品要件 |
+| Evidence Cloud公式ページ上の責務 | RepChatで採用する責務 | 採用しない短絡 | 製品要件 |
 |----------------------------|------------------------|----------------|----------|
 | Search／Chat／Insights | 検索、分析対話、保存済みインサイトを別の情報型としてナビゲーションする | 単一グラフ検証画面を製品の主ナビへ残す | NAV-004、NAV-011 |
 | 現在pageとfilterをagentが理解 | 利用企業、成果物revision、filter、選択panel、追加contextを送信前にchipで明示する | 画面上で見えない文脈を自動送信する | MAIN-009、INS-011 |
@@ -328,7 +328,7 @@ tablet以下ではArtifact Previewをoverlay／全幅sheetへ変え、閉じる�
 | code font | `ui-monospace`, `SFMono-Regular`, monospace |
 
 グラフを主役にするため、navigationとinspectorは白・灰・primaryの低彩度配色を使い、error、warning、successだけに
-意味色を使います。OpenAI／Evidenceのicon、ロゴ、固有文言は使用しません。
+意味色を使います。OpenAI／Evidence Cloud／Evidence Studioのicon、ロゴ、固有文言は使用しません。
 
 ### 7.3 Motion
 
@@ -513,7 +513,7 @@ app shell自体に新しい有料infraや外部UI libraryを必須としませ�
 | AC-09 | build中に別routeへ移動して戻っても同じjob IDと進捗を表示する | MAIN-006 | reconnect E2E |
 | AC-10 | dialog、drawer、menuがfocus trap、Escape、focus復帰を満たす | OVR-005、NFR-005 | keyboard E2E |
 | AC-11 | 長い日本語title、SQL、空、loading、errorで縦書き化や意図しない横overflowがない | 成功指標 | fixture visual test |
-| AC-12 | OpenAI／Evidence固有brand asset、文言、非公開tokenを成果物に含めない | C-1 | asset／copy review |
+| AC-12 | OpenAI／Evidence Cloud／Evidence Studio固有brand asset、文言、非公開tokenを成果物に含めない | C-1 | asset／copy review |
 | AC-13 | AI送信前にtenant、artifact revision、filter、panel、context／skillがchipで見え、任意項目を解除できる | MAIN-009、MAIN-013 | context E2E |
 | AC-14 | quick answerの数値から対応result／panel revisionへ移動でき、SQL permissionがない利用者にはSQLを出さない | MAIN-010、INS-005 | role別E2E |
 | AC-15 | quick answerを再queryなしでInsight draftへ保存し、再読込後も質問、methodology、filter、query／result revisionを復元する | MAIN-011、OVR-006、NFR-011 | API＋billing E2E |
@@ -535,7 +535,7 @@ app shell自体に新しい有料infraや外部UI libraryを必須としませ�
 | R-4 | 機能を左navへ詰め込み、初見利用者が迷う | 中 | 中 | primary 4項目、secondary collection、user testで検証 |
 | R-5 | SQL／dataを便利さのため閲覧者へ漏らす | 低 | 高 | permissionでtabとAPIを同時に遮断する |
 | R-6 | 永続履歴やGit状態を先に作り、Issue #160前に製品範囲が拡大する | 中 | 高 | C-4、C-5、milestone順序を守る |
-| R-7 | 競合追随でEvidenceの情報構造をそのまま複製し、RepChatの対話→仕様確認→費用gateを弱める | 中 | 高 | §5.1の「採用しない短絡」と既存ADRを実装契約にする |
+| R-7 | 競合追随でEvidence Cloud／Evidence Studioの情報構造をそのまま複製し、RepChatの対話→仕様確認→費用gateを弱める | 中 | 高 | §5.1の「採用しない短絡」と既存ADRを実装契約にする |
 | R-8 | page-aware AIが不可視のfilterやmemoryを使い、利用者が回答条件を誤認する | 中 | 高 | MAIN-009、MAIN-013、INS-011で送信文脈を明示する |
 | R-9 | quick answerを無制限に保存してInsightが検索不能になる | 中 | 中 | collection、status、archive、参照先を必須metadataにし、retentionをQ-2で決める |
 | R-10 | customer previewがtenant impersonationまたは共有linkの抜け道になる | 低 | 高 | admin限定identity切替、短期server session、通常共有linkとの分離 |


### PR DESCRIPTION
## What & why

Follow up merged PR #339 by consistently naming the competing product Evidence Cloud and adding an explicit current-strength comparison. Clarify that Evidence Cloud currently leads in product breadth, while RepChat's Japanese analysis-planning flow, pre-execution cost confirmation, and strict evidence validation remain differentiating hypotheses until benchmarked.

Also distinguish Evidence Studio SQL Console from Report Editor and Embedded Analytics so future authoring, publishing, and delivery work does not mix their responsibilities.

Refs: #338

## Change classification (ARC-020)

- [x] Local (documentation only; module contracts unchanged)
- [ ] Contract
- [ ] Architectural

## Breaking change?

- [x] No
- [ ] Yes

## Testing (GR-021 / TST-002)

- make format
- make lint
- make test
- git diff --check
- No paid Vertex AI or BigQuery calls were made.

## Documentation (DOC-030)

- [x] docs/competitive-landscape.md
- [x] docs/positioning.md
- [x] docs/requirements/analysis-workspace-ui.md
- [x] docs/development-handoff.md

## AI disclosure

- [x] Authored by AI agent: Codex
- [ ] Authored by human

## Self-review checklist (WF-090)

- [x] Official Evidence Cloud pages and Evidence Studio documentation remain the fact sources
- [x] Current capability, accepted design, and future hypothesis are separated
- [x] No unrelated product implementation changes