### PR TITLE
fix(demo): keep workspace titles compact

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -97,6 +97,11 @@ JSON以外を返した場合はHTML断片やJSON parser例外を表示せず、�
 右のArtifact／Inspector paneで確認します。actionと対象を画面に表示したうえで、従来どおり費用確認dialogを
 通過しなければVertex AIとBigQueryを呼びません。
 
+選択中の成果物／分析スレッド名は、左treeの選択行と中央列の44px headerに同じ文言で表示します。中央本文の
+上部には同じtitleや説明を大型blockとして繰り返さず、成果物、進行状況、共通入力欄へ縦の領域を使います。
+製品版の画面履歴はURLで表現してブラウザの戻る／進むを使う方針です。現在のデモにもワークスペース固有の
+重複buttonは置きません。
+
 左ナビゲーションと右の成果物paneは、viewport左右上端の小型ボタンで個別に開閉できます。ボタン座標は
 paneの開閉や幅変更で動かず、icon、ラベル、`aria-expanded`が開閉状態に合わせて変わります。
 左右paneはviewportの上端から下端までを所有し、中央headerは左右paneの上を横断しません。デスクトップ幅では
@@ -117,6 +122,7 @@ paneの開閉や幅変更で動かず、icon、ラベル、`aria-expanded`が開
 - 左右paneが画面全高を所有し、44pxの中央headerがpaneの上を横断しない
 - 1pxの可視境界と8pxのdrag hit areaを分離し、header iconを32px角、navigation行を36px以上にする
 - pane開閉前後で左右toggleの座標が変わらず、iconとaccessible nameだけが状態に合わせて変わる
+- 左treeの選択titleと中央のcompact headerが一致し、本文上部に同じ大型title／説明blockを置かない
 - 共通入力欄が中央列下端に残り、actionごとに既存の費用確認へ接続する
 - 単一グラフの生成物が右Artifact Previewへ移り、取得データとSQLを同じ成果物内で確認できる
 - 左右paneを両方開く、片方だけ開く、両方閉じる、の各状態で中央が横にはみ出さない

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -15,11 +15,11 @@ updated: 2026-08-11
 
 | 項目 | 現在地 |
 |------|--------|
-| 作業 | [Issue #350](https://github.com/Yukihide-Mitsuoka/repchat/issues/350) — 固定表示用serverを操作可能なlive demoと混同したことによる非JSONエラーを解消し、左右paneがviewport全高を所有するshellへ直す |
-| デモ実行状態 | [PR #348](https://github.com/Yukihide-Mitsuoka/repchat/pull/348)はmerge済み。視覚階層の第一弾は完了したが、全体headerが左右paneを覆う構造、太い境界、大型control、固定serverへの誤誘導が残った。Issue #350で修正中。実Vertex AIとBigQueryは再実行していない |
-| 直近完了 | [PR #348](https://github.com/Yukihide-Mitsuoka/repchat/pull/348)のデモ視覚階層、[PR #344](https://github.com/Yukihide-Mitsuoka/repchat/pull/344)のGA4/GTM計測支援境界、[PR #342](https://github.com/Yukihide-Mitsuoka/repchat/pull/342)の統制されたcohort分析要件はmerge済み |
+| 作業 | [Issue #352](https://github.com/Yukihide-Mitsuoka/repchat/issues/352) — 4つのpeer modeを一つの分析対話、成果物tree、中央下端composer、右Artifact／Inspector paneへ統合する |
+| デモ実行状態 | [PR #351](https://github.com/Yukihide-Mitsuoka/repchat/pull/351)はmerge済み。Issue #352／PR #353で成果物tree、共通composer、compact headerを固定応答で検証中。実Vertex AIとBigQueryは再実行していない |
+| 直近完了 | [PR #351](https://github.com/Yukihide-Mitsuoka/repchat/pull/351)の非JSON応答・pane所有構造修正、[PR #348](https://github.com/Yukihide-Mitsuoka/repchat/pull/348)のデモ視覚階層、[PR #344](https://github.com/Yukihide-Mitsuoka/repchat/pull/344)のGA4/GTM計測支援境界はmerge済み |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
-| AIができること | Issue #350を`spikes/report-generation`内で仕上げ、非JSON応答、pane所有関係、4状態、responsive、keyboard focus、既存品質gateを検証する。製品UIへ移植せず、有料queryを実行しない |
+| AIができること | Issue #352を`spikes/report-generation`内で仕上げ、成果物tree、compact header、左右pane、responsive、keyboard focus、既存品質gateを固定応答で検証する。製品UIへ移植せず、有料queryを実行しない |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |
 | 完了時 | 証拠を`proceed` / `revise` / `reject`に分類し、Issue #160と[status](status.md)を更新する。方向が変わる場合だけpositioning、ADR、decision logを更新する |
 
@@ -55,7 +55,7 @@ strict validatorを維持し、生成経路だけで妥当な項目を保持、�
 | 現在の競合・配信境界整理 | [#338 Evidence Cloud positioning and embedded delivery](https://github.com/Yukihide-Mitsuoka/repchat/issues/338)。Evidence Cloud公式仕様を事実側へ置き、RepChatの差別化仮説とauthoring／publishing／embedded deliveryのroute・permission分離を記録する | [競合比較](competitive-landscape.md)、[ポジショニング](positioning.md)、[分析ワークスペースUI要件](requirements/analysis-workspace-ui.md) |
 | 現在のUI情報設計 | [#179 dashboard／SQL来歴UX](https://github.com/Yukihide-Mitsuoka/repchat/issues/179)。外部UIは情報構造の参考に限定し、RepChat機能mapping、左右pane、responsive、keyboard、可視context、Insight保存／昇格、review／publish、embedded previewを再現可能な要件として固定する。Issue #160判定前に製品実装しない | [分析ワークスペースUI要件](requirements/analysis-workspace-ui.md)、[デモ手順](demo.md)、Issue #179 |
 | 完了した会議報告修正 | [#295 evidence validation](https://github.com/Yukihide-Mitsuoka/repchat/issues/295)／[PR #333](https://github.com/Yukihide-Mitsuoka/repchat/pull/333)。strict validatorを維持し、生成経路では根拠外数値を含む項目だけを除外する | [トラブルシューティング](troubleshooting/live-demo.md)、`meeting_report.py` |
-| 直近のデモUX | [#352 unified analysis workspace](https://github.com/Yukihide-Mitsuoka/repchat/issues/352)。4つのpeer modeを成果物treeと分析スレッドへ変え、中央下端の共通composerからdashboard／Insight／reportを明示選択する。単一グラフは右Artifact Preview、dashboard／reportは中央の成果物pageとし、既存の費用gate・SQL検査・根拠検証を維持する。左右toggleはviewport端へ固定して開閉時に座標を変えず、永続履歴・保存・Git連携は未実装 | [分析ワークスペースUI要件](requirements/analysis-workspace-ui.md)、[デモ手順](demo.md)、`live_demo.py`、`live-demo.test.ts` |
+| 直近のデモUX | [#352 unified analysis workspace](https://github.com/Yukihide-Mitsuoka/repchat/issues/352)。4つのpeer modeを成果物treeと分析スレッドへ変え、中央下端の共通composerからdashboard／Insight／reportを明示選択する。単一グラフは右Artifact Preview、dashboard／reportは中央の成果物pageとし、既存の費用gate・SQL検査・根拠検証を維持する。左右toggleはviewport端へ固定して開閉時に座標を変えない。選択titleは左treeと44px headerだけに置き、本文上部の大型重複blockを廃止する。履歴操作はブラウザへ委ね、永続履歴・保存・Git連携は未実装 | [分析ワークスペースUI要件](requirements/analysis-workspace-ui.md)、[デモ手順](demo.md)、`live_demo.py`、`live-demo.test.ts` |
 | 直近のデモ阻害解消 | [#325 requested navigation depth](https://github.com/Yukihide-Mitsuoka/repchat/issues/325)／[PR #326](https://github.com/Yukihide-Mitsuoka/repchat/pull/326)。custom depthの最終ページ到達前に上位12経路を選ぶSQLと、指定depth未満の結果を拒否する | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md)、`live_demo.py` |
 | 直近の認証修正 | [#321 ADC再認証エラー](https://github.com/Yukihide-Mitsuoka/repchat/issues/321)／[PR #322](https://github.com/Yukihide-Mitsuoka/repchat/pull/322)。`RefreshError`を安全な復旧手順へ変換し、ADC再認証とデモ再起動を確認済み。実問い合わせは費用再確認後だけ行う | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md)、`live_demo.py` |
 | 直近のデモ修正 | [#319 Sankey SVG ID分離](https://github.com/Yukihide-Mitsuoka/repchat/issues/319)／[PR #320](https://github.com/Yukihide-Mitsuoka/repchat/pull/320)。複数workspaceのSVG ID衝突を修正し、固定データで二つ同時描画を検証済み | [デモ手順](demo.md)、[トラブルシューティング](troubleshooting/live-demo.md)、`live_demo.py` |
@@ -82,7 +82,7 @@ positioningとroadmapを再評価します。
 
 ## 次にやる順序（2026-08-11）
 
-1. **現在:** [Issue #350](https://github.com/Yukihide-Mitsuoka/repchat/issues/350)で、操作不能な固定serverへの誘導をなくし、非JSON応答を安全に案内し、左右paneを全高・中央headerを中央列だけにしたshellを固定応答で検証する。実Vertex AI・BigQueryは実行しない。
+1. **現在:** [Issue #352](https://github.com/Yukihide-Mitsuoka/repchat/issues/352)で、成果物tree、共通composer、右Artifact／Inspector pane、compact headerを固定応答で検証する。選択titleは左treeと44px headerだけに置き、本文上部の大型重複blockは置かない。実Vertex AI・BigQueryは実行しない。
 2. **UI確認後:** ローカルデモを最新mainから再起動し、オーナーがダッシュボード、作成・編集、会議報告、単一グラフの見た目と操作を確認する。必要ならデザインパートナーへ見せる前の改善をIssueへ分ける。
 3. **オーナー承認後:** 実Vertex AI相談を1回確認する。成功後、別の費用確認を経てダッシュボードbuildを実行し、連続同一ページ統合後のR17参照値、色、リンク値、2ページ目終了注記、取得データを確認する。
 4. **並行するオーナー作業:** [#160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)の参加者を選定して日程を決める。デモ阻害を解消後に5分デモを行い、`proceed` / `revise` / `reject`へ分類する。

--- a/docs/requirements/analysis-workspace-ui.md
+++ b/docs/requirements/analysis-workspace-ui.md
@@ -101,6 +101,7 @@ SQL来歴確認、会議報告を一つの再現可能なワークスペース�
 | SRC-17 | Official | ChatGPTのProjectsはsidebarから作成・選択し、project内へchatとfileをまとめ、chatをprojectへ移動できる | [Projects in ChatGPT](https://help.openai.com/en/articles/10169521-using-projects-in-chatgpt) |
 | SRC-18 | Official | ChatGPT Canvasはchatとは別の右側workspaceを開き、本文を直接編集しながら会話で修正できる | [Canvas in ChatGPT](https://help.openai.com/en/articles/9930697-what-is-the-canvas-feature-in-chatgpt) |
 | SRC-19 | Owner-provided observation | 2026-08-11のChatGPTデスクトップ画像では、左paneがviewport上端から下端までを所有し、中央headerは左paneの右から始まる。pane境界は細い線、上部操作は小型で、階層は余白・濃淡・選択背景を中心に表現される | この依頼の添付画像 |
+| SRC-20 | Owner-provided observation | 2026-08-11のChatGPTデスクトップ画像では、左treeの選択中thread名と中央compact headerの文言が一致し、同じthread名を中央本文の大型見出しとして繰り返さない | この依頼の添付画像 |
 
 ### 4.2 証拠の扱い
 
@@ -159,7 +160,7 @@ SQL来歴確認、会議報告を一つの再現可能なワークスペース�
 | ID | 要件 | 目的 | 優先度 | 根拠 |
 |----|------|------|--------|------|
 | APP-001 | app shellは全高の`PrimaryNavigationPane`、`MainColumn`、全高の`SecondaryPane`、`OverlayHost`を兄弟領域として持つ。`MainHeader`は`MainColumn`内に置き、左右paneの上を横断しない | 文脈保持 | Must | SRC-18、SRC-19 |
-| APP-002 | `MainHeader`は高さ44pxでstickyとし、現在の成果物、組織／分析コレクション、状態を置く。製品名、検索、projectは左paneの`NavigationHeader`へ置き、左右toggleはAPP-008の固定`ChromeAnchorLayer`が所有する | 発見性 | Must | SRC-17、SRC-19、RepChat decision |
+| APP-002 | `MainHeader`は高さ44pxでstickyとし、左treeで選択中の成果物／threadと同じtitle、組織／分析コレクション、状態を置く。同じtitleを本文上部の大型見出しとして反復しない。製品名、検索、projectは左paneの`NavigationHeader`へ置き、左右toggleはAPP-008の固定`ChromeAnchorLayer`が所有する | 発見性 | Must | SRC-17、SRC-19、SRC-20、RepChat decision |
 | APP-003 | 左右paneがpush状態でも`MainSurface`をDOM上の明示的な中央grid列に保ち、閉じたpaneは0pxにする | レイアウト安定性 | Must | PR #332 |
 | APP-004 | route、選択panel、表示revisionをURLで表現し、再読込、back、forward、共有linkで復元する | 文脈保持 | Must | Issue #179 |
 | APP-005 | viewer、editor、adminで利用不能な機能は、存在を隠すか理由付きdisabledにする。クリック後に権限エラーを初めて出さない | 安全性 | Must | C-3 |
@@ -551,7 +552,8 @@ app shell自体に新しい有料infraや外部UI libraryを必須としませ�
 | AC-21 | 分析対話で右paneをArtifact PreviewからInspectorへ切り替えても会話位置とdraft revisionを維持し、tablet以下ではoverlay／sheetとして復帰できる | APP-006、INS-012、§6.7 | viewport E2E |
 | AC-22 | embedded customer viewはpublished revisionだけを表示し、URL直打ちを含めSQL編集、panel構成、branch、publishへ到達できない。編集者は別authoring routeでのみ修正できる | C-6、MAIN-017、NFR-004 | role別authorization E2E |
 | AC-23 | visible splitterは1px、drag hit areaは8px、header iconは32px角、navigation rowは36px以上、通常文字weightは400〜600であり、太い境界や大型buttonで階層を代用しない | APP-002、§7 | computed style＋visual regression |
-| AC-24 | APIがHTMLまたは空bodyを返してもJSON parser例外やHTML断片を表示せず、操作可能なlive serverへの接続案内を表示する | MAIN-008 | endpoint contract test |
+| AC-24 | 左treeの選択titleと44px header titleが一致し、本文上部に同じ大型title／説明blockがない | APP-002 | viewport E2E＋navigation review |
+| AC-25 | APIがHTMLまたは空bodyを返してもJSON parser例外やHTML断片を表示せず、操作可能なlive serverへの接続案内を表示する | MAIN-008 | endpoint contract test |
 
 ## 15. リスク
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -35,7 +35,8 @@ Issue #350／PR #351で非JSON応答、pane所有構造、hairline、control密�
 成果物treeと分析スレッドへ置き換え、中央下端の一つのcomposerからdashboard、未保存Insight、会議報告を
 明示選択する。単一グラフの結果は右Artifact Preview、dashboard／reportは中央成果物pageへ置く。左右toggleは
 viewport端に固定し、pane開閉・resizeで座標を変えず、iconとaccessible nameで状態を示す。既存の費用gate、
-SQL検査、根拠検証は変更しない。固定応答・静的ブラウザ検査だけを行い、実Vertex AI・BigQueryは呼ばない。
+SQL検査、根拠検証は変更しない。選択titleは左treeと44px headerだけに置き、本文上部の大型重複blockをなくす。
+製品版の履歴操作はURL化してブラウザへ委ねる。固定応答・静的ブラウザ検査だけを行い、実Vertex AI・BigQueryは呼ばない。
 製品UIへの移植、永続履歴、成果物保存、Git連携、公開workflowは未実装である。
 
 `make doctor`の最終実行では、今回未変更の`setup-github.sh` wrapper testが5秒timeoutした。

--- a/spikes/report-generation/live_demo.py
+++ b/spikes/report-generation/live_demo.py
@@ -150,7 +150,7 @@ if _GLOBAL_HEADER is None:  # pragma: no cover - static template invariant
 _original_header_markup = _GLOBAL_HEADER.group(0)
 _header_markup = _original_header_markup.replace(
     '<span class="brand">RepChat</span><span>Live analysis demo</span>',
-    '<span class="header-title">分析ワークスペース</span>',
+    '<span id="compact-title" class="header-title">分析ワークスペース</span>',
 )
 HTML = HTML.replace(_original_header_markup, "", 1)
 HTML = HTML.replace('<main id="workspace-main"', _header_markup + '<main id="workspace-main"', 1)
@@ -172,8 +172,8 @@ _sidebar_body = r"""
 <button id="new-analysis" class="new-analysis" type="button">新しい分析</button>
 <p class="sidebar-label">成果物</p>
 <nav class="workspace-nav artifact-tree" aria-label="分析成果物">
-<button id="view-dashboard" type="button"><span>ダッシュボード</span><small>2021年1月 購入成果改善</small></button>
-<button id="view-graph" type="button"><span>インサイト</span><small>未保存の単一グラフ</small></button>
+<button id="view-dashboard" type="button"><span>購入成果改善ダッシュボード</span><small>2021年1月</small></button>
+<button id="view-graph" type="button"><span>未保存のインサイト</span><small>単一グラフ</small></button>
 <button id="view-report" type="button"><span>会議報告</span><small>根拠付き下書き</small></button>
 </nav>
 <p class="sidebar-label">分析スレッド</p>
@@ -227,6 +227,11 @@ HTML = HTML.replace(
 HTML = HTML.replace(
     'build:["ダッシュボードを作成・編集","AIと分析目的を相談し、確認した仕様だけをbuildします。","相談・build"]',
     'build:["購入成果を改善する","AIと目的・KPI・比較軸を相談し、確認した仕様だけをbuildします。","分析スレッド"]',
+    1,
+)
+HTML = HTML.replace(
+    'graph:["単一グラフを生成","日本語からSQL生成・安全検査・BigQuery実行・可視化までを確認します。","ライブ実行"]',
+    'graph:["未保存のインサイト","日本語からSQL生成・安全検査・BigQuery実行・可視化までを確認します。","ライブ実行"]',
     1,
 )
 
@@ -440,6 +445,7 @@ h1{font-size:22px}
 .sidebar-chrome{padding-left:42px;border-bottom:1px solid #e7e7e8}
 .workspace-inspector{padding-top:52px}
 .workspace{height:calc(100vh - var(--header-height));overflow:auto;padding-bottom:150px}
+.workspace-topbar{display:none}
 .workspace-sidebar .new-analysis{width:100%;justify-content:flex-start;margin:10px 0 2px;border:0;background:transparent;color:#202123;text-align:left}
 .workspace-sidebar .new-analysis::before{content:"＋";margin-right:9px;font-size:17px}
 .artifact-tree button,.thread-tree button{grid-template-rows:auto auto}
@@ -474,6 +480,8 @@ function toggleInspector(){const collapsed=$("app-shell").classList.toggle("insp
 function showInsightArtifact(hasResult=false){const pane=$("panel-inspector");pane.classList.add("artifact-active");$("artifact-preview").className="artifact-preview";$("artifact-preview-empty").className=hasResult?"hidden":"inspector-empty";$("inspector-title").textContent="インサイト";$("inspector-subtitle").textContent="未保存の分析結果";if($("app-shell").classList.contains("inspector-collapsed"))toggleInspector()}
 function hideInsightArtifact(){const pane=$("panel-inspector");pane.classList.remove("artifact-active");$("artifact-preview").className="artifact-preview hidden"}
 function setComposerAction(action,copyInput=true){document.querySelectorAll("[data-composer-action]").forEach(button=>button.classList.toggle("selected",button.dataset.composerAction===action));$("analysis-composer").dataset.action=action;$("composer-profile").className=action==="insight"?"":"hidden";const input=$("composer-input");if(copyInput)input.value=action==="dashboard"?$("dashboard-question").value:action==="insight"?$("question").value:"このダッシュボードの結果から、会議で判断すべき論点と次のアクションを報告案にして";$("composer-target").textContent=action==="dashboard"?"対象: 現在の分析スレッド":action==="insight"?"対象: 未保存のインサイト":"対象: 最新ダッシュボード"}
+const baseSelectWorkspace=selectWorkspace;
+selectWorkspace=view=>{baseSelectWorkspace(view);$("compact-title").textContent=$("page-title").textContent};
 function submitComposer(){const action=$("analysis-composer").dataset.action||"dashboard",question=$("composer-input").value.trim();if(!question){$("composer-message").textContent="分析したい内容を入力してください。";return}$("composer-message").textContent="費用と実行範囲を確認します。";if(action==="insight"){selectWorkspace("graph");$("question").value=question;$("dataset-profile").value=$("composer-profile").value;selectProfile($("composer-profile").value);showInsightArtifact();showCost("graph");return}$("dashboard-question").value=question;if(action==="report"){if(!latestBuildRevision){$("composer-message").textContent="先にダッシュボードをbuildしてください。";return}showCost("report");return}currentAnswers={};currentPlan=null;pendingPlan=null;dashboardStage();showCost("dashboard-plan")}
 const originalQueryHandler=handle;handle=e=>{if(["sql","result","refusal"].includes(e.type))showInsightArtifact(true);originalQueryHandler(e)};
 const originalPanelInspector=openPanelInspector;openPanelInspector=panelId=>{hideInsightArtifact();originalPanelInspector(panelId)};
@@ -487,6 +495,7 @@ $("view-build").onclick=()=>{hideInsightArtifact();selectWorkspace("build");setC
 $("view-report").onclick=()=>{hideInsightArtifact();selectWorkspace("report");setComposerAction("report",false)};
 $("view-graph").onclick=()=>{selectWorkspace("graph");setComposerAction("insight",false);showInsightArtifact(!$("output").classList.contains("hidden"))};
 updatePaneButton("sidebar-toggle","left",!$("app-shell").classList.contains("sidebar-collapsed"),$("app-shell").classList.contains("sidebar-collapsed")?"ナビゲーションを展開":"ナビゲーションを折りたたむ");updatePaneButton("inspector-toggle","right",!$("app-shell").classList.contains("inspector-collapsed"),$("app-shell").classList.contains("inspector-collapsed")?"成果物パネルを展開":"成果物パネルを折りたたむ");
+const headerMeta=document.querySelector(".app-header .header-context:last-child");headerMeta.insertBefore($("workspace-state"),headerMeta.querySelector(".draft-badge"));
 selectWorkspace("build");setComposerAction("dashboard",false);
 if(window.innerWidth<=1180 && $("inspector-toggle").getAttribute("aria-expanded")==="true")toggleInspector();
 if(window.innerWidth<=960 && $("sidebar-toggle").getAttribute("aria-expanded")==="true")toggleSidebar();

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -1291,7 +1291,7 @@ print(json.dumps({
  "views":all(value in html for value in ['id="artifact-dashboard-view"','id="build-studio-view"','id="meeting-report-view"','id="graph-workspace"']),
  "navigation":all(value in html for value in ['id="view-dashboard"','id="view-build"','id="view-report"','id="view-graph"']),
  "conversation":all(value in html for value in ['id="analysis-composer"','id="composer-input"','data-composer-action="dashboard"','data-composer-action="insight"','data-composer-action="report"']),
- "artifact_tree":all(value in html for value in ['aria-label="分析成果物"','未保存の単一グラフ','aria-label="分析スレッド"','現在の対話']),
+ "artifact_tree":all(value in html for value in ['aria-label="分析成果物"','購入成果改善ダッシュボード','未保存のインサイト','aria-label="分析スレッド"','購入成果を改善する','現在の対話']),
  "inspector":all(value in html for value in ['id="inspector-empty"','id="inspector-content"','id="inspector-tab-reason"','id="inspector-tab-sql"','id="inspector-tab-data"','id="inspector-tab-provenance"']),
  "artifact_preview":all(value in html for value in ['id="artifact-preview"','id="artifact-preview-host"','単一グラフのインサイト']),
 }))
@@ -1381,8 +1381,23 @@ test('workspace panes own the full height while the header belongs to the main c
   assert.match(html, /\.workspace-inspector\{grid-column:5;grid-row:1\/3/);
   assert.match(html, /\.app-header\{grid-column:3;grid-row:1/);
   assert.match(html, /class="sidebar-chrome"><span class="brand">RepChat/);
-  assert.match(html, /class="header-title">分析ワークスペース/);
+  assert.match(html, /id="compact-title" class="header-title">分析ワークスペース/);
   assert.doesNotMatch(html, /<span class="brand">RepChat<\/span><span>Live analysis demo/);
+});
+
+test('selected workspace title is compact and not repeated above the main content', () => {
+  const rendered = python('print(m.HTML)');
+  assert.equal(rendered.status, 0, rendered.stderr);
+  assert.match(rendered.stdout, /\.workspace-topbar\{display:none\}/);
+  assert.match(
+    rendered.stdout,
+    /selectWorkspace=view=>\{baseSelectWorkspace\(view\);\$\("compact-title"\)\.textContent=\$\("page-title"\)\.textContent\}/,
+  );
+  assert.match(
+    rendered.stdout,
+    /build:\["購入成果を改善する","AIと目的・KPI・比較軸を相談し、確認した仕様だけをbuildします。","分析スレッド"\]/,
+  );
+  assert.doesNotMatch(rendered.stdout, /id="workspace-back"|id="workspace-forward"/);
 });
 
 test('workspace chrome uses compact controls and separates splitter hit area from its hairline', () => {


### PR DESCRIPTION
## 概要

Issue #352 のUI追補です。

- 左treeの選択titleと44px header titleを同期
- 中央本文上部の大型title・説明blockを廃止
- ダッシュボードと未保存Insightの左tree名を成果物名へ変更
- 独自の戻る・進むbuttonは追加せず、製品版はURLとブラウザ履歴へ委ねる方針を記録
- handoffとstatusを現在のIssue #352へ更新

## 検証

- make format
- make lint
- make test
- 1280x720の固定応答ブラウザ検査
  - 左treeとcompact headerのtitle一致
  - 大型title block非表示
  - 左pane開閉前後でtoggle座標不変
  - horizontal overflow 0
  - console warning/error 0

Vertex AIとBigQueryは実行していません。

Closes #352