### PR TITLE
feat(demo): add stateful analysis consultation planner

### DIFF
--- a/spikes/report-generation/analysis_planner.py
+++ b/spikes/report-generation/analysis_planner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import re
 
 ORGANIZATION_CONTEXT = {
     "revision": "demo-org-ec-v1",
@@ -260,6 +261,179 @@ def propose(client, model: str, objective: str, period: dict, metrics: str, answ
         period,
         answers,
         complete_purchase_recommendations=True,
+    ), token_counts(response.usage_metadata)
+
+
+CONSULTATION_CHARTS = (
+    "scorecard",
+    "bar",
+    "line",
+    "table",
+    "sankey",
+)
+CONSULTATION_FIELDS = (
+    "title",
+    "objective",
+    "metric",
+    "dimension",
+    "comparison",
+    "chart",
+    "execution_prompt",
+    "reason",
+)
+
+
+def _consultation_schema() -> dict:
+    recommendation_properties = {
+        field: {"type": "string"} for field in CONSULTATION_FIELDS
+    }
+    recommendation_properties["chart"] = {
+        "type": "string",
+        "format": "enum",
+        "enum": list(CONSULTATION_CHARTS),
+    }
+    return {
+        "type": "object",
+        "properties": {
+            "assistant_message": {"type": "string"},
+            "recommendations": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 4,
+                "items": {
+                    "type": "object",
+                    "properties": recommendation_properties,
+                    "required": list(CONSULTATION_FIELDS),
+                },
+            },
+            "follow_up_question": {"type": "string"},
+        },
+        "required": [
+            "assistant_message",
+            "recommendations",
+            "follow_up_question",
+        ],
+    }
+
+
+def consultation_request(
+    question: str,
+    history: list[dict[str, str]],
+    context: str,
+    profile: str,
+) -> str:
+    """Build one bounded, history-aware consultation turn."""
+    transcript = "\n".join(
+        f"{item['role']}: {item['content']}" for item in history
+    ) or "（初回）"
+    return f"""日本語で分析テーマを相談する。SQLやデータ取得はまだ行わない。
+
+これまでの対話:
+{transcript}
+
+今回の利用者発言: {question}
+
+分析対象profile: {profile}
+利用できるスキーマ・指標・期間の文脈:
+{context}
+
+規則:
+- 今回の発言と対話履歴を踏まえ、分析担当者として自然な日本語で応答する。
+- 分析仮説を立て、目的に役立つ新しい分析仕様を1〜4件考える。
+- 各仕様には、指標、切り口、比較軸、可視化、選択理由、SQL生成へ渡せる具体的な日本語依頼を書く。
+- 「他にない」など別案を求められた場合、履歴で既に提示した分析をできる限り避ける。
+- 最後に、分析目的を具体化する短い確認質問を1件だけ書く。
+- 文脈にない指標・列・因果関係・取得済みでない数値を捏造しない。
+- SQLは書かない。execution_promptは、別工程のSQL生成AIへ渡す1行の日本語仕様にする。
+- 固定例から選択したように見せず、今回の目的に対する考察をassistant_messageとreasonへ明示する。
+"""
+
+
+def _bounded_consultation_text(value, label: str, limit: int = 500) -> str:
+    text = " ".join(str(value or "").split())
+    if not text:
+        raise PlannerError(f"分析相談の{label}が空です。")
+    if len(text) > limit:
+        raise PlannerError(f"分析相談の{label}が長すぎます。")
+    return text
+
+
+def normalize_consultation(raw: dict) -> dict:
+    """Validate newly reasoned analysis specifications before SQL generation."""
+    if not isinstance(raw, dict):
+        raise PlannerError("分析相談がJSON objectではありません。")
+    recommendations = []
+    seen: set[str] = set()
+    raw_recommendations = raw.get("recommendations")
+    if not isinstance(raw_recommendations, list) or not 1 <= len(raw_recommendations) <= 4:
+        raise PlannerError("分析相談の候補は1〜4件にしてください。")
+    for item in raw_recommendations:
+        if not isinstance(item, dict):
+            raise PlannerError("分析相談の候補がobjectではありません。")
+        recommendation = {
+            field: _bounded_consultation_text(
+                item.get(field),
+                "候補理由" if field == "reason" else field,
+                80 if field in {"title", "metric", "dimension", "comparison"} else 500,
+            )
+            for field in CONSULTATION_FIELDS
+        }
+        if recommendation["chart"] not in CONSULTATION_CHARTS:
+            raise PlannerError("分析相談の可視化種別が未対応です。")
+        execution_prompt = recommendation["execution_prompt"]
+        if re.search(
+            r"(?:```|`|\b(?:SELECT|WITH|FROM|GROUP\s+BY)\b)",
+            execution_prompt,
+            flags=re.IGNORECASE,
+        ):
+            raise PlannerError("分析相談の実行依頼にはSQLを書けません。")
+        duplicate_key = "".join(execution_prompt.lower().split())
+        if duplicate_key in seen:
+            raise PlannerError("分析相談に重複した候補があります。")
+        seen.add(duplicate_key)
+        recommendations.append(recommendation)
+    assistant_message = _bounded_consultation_text(raw.get("assistant_message"), "応答")
+    follow_up_question = _bounded_consultation_text(
+        raw.get("follow_up_question"), "確認質問"
+    )
+    titles = "、".join(item["title"] for item in recommendations)
+    history_message = (
+        f"{assistant_message}\n提案: {titles}\n確認: {follow_up_question}"
+    )
+    return {
+        "assistant_message": assistant_message,
+        "recommendations": recommendations,
+        "follow_up_question": follow_up_question,
+        "history_message": history_message,
+    }
+
+
+def propose_consultation(
+    client,
+    model: str,
+    question: str,
+    history: list[dict[str, str]],
+    context: str,
+    profile: str,
+):
+    """Ask Vertex AI to reason about new analyses without generating SQL."""
+    from google.genai import types
+    from vertex_usage import token_counts
+
+    response = client.models.generate_content(
+        model=model,
+        contents=consultation_request(question, history, context, profile),
+        config=types.GenerateContentConfig(
+            system_instruction=(
+                "あなたは利用者の意思決定を明確にし、実行可能な分析だけを提案する"
+                "日本語BIアナリスト。"
+            ),
+            response_mime_type="application/json",
+            response_schema=_consultation_schema(),
+        ),
+    )
+    return normalize_consultation(
+        json.loads(response.text)
     ), token_counts(response.usage_metadata)
 
 

--- a/tests/spikes/report-generation/analysis-planner.test.ts
+++ b/tests/spikes/report-generation/analysis-planner.test.ts
@@ -115,6 +115,69 @@ print(json.dumps({"recommended":[panel["id"] for panel in recommended["panels"]]
   });
 });
 
+test('analysis consultation creates new executable specifications from context and history', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+context="定義済み指標: セッション数、購入件数。利用可能な軸: medium、device category。"
+history=[
+ {"role":"user","content":"どんな分析をしたらいい？"},
+ {"role":"assistant","content":"全体規模を確認する分析を提案しました。"},
+]
+raw={
+ "assistant_message":"別の切り口なら流入元を比較できます。",
+ "recommendations":[{
+  "title":"流入チャネル別の購入効率",
+  "objective":"集客量だけでなく購入成果につながる流入元を見つける",
+  "metric":"セッション数と購入件数",
+  "dimension":"medium",
+  "comparison":"2021年1月の流入チャネル間比較",
+  "chart":"bar",
+  "execution_prompt":"2021年1月のセッション数と購入件数を流入チャネル（medium）別に出して",
+  "reason":"集客の偏りと成果の両方を判断できるため"
+ }],
+ "follow_up_question":"成果と集客のどちらを優先しますか？",
+}
+normalized=p.normalize_consultation(raw)
+request=p.consultation_request("他にない？",history,context,"ga4")
+errors=[]
+for invalid in [
+ {**raw,"recommendations":[raw["recommendations"][0],raw["recommendations"][0]]},
+ {**raw,"recommendations":[{**raw["recommendations"][0],"execution_prompt":"SELECT * FROM events"}]},
+ {**raw,"recommendations":[{**raw["recommendations"][0],"reason":""}]},
+]:
+ try:p.normalize_consultation(invalid)
+ except p.PlannerError as error:errors.append(str(error))
+print(json.dumps({
+ "titles":[item["title"] for item in normalized["recommendations"]],
+ "generated_prompt":normalized["recommendations"][0]["execution_prompt"],
+ "history_in_request":all(item["content"] in request for item in history),
+ "current_in_request":"他にない？" in request,
+ "context_in_request":"medium" in request,
+ "errors":errors,
+},ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    titles: ['流入チャネル別の購入効率'],
+    generated_prompt: '2021年1月のセッション数と購入件数を流入チャネル（medium）別に出して',
+    history_in_request: true,
+    current_in_request: true,
+    context_in_request: true,
+    errors: [
+      '分析相談に重複した候補があります。',
+      '分析相談の実行依頼にはSQLを書けません。',
+      '分析相談の候補理由が空です。',
+    ],
+  });
+});
+
 test('planner constrains each response schema to unanswered clarification fields', () => {
   const result = spawnSync(
     'python3',


### PR DESCRIPTION
## What & why

Issue #373の第1段階として、固定候補を並べ替える相談から、schema・指標・目的・対話履歴を使って分析仕様を新規作成するplanner契約へ移行します。このPRは構造化response schema、履歴付きprompt、SQL混入・重複・未対応chartのfail-closed検証だけを追加し、UI/API接続は次の小さいPRに分離します。

Refs: #373

## Change classification (ARC-020)

- [x] Local (inside one module, contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: 回帰テストを先に追加し、`normalize_consultation`未実装で失敗することを確認。実装後に`make format`、`make lint`、`make test`が成功（PR #372を含む`origin/main`へrebase後）。
- Not verified (be honest — GR-042): 実Vertex AI呼出しは課金対象のため未実行。固定応答と構造検証のみ。

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: n/a — planner準備PR。利用者向け文書はUI/API接続PRで同時更新

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes (optional, helps reviewers): 分析内容をハードコードせず、将来の分析skillを差し込める構造を優先

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)
