### PR TITLE
feat(demo): define AI-authored dashboard plans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,13 @@
 # only to run migrations; may be the -pooler host (the runner derives the direct
 # endpoint for DDL). Real value lives in .env, never here.
 DATABASE_URL=postgresql://neondb_owner:CHANGE_ME@ep-xxxx-pooler.REGION.aws.neon.tech/neondb?sslmode=require
+
 # APP_RUNTIME_PASSWORD: a fresh 16+ char secret ([A-Za-z0-9_-]) for the
 # least-privilege app_runtime role. NOT the neondb_owner password. The runner
 # sets app_runtime's login password from this on apply.
 APP_RUNTIME_PASSWORD=CHANGE_ME_16_CHARS_MIN
+
+# --- local analysis demo policy (non-secret; restart required after changes) ---
+# Bounds AI-authored dashboard plans without selecting topics or chart types.
+ANALYSIS_INITIAL_PANEL_COUNT=6
+ANALYSIS_MAX_PANEL_COUNT=20

--- a/spikes/report-generation/README.md
+++ b/spikes/report-generation/README.md
@@ -343,6 +343,11 @@ Sankeyの結果形状と
 これはIssue #180のローカル未検証プロトタイプです。本番の永続revision、非同期queue、再開、公開、
 任意の分析パネル生成、デザインパートナー評価は未実装です。
 
+Issue #374の準備として、固定候補を渡さずにAIが`title`、`kpi`、`chart`、`decision`、`reason`、
+`execution_prompt`を作る別のplanner契約を追加しています。初回提案数は
+`ANALYSIS_INITIAL_PANEL_COUNT`、上限は`ANALYSIS_MAX_PANEL_COUNT`で管理し、既定は6件／20件です。
+この準備契約は現在のlive endpointから未使用であり、固定候補を置き換えるdashboard連携は後続PRで行います。
+
 単一グラフの「相談」は、Vertex AIへ現在の問いと最大8 turnのbrowser session履歴、対象schema、
 定義済み指標を渡し、1〜4件の分析仕様を新規に作ります。「他にない？」では既出提案を避けます。
 固定候補配列はplannerへ渡しません。提案選択は日本語の実行仕様をcomposerへ移すだけで、SQL生成と

--- a/spikes/report-generation/analysis_planner.py
+++ b/spikes/report-generation/analysis_planner.py
@@ -61,12 +61,7 @@ DASHBOARD_CHARTS = ("scorecard", "bar", "line", "table", "sankey")
 DEFAULT_INITIAL_PANEL_COUNT = 6
 DEFAULT_MAX_PANEL_COUNT = 20
 DYNAMIC_PANEL_FIELDS = (
-    "title",
-    "kpi",
-    "chart",
-    "decision",
-    "reason",
-    "execution_prompt",
+    "title", "kpi", "chart", "decision", "reason", "execution_prompt"
 )
 
 

--- a/spikes/report-generation/analysis_planner.py
+++ b/spikes/report-generation/analysis_planner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import os
 import re
 
 ORGANIZATION_CONTEXT = {
@@ -56,7 +57,43 @@ PANEL_CATALOG = {
 }
 
 CLARIFICATION_FIELDS = ("audience", "comparison", "business_goal")
-PURCHASE_IMPROVEMENT_PANEL_IDS = tuple(PANEL_CATALOG)
+DASHBOARD_CHARTS = ("scorecard", "bar", "line", "table", "sankey")
+DEFAULT_INITIAL_PANEL_COUNT = 6
+DEFAULT_MAX_PANEL_COUNT = 20
+DYNAMIC_PANEL_FIELDS = (
+    "title",
+    "kpi",
+    "chart",
+    "decision",
+    "reason",
+    "execution_prompt",
+)
+
+
+def _positive_count_setting(name: str, default: int) -> int:
+    """Read one admin-owned positive count without selecting analysis content."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise ValueError(f"{name} must be a positive integer") from error
+    if value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+MAX_PANEL_COUNT = _positive_count_setting(
+    "ANALYSIS_MAX_PANEL_COUNT", DEFAULT_MAX_PANEL_COUNT
+)
+INITIAL_PANEL_COUNT = _positive_count_setting(
+    "ANALYSIS_INITIAL_PANEL_COUNT", min(DEFAULT_INITIAL_PANEL_COUNT, MAX_PANEL_COUNT)
+)
+if INITIAL_PANEL_COUNT > MAX_PANEL_COUNT:
+    raise ValueError(
+        "ANALYSIS_INITIAL_PANEL_COUNT must not exceed ANALYSIS_MAX_PANEL_COUNT"
+    )
 
 PLAN_SCHEMA = {
     "type": "object",
@@ -99,6 +136,29 @@ PLAN_SCHEMA = {
     ],
 }
 
+DYNAMIC_PLAN_SCHEMA = copy.deepcopy(PLAN_SCHEMA)
+DYNAMIC_PLAN_SCHEMA["properties"]["panels"] = {
+    "type": "array",
+    "minItems": INITIAL_PANEL_COUNT,
+    "maxItems": INITIAL_PANEL_COUNT,
+    "items": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string"},
+            "kpi": {"type": "string"},
+            "chart": {
+                "type": "string",
+                "format": "enum",
+                "enum": list(DASHBOARD_CHARTS),
+            },
+            "decision": {"type": "string"},
+            "reason": {"type": "string"},
+            "execution_prompt": {"type": "string"},
+        },
+        "required": list(DYNAMIC_PANEL_FIELDS),
+    },
+}
+
 
 class PlannerError(ValueError):
     """A planner contract violation safe to show in the local UI."""
@@ -116,6 +176,15 @@ def _response_schema(answers: dict[str, str]) -> dict:
         field_schema = clarifications["items"]["properties"]["field"]
         field_schema["format"] = "enum"
         field_schema["enum"] = unanswered
+    return schema
+
+
+def _dashboard_response_schema(answers: dict[str, str]) -> dict:
+    """Constrain an initial AI-authored dashboard to the configured panel count."""
+    schema = _response_schema(answers)
+    schema["properties"]["panels"] = copy.deepcopy(
+        DYNAMIC_PLAN_SCHEMA["properties"]["panels"]
+    )
     return schema
 
 
@@ -150,6 +219,41 @@ def planning_request(
 """
 
 
+def dashboard_planning_request(
+    objective: str, period: dict[str, str], metrics: str, answers: dict[str, str]
+) -> str:
+    """Build an initial request that asks the model to author panel specifications."""
+    answered = json.dumps(answers, ensure_ascii=False, sort_keys=True)
+    return f"""次の依頼から、月次ECサイト分析ダッシュボードを計画する。
+
+依頼: {objective}
+対象期間: {period['label']}
+読者回答: {answered}
+組織コンテキスト: {json.dumps(ORGANIZATION_CONTEXT, ensure_ascii=False)}
+スキーマ・指標定義:
+{metrics}
+
+利用できる可視化形式:
+- scorecard: 1つの成果指標
+- bar: 1つの区分軸と1つの数値
+- line: 日付と1つの数値
+- table: 意思決定に必要な最小限の列
+- sankey: source、target、sessionsで表せる段階付きフロー
+
+規則:
+- 目的を意思決定へ言い換え、検証可能な仮説を最大3件にする。
+- 固定済みの分析候補から選ばず、目的と仮説から分析仕様そのものを新規に考える。
+- 最初から大量に列挙せず、今回の目的に適したパネルを{INITIAL_PANEL_COUNT}件提案する。
+- 可視化は慣例で決めず、比較、構成比、時系列、偏り、フローのどれを判断するかに合わせて選ぶ。
+- 各パネルにはtitle、kpi、chart、decision、reasonと、SQL生成へ渡す具体的な1行の日本語execution_promptを書く。
+- execution_promptにはSQLを書かない。対象期間、指標、軸、比較、必要な出力列が分かる仕様にする。
+- KPI・グラフの選択理由をパネルごとに日本語で説明する。
+- 初回は audience / comparison / business_goal から重要な確認を1〜3件だけ質問する。
+- 読者回答にあるfieldは再質問しない。十分ならclarificationsを空にする。
+- 利用できない指標や因果関係を捏造しない。
+"""
+
+
 def _text(value, label: str) -> str:
     normalized = str(value or "").strip()
     if not normalized:
@@ -157,15 +261,19 @@ def _text(value, label: str) -> str:
     return normalized
 
 
-def normalize_plan(
+def _plan_panel_text(value, label: str, limit: int = 300) -> str:
+    text = " ".join(_text(value, label).split())
+    if len(text) > limit:
+        raise PlannerError(f"分析計画の{label}が長すぎます。")
+    return text
+
+
+def _normalize_plan_header(
     raw: dict,
     objective: str,
     period: dict[str, str],
-    answers: dict[str, str] | None = None,
-    *,
-    complete_purchase_recommendations: bool = False,
+    answers: dict[str, str] | None,
 ) -> dict:
-    """Validate model output and produce a deterministic proposed revision."""
     answers = answers or {}
     if not isinstance(raw, dict):
         raise PlannerError("分析計画がJSON objectではありません。")
@@ -178,11 +286,10 @@ def normalize_plan(
     if not 1 <= len(hypotheses) <= 3:
         raise PlannerError("分析計画の仮説は1〜3件にしてください。")
     clarifications = []
-    allowed_fields = set(CLARIFICATION_FIELDS)
     for item in raw.get("clarifications", []):
         field = item.get("field") if isinstance(item, dict) else None
         diagnostic = json.dumps(field, ensure_ascii=False)
-        if field not in allowed_fields:
+        if field not in CLARIFICATION_FIELDS:
             raise PlannerError(f"確認事項のfieldが許可範囲外です: {diagnostic}")
         if field in answers:
             raise PlannerError(f"確認事項のfieldは回答済みです: {diagnostic}")
@@ -197,33 +304,7 @@ def normalize_plan(
         )
     if len(clarifications) > 3 or (not answers and not clarifications):
         raise PlannerError("初回の確認事項は1〜3件にしてください。")
-    panel_reasons, seen = {}, set()
-    for item in raw.get("panels", []):
-        panel_id = item.get("id") if isinstance(item, dict) else None
-        if panel_id not in PANEL_CATALOG or panel_id in seen:
-            raise PlannerError("分析計画に未登録または重複したパネルがあります。")
-        seen.add(panel_id)
-        panel_reasons[panel_id] = _text(item.get("reason"), "パネル選択理由")
-    if not 4 <= len(panel_reasons) <= 6:
-        raise PlannerError("分析計画のパネルは4〜6件にしてください。")
-    compact_objective = "".join(objective.split())
-    broad_purchase_improvement = (
-        "購入" in compact_objective
-        and "改善" in compact_objective
-        and any(word in compact_objective for word in ("課題", "優先施策"))
-    )
-    if complete_purchase_recommendations and broad_purchase_improvement:
-        for panel_id in PURCHASE_IMPROVEMENT_PANEL_IDS:
-            panel_reasons.setdefault(
-                panel_id,
-                f"{PANEL_CATALOG[panel_id]['decision']}ため",
-            )
-    panels = [
-        {"id": panel_id, **item, "reason": panel_reasons[panel_id]}
-        for panel_id, item in PANEL_CATALOG.items()
-        if panel_id in panel_reasons
-    ]
-    plan = {
+    return {
         "status": "proposed",
         "objective": _text(objective, "目的"),
         "objective_summary": _text(raw.get("objective_summary"), "目的要約"),
@@ -234,11 +315,90 @@ def normalize_plan(
         "clarifications": clarifications,
         "answers": answers,
         "organization_context_revision": ORGANIZATION_CONTEXT["revision"],
-        "panels": panels,
     }
+
+
+def _revisioned_plan(plan: dict) -> dict:
     canonical = json.dumps(plan, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     plan["revision"] = "plan-" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
     return plan
+
+
+def normalize_plan(
+    raw: dict,
+    objective: str,
+    period: dict[str, str],
+    answers: dict[str, str] | None = None,
+    *,
+    complete_purchase_recommendations: bool = False,
+) -> dict:
+    """Validate the fixed-catalog fixture contract used by the current demo."""
+    plan = _normalize_plan_header(raw, objective, period, answers)
+    panel_reasons, seen = {}, set()
+    for item in raw.get("panels", []):
+        panel_id = item.get("id") if isinstance(item, dict) else None
+        if panel_id not in PANEL_CATALOG or panel_id in seen:
+            raise PlannerError("分析計画に未登録または重複したパネルがあります。")
+        seen.add(panel_id)
+        panel_reasons[panel_id] = _text(item.get("reason"), "パネル選択理由")
+    if not 4 <= len(panel_reasons) <= 6:
+        raise PlannerError("分析計画のパネルは4〜6件にしてください。")
+    compact_objective = "".join(objective.split())
+    if (
+        complete_purchase_recommendations
+        and "購入" in compact_objective
+        and "改善" in compact_objective
+        and any(word in compact_objective for word in ("課題", "優先施策"))
+    ):
+        for panel_id, item in PANEL_CATALOG.items():
+            panel_reasons.setdefault(panel_id, f"{item['decision']}ため")
+    plan["panels"] = [
+        {"id": panel_id, **item, "reason": panel_reasons[panel_id]}
+        for panel_id, item in PANEL_CATALOG.items()
+        if panel_id in panel_reasons
+    ]
+    return _revisioned_plan(plan)
+
+
+def normalize_dashboard_plan(
+    raw: dict,
+    objective: str,
+    period: dict[str, str],
+    answers: dict[str, str] | None = None,
+) -> dict:
+    """Validate model output and produce a deterministic proposed revision."""
+    plan = _normalize_plan_header(raw, objective, period, answers)
+    raw_panels = raw.get("panels", [])
+    if not isinstance(raw_panels, list) or not 1 <= len(raw_panels) <= MAX_PANEL_COUNT:
+        raise PlannerError(f"分析計画のパネルは1〜{MAX_PANEL_COUNT}件にしてください。")
+    panels, seen_prompts = [], set()
+    for index, item in enumerate(raw_panels, start=1):
+        if not isinstance(item, dict):
+            raise PlannerError("分析計画のパネルがobjectではありません。")
+        panel = {
+            field: _plan_panel_text(
+                item.get(field),
+                "パネル選択理由" if field == "reason" else field,
+                80 if field in {"title", "kpi", "chart"} else 300,
+            )
+            for field in DYNAMIC_PANEL_FIELDS
+        }
+        if panel["chart"] not in DASHBOARD_CHARTS:
+            raise PlannerError("分析計画の可視化種別が未対応です。")
+        prompt = panel["execution_prompt"]
+        if re.search(
+            r"(?:```|`|\b(?:SELECT|WITH|FROM|GROUP\s+BY)\b)",
+            prompt,
+            flags=re.IGNORECASE,
+        ):
+            raise PlannerError("分析計画の実行仕様にはSQLを書けません。")
+        prompt_key = "".join(prompt.lower().split())
+        if prompt_key in seen_prompts:
+            raise PlannerError("分析計画に重複した実行仕様があります。")
+        seen_prompts.add(prompt_key)
+        panels.append({"id": f"P{index}", **panel})
+    plan["panels"] = panels
+    return _revisioned_plan(plan)
 
 
 def propose(client, model: str, objective: str, period: dict, metrics: str, answers: dict):
@@ -264,13 +424,28 @@ def propose(client, model: str, objective: str, period: dict, metrics: str, answ
     ), token_counts(response.usage_metadata)
 
 
-CONSULTATION_CHARTS = (
-    "scorecard",
-    "bar",
-    "line",
-    "table",
-    "sankey",
-)
+def propose_dashboard(
+    client, model: str, objective: str, period: dict, metrics: str, answers: dict
+):
+    """Ask Vertex AI to author bounded dashboard panel specifications."""
+    from google.genai import types
+    from vertex_usage import token_counts
+
+    response = client.models.generate_content(
+        model=model,
+        contents=dashboard_planning_request(objective, period, metrics, answers),
+        config=types.GenerateContentConfig(
+            system_instruction="あなたは意思決定から分析仕様を設計する日本語BIプランナー。",
+            response_mime_type="application/json",
+            response_schema=_dashboard_response_schema(answers),
+        ),
+    )
+    return normalize_dashboard_plan(
+        json.loads(response.text), objective, period, answers
+    ), token_counts(response.usage_metadata)
+
+
+CONSULTATION_CHARTS = DASHBOARD_CHARTS
 CONSULTATION_FIELDS = (
     "title",
     "objective",
@@ -473,3 +648,37 @@ def confirm_plan(plan: dict) -> dict:
     )
     confirmed["revision"] = "plan-" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
     return confirmed
+
+
+def confirm_dashboard_plan(plan: dict) -> dict:
+    """Revalidate an edited AI-authored proposal and freeze its full specification."""
+    answers = plan.get("answers", {})
+    if not isinstance(answers, dict):
+        raise PlannerError("確認事項の回答がobjectではありません。")
+    clarifications = plan.get("clarifications", [])
+    if not isinstance(clarifications, list):
+        raise PlannerError("確認事項が配列ではありません。")
+    for item in clarifications:
+        field = item.get("field") if isinstance(item, dict) else None
+        if field not in CLARIFICATION_FIELDS:
+            diagnostic = json.dumps(field, ensure_ascii=False)
+            raise PlannerError(f"確認事項のfieldが許可範囲外です: {diagnostic}")
+        answer = answers.get(field)
+        if not isinstance(answer, str) or not answer.strip():
+            raise PlannerError(f"確認事項{field}の回答が空です。")
+    raw = {
+        key: plan.get(key)
+        for key in ("objective_summary", "audience", "comparison", "hypotheses")
+    }
+    raw["clarifications"] = []
+    raw["panels"] = [
+        {field: item.get(field) for field in DYNAMIC_PANEL_FIELDS}
+        for item in plan.get("panels", [])
+    ]
+    confirmed = normalize_dashboard_plan(
+        raw, plan.get("objective", ""), plan.get("period", {}), answers
+    )
+    if confirmed["clarifications"]:
+        raise PlannerError("未回答の確認事項があります。")
+    confirmed["status"] = "confirmed"
+    return _revisioned_plan(confirmed)

--- a/tests/spikes/report-generation/analysis-planner.test.ts
+++ b/tests/spikes/report-generation/analysis-planner.test.ts
@@ -7,39 +7,52 @@ import path from 'node:path';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const PLANNER = path.join(ROOT, 'spikes/report-generation/analysis_planner.py');
 
-test('analysis planner creates a bounded revision and requires clarification', () => {
+test('analysis planner validates and freezes AI-authored panel specifications', () => {
   const result = spawnSync(
     'python3',
     [
       '-c',
-      `import importlib.util,json
+      `import importlib.util,json,sys,types
+sys.path.insert(0,${JSON.stringify(path.dirname(PLANNER))})
 spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
 p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+google=types.ModuleType("google");genai=types.ModuleType("google.genai")
+class GenerateContentConfig:
+ def __init__(self,**kwargs):self.__dict__.update(kwargs)
+genai.types=types.SimpleNamespace(GenerateContentConfig=GenerateContentConfig)
+google.genai=genai;sys.modules["google"]=google;sys.modules["google.genai"]=genai
 period={"from":"20210101","to":"20210131","label":"2021年1月"}
+def panel(index,chart="bar"):
+ return {"title":f"分析{index}","kpi":f"指標{index}","chart":chart,"decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の定義済み指標{index}を区分別に出して"}
 base={
  "objective_summary":"購入成果の阻害箇所を特定して優先施策を決める",
  "audience":"月次マーケティング会議",
  "comparison":"月内の日次推移とファネル段階",
  "hypotheses":["商品閲覧からカート追加への減少が大きい"],
  "clarifications":[{"field":"audience","question":"主な読者は誰ですか","recommended_answer":"マーケティング責任者"}],
- "panels":[{"id":panel_id,"reason":"目的に必要"} for panel_id in ["R4","R9","R16","R17"]],
+ "panels":[panel(index) for index in range(1,7)],
 }
-first=p.normalize_plan(base,"2021年1月の購入成果を改善するダッシュボードを作って",period,{})
+class Models:
+ def generate_content(self,**_kwargs):return types.SimpleNamespace(text=json.dumps(base,ensure_ascii=False),usage_metadata=types.SimpleNamespace(prompt_token_count=1,candidates_token_count=1))
+client=types.SimpleNamespace(models=Models())
+first,_usage=p.propose_dashboard(client,"test-model","2021年1月の購入成果を改善するダッシュボードを作って",period,"指標定義",{})
 answered={**base,"clarifications":[],"audience":"マーケティング責任者"}
-second=p.normalize_plan(answered,first["objective"],period,{"audience":"マーケティング責任者"})
-confirmed=p.confirm_plan(second)
+second=p.normalize_dashboard_plan(answered,first["objective"],period,{"audience":"マーケティング責任者"})
+confirmed=p.confirm_dashboard_plan(second)
 errors=[]
 for changed in [
- {**base,"panels":base["panels"][:3]},
- {**base,"panels":[*base["panels"][:3],{"id":"UNKNOWN","reason":"x"}]},
+ {**base,"panels":[]},
+ {**base,"panels":[*base["panels"][:5],base["panels"][0]]},
+ {**base,"panels":[*base["panels"][:5],{**panel(6),"execution_prompt":"SELECT * FROM events"}]},
 ]:
- try:p.normalize_plan(changed,first["objective"],period,{})
+ try:p.normalize_dashboard_plan(changed,first["objective"],period,{})
  except p.PlannerError as error:errors.append(str(error))
 print(json.dumps({
  "first_status":first["status"],"question_count":len(first["clarifications"]),
- "revision_stable":first["revision"]==p.normalize_plan(base,first["objective"],period,{})["revision"],
+ "revision_stable":first["revision"]==p.normalize_dashboard_plan(base,first["objective"],period,{})["revision"],
  "confirmed_status":confirmed["status"],"revision_changed":confirmed["revision"]!=first["revision"],
  "context":confirmed["organization_context_revision"],"panel_ids":[item["id"] for item in confirmed["panels"]],
+ "frozen_prompt":confirmed["panels"][0]["execution_prompt"],
  "errors":errors,
 },ensure_ascii=False))`,
     ],
@@ -53,15 +66,17 @@ print(json.dumps({
     confirmed_status: 'confirmed',
     revision_changed: true,
     context: 'demo-org-ec-v1',
-    panel_ids: ['R4', 'R9', 'R16', 'R17'],
+    panel_ids: ['P1', 'P2', 'P3', 'P4', 'P5', 'P6'],
+    frozen_prompt: '2021年1月の定義済み指標1を区分別に出して',
     errors: [
-      '分析計画のパネルは4〜6件にしてください。',
-      '分析計画に未登録または重複したパネルがあります。',
+      '分析計画のパネルは1〜20件にしてください。',
+      '分析計画に重複した実行仕様があります。',
+      '分析計画の実行仕様にはSQLを書けません。',
     ],
   });
 });
 
-test('planner prompt is bounded to declared context, metrics, and panel catalog', () => {
+test('planner prompt requests new specifications without exposing fixed analyses', () => {
   const result = spawnSync(
     'python3',
     [
@@ -69,8 +84,9 @@ test('planner prompt is bounded to declared context, metrics, and panel catalog'
       `import importlib.util,json
 spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
 p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
-request=p.planning_request("目的",{"label":"2021年1月"},"指標定義",{})
-print(json.dumps({"context":p.ORGANIZATION_CONTEXT["revision"] in request,"metrics":"指標定義" in request,"catalog":all(panel_id in request for panel_id in p.PANEL_CATALOG),"questions":"確認を1〜3件" in request},ensure_ascii=False))`,
+request=p.dashboard_planning_request("目的",{"label":"2021年1月"},"指標定義",{})
+panels=p._dashboard_response_schema({})["properties"]["panels"]
+print(json.dumps({"context":p.ORGANIZATION_CONTEXT["revision"] in request,"metrics":"指標定義" in request,"new_specs":"分析仕様そのものを新規" in request,"fixed_ids":any(panel_id in request for panel_id in p.PANEL_CATALOG),"count":[panels["minItems"],panels["maxItems"]],"questions":"確認を1〜3件" in request},ensure_ascii=False))`,
     ],
     { cwd: ROOT, encoding: 'utf8' },
   );
@@ -78,12 +94,14 @@ print(json.dumps({"context":p.ORGANIZATION_CONTEXT["revision"] in request,"metri
   assert.deepEqual(JSON.parse(result.stdout), {
     context: true,
     metrics: true,
-    catalog: true,
+    new_specs: true,
+    fixed_ids: false,
+    count: [6, 6],
     questions: true,
   });
 });
 
-test('broad purchase improvement recommends all six panels but preserves explicit removal', () => {
+test('dashboard panel counts are administrator policy rather than analysis hardcodes', () => {
   const result = spawnSync(
     'python3',
     [
@@ -91,28 +109,41 @@ test('broad purchase improvement recommends all six panels but preserves explici
       `import importlib.util,json
 spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
 p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
-period={"from":"20210101","to":"20210131","label":"2021年1月"}
-raw={
- "objective_summary":"購入成果の阻害箇所を特定して優先施策を決める",
- "audience":"月次マーケティング会議",
- "comparison":"月内の日次推移とファネル段階",
- "hypotheses":["購入導線に課題がある"],
- "clarifications":[],
- "panels":[{"id":panel_id,"reason":"目的に必要"} for panel_id in ["R4","R11","R9","R16","R17"]],
-}
-objective="2021年1月のECサイトで購入成果を改善するため、課題の場所と優先施策を判断できるダッシュボードを作って"
-recommended=p.normalize_plan(raw,objective,period,{"audience":"月次マーケティング会議"},complete_purchase_recommendations=True)
-edited={**recommended,"panels":[panel for panel in recommended["panels"] if panel["id"]!="R12"]}
-confirmed=p.confirm_plan(edited)
-print(json.dumps({"recommended":[panel["id"] for panel in recommended["panels"]],"confirmed":[panel["id"] for panel in confirmed["panels"]]},ensure_ascii=False))`,
+panels=p._dashboard_response_schema({})["properties"]["panels"]
+print(json.dumps({"initial":p.INITIAL_PANEL_COUNT,"maximum":p.MAX_PANEL_COUNT,"schema":[panels["minItems"],panels["maxItems"]]},ensure_ascii=False))`,
     ],
-    { cwd: ROOT, encoding: 'utf8' },
+    {
+      cwd: ROOT,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ANALYSIS_INITIAL_PANEL_COUNT: '5',
+        ANALYSIS_MAX_PANEL_COUNT: '15',
+      },
+    },
   );
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
-    recommended: ['R4', 'R11', 'R12', 'R9', 'R16', 'R17'],
-    confirmed: ['R4', 'R11', 'R9', 'R16', 'R17'],
+    initial: 5,
+    maximum: 15,
+    schema: [5, 5],
   });
+  for (const [initial, maximum, error] of [
+    ['0', '20', 'ANALYSIS_INITIAL_PANEL_COUNT must be a positive integer'],
+    ['6', '5', 'ANALYSIS_INITIAL_PANEL_COUNT must not exceed ANALYSIS_MAX_PANEL_COUNT'],
+  ] as const) {
+    const invalid = spawnSync('python3', ['-c', `exec(open(${JSON.stringify(PLANNER)}).read())`], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ANALYSIS_INITIAL_PANEL_COUNT: initial,
+        ANALYSIS_MAX_PANEL_COUNT: maximum,
+      },
+    });
+    assert.notEqual(invalid.status, 0);
+    assert.match(invalid.stderr, new RegExp(error));
+  }
 });
 
 test('analysis consultation creates new executable specifications from context and history', () => {


### PR DESCRIPTION
## What & why

Issue #374の第1段階として、固定パネルcatalogを渡さず、目的・schema・指標・期間からAIがdashboard分析仕様そのものを作るplanner契約を追加します。初回提案数と最大パネル数だけを管理者設定にし、生成されたtitle、KPI、可視化、判断用途、理由、SQL生成用日本語仕様を検証してrevisionへfreezeします。現在のlive endpointは既存契約のまま維持し、dashboard UI／build接続は後続PRへ分離します。

Refs: #374

## Change classification (ARC-020)

- [x] Local (inside one module, contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: 固定応答で、固定catalog IDをpromptへ含めないこと、既定6件／最大20件と環境変数境界、全fieldのfreeze、revision安定性、重複・SQL混入・未対応chart・不正件数の拒否を検証。`make format`、`make lint`、`make test`はいずれもexit 0。
- Not verified (be honest — GR-042): 実Vertex AI・BigQueryは課金対象のため未実行。live endpointへの接続とbrowser UI確認は後続PRの範囲。

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: `.env.example`、`spikes/report-generation/README.md`

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes (optional, helps reviewers): 分析内容をハードコードせず、費用と画面密度に関わる件数だけを管理者設定に限定。

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)
