### PR TITLE
fix: own inherited expand compatibility test

### DIFF
--- a/.github/inheritance/manifest.json
+++ b/.github/inheritance/manifest.json
@@ -48,6 +48,7 @@
     "scripts/template_inheritance.py",
     "scripts/tests/test_agent_contract_profile.py",
     "scripts/tests/test_context_budget.py",
+    "scripts/tests/test_expand_phase_compatibility.py",
     "scripts/tests/test_foundation_docs_portability.py",
     "scripts/tests/test_foundation_document_language.py",
     "scripts/tests/test_github_governance.py",

--- a/scripts/tests/test_repchat_template_sync_contract.py
+++ b/scripts/tests/test_repchat_template_sync_contract.py
@@ -28,6 +28,14 @@ class RepChatTemplateSyncContractTest(unittest.TestCase):
         self.assertIn("Sweep for siblings", skill)
         self.assertIn("Sibling occurrences searched; results reported", skill)
 
+    def test_foundation_expand_compatibility_test_has_explicit_ownership(self):
+        path = "scripts/tests/test_expand_phase_compatibility.py"
+        manifest = json.loads(MANIFEST_FILE.read_text(encoding="utf-8"))
+
+        self.assertIn(path, manifest["inherited_paths"])
+        self.assertNotIn(path, manifest["protected_paths"])
+        self.assertNotIn(path, self.entries())
+
     def test_project_release_history_and_codeql_invariant_are_target_owned(self):
         entries = self.entries()
         manifest = json.loads(MANIFEST_FILE.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- classify the Foundation expand-phase compatibility regression as an inherited path
- keep the file available to reviewed Template Sync
- add a RepChat-owned regression assertion so the ownership gap cannot recur

## Root cause
The Foundation added `scripts/tests/test_expand_phase_compatibility.py` after RepChat had enumerated its inherited test paths. Legacy Template Sync transported the file, but the protected manifest was never extended, so `finalize-sync` correctly reported an ownership review and blocked PR #381.

## Verification
- failing-first: `python3 -m unittest scripts.tests.test_repchat_template_sync_contract` failed because the path was absent from `inherited_paths`
- after fix: 3 contract tests passed
- `scripts.tests.test_setup_github_wrapper`: 6 passed after the first concurrent doctor run exceeded its 5-second subprocess budget
- GitHub CI is authoritative for the complete isolated run

Closes #382

After merge, update and finalize #381.
