### PR TITLE
refactor(demo): remove meeting report fallback

### DIFF
--- a/spikes/report-generation/meeting_report.py
+++ b/spikes/report-generation/meeting_report.py
@@ -18,9 +18,6 @@ MAX_PANEL_REFS = 6
 REPORT_DECIMAL_PLACES = 2
 FUNNEL_RATE_DECIMAL_PLACES = 1
 NO_DIGITS_PATTERN = r"^[^0-9０-９]*$"
-GENERATION_WARNING = (
-    "AI出力のうち、根拠を確認できない数値表現または構造を除外しました。"
-)
 REPORT_ITEM_LIMITS = {
     "observations": 3,
     "interpretations": 2,
@@ -385,14 +382,9 @@ def normalize_report(raw: dict, bundle: dict) -> dict:
             raise ReportError(f"会議報告の{name}は{limit}件以内にしてください。")
         return [cited(item, name, extra) for item in source]
 
-    summary_source = raw.get("executive_summary")
-    if isinstance(summary_source, str):
-        summary_text = _text(summary_source, "要約", SUMMARY_MAX_CHARS)
-        if re.search(r"\d", summary_text):
-            raise ReportError("会議報告の要約には根拠リンクのない数値を書けません。")
-        summary = {"text": summary_text, "panel_ids": [], "evidence_refs": []}
-    else:
-        summary = cited(summary_source, "要約", text_limit=SUMMARY_MAX_CHARS)
+    summary = cited(
+        raw.get("executive_summary"), "要約", text_limit=SUMMARY_MAX_CHARS
+    )
     limitations = raw.get("limitations")
     if not isinstance(limitations, list):
         raise ReportError("会議報告のlimitationsが配列ではありません。")
@@ -439,103 +431,6 @@ def normalize_report(raw: dict, bundle: dict) -> dict:
     return _set_report_revision(report)
 
 
-def _fallback_raw_report(bundle: dict) -> dict:
-    """Return a numeric-free cited draft used only when generated items are unsafe."""
-    panel_id = bundle["panels"][0]["id"]
-    return {
-        "executive_summary": {
-            "text": "確認できる根拠を基に、傾向と追加検証事項を整理しました。",
-            "panel_ids": [panel_id],
-        },
-        "observations": [
-            {
-                "text": "根拠パネルの集計結果を確認しました。",
-                "panel_ids": [panel_id],
-            }
-        ],
-        "interpretations": [
-            {
-                "text": "この集計だけでは変化の要因を確定できません。",
-                "uncertainty": "比較対象と施策履歴が不足しています。",
-                "panel_ids": [panel_id],
-            }
-        ],
-        "hypotheses": [
-            {
-                "text": "表示された傾向に影響する条件がある可能性があります。",
-                "validation": "同じ指標を比較条件別に確認します。",
-                "panel_ids": [panel_id],
-            }
-        ],
-        "actions": [
-            {
-                "text": "根拠パネルを確認し、追加検証の優先順位を決めます。",
-                "owner": "マーケティング責任者",
-                "urgency": "次回会議まで",
-                "expected_impact": "判断に必要な不足情報を特定できます。",
-                "next_step": "比較条件と施策履歴を確認します。",
-                "success_metric": "確定済みの主要指標",
-                "panel_ids": [panel_id],
-            }
-        ],
-        "limitations": [
-            "比較対象、目標値、施策履歴の不足を確認する必要があります。"
-        ],
-    }
-
-
-def normalize_generated_report(raw: dict, bundle: dict) -> dict:
-    """Keep valid generated items while discarding unsafe claims without another call."""
-    _evidence_index(bundle)
-    try:
-        return normalize_report(raw, bundle)
-    except ReportError:
-        pass
-
-    fallback = _fallback_raw_report(bundle)
-    source = raw if isinstance(raw, dict) else {}
-    repaired = dict(fallback)
-
-    summary = source.get("executive_summary")
-    if summary is not None:
-        probe = {**fallback, "executive_summary": summary}
-        try:
-            normalize_report(probe, bundle)
-            repaired["executive_summary"] = summary
-        except ReportError:
-            pass
-
-    for name in ("observations", "interpretations", "hypotheses", "actions"):
-        valid = []
-        candidates = source.get(name)
-        if isinstance(candidates, list):
-            for candidate in candidates[: REPORT_ITEM_LIMITS[name]]:
-                probe = {**fallback, name: [candidate]}
-                try:
-                    normalize_report(probe, bundle)
-                    valid.append(candidate)
-                except ReportError:
-                    continue
-        if valid:
-            repaired[name] = valid
-
-    valid_limitations = []
-    limitations = source.get("limitations")
-    if isinstance(limitations, list):
-        for candidate in limitations[: REPORT_ITEM_LIMITS["limitations"]]:
-            probe = {**fallback, "limitations": [candidate]}
-            try:
-                normalize_report(probe, bundle)
-                valid_limitations.append(candidate)
-            except ReportError:
-                continue
-    if valid_limitations:
-        repaired["limitations"] = valid_limitations
-
-    report = normalize_report(repaired, bundle)
-    report["generation_warnings"] = [GENERATION_WARNING]
-    return _set_report_revision(report)
-
 def generate(client, model: str, bundle: dict):
     """Generate and validate one report draft without another warehouse query."""
     from google.genai import types
@@ -570,7 +465,7 @@ def generate(client, model: str, bundle: dict):
             "今回のVertex AI呼出しは課金対象で、自動再実行していません。"
         ) from error
     usage = response.usage_metadata
-    return normalize_generated_report(raw, bundle), {
+    return normalize_report(raw, bundle), {
         "input_tokens": usage.prompt_token_count or 0,
         "output_tokens": (usage.candidates_token_count or 0)
         + (getattr(usage, "thoughts_token_count", 0) or 0),

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -2045,7 +2045,7 @@ def run_section(section,period,emit,context=None,profile="ga4"):
  emit({"type":"result","columns":columns[section["id"]],"rows":rows[section["id"]],"verification":"matched","verification_label":"照合済み","visualization":section["component"],**context})
  return .1
 e._run_section=run_section;events=[];e.dashboard(plan["objective"],events.append,plan);bundle=e.latest_dashboard
-raw={"executive_summary":"追加診断が必要です。","observations":[{"text":"購入件数は895件です。","panel_ids":["R4"]}],"interpretations":[{"text":"変動があります。","uncertainty":"施策履歴がありません。","panel_ids":["R16"]}],"hypotheses":[{"text":"導線に課題がある可能性があります。","validation":"流入別に検証します。","panel_ids":["R9"]}],"actions":[{"text":"導線を確認します。","owner":"マーケティング責任者","urgency":"次回会議まで","expected_impact":"阻害箇所を特定できます。","next_step":"流入別に比較します。","success_metric":"購入件数","panel_ids":["R4"]}],"limitations":["目標値と施策履歴が未登録です。"]}
+raw={"executive_summary":{"text":"追加診断が必要です。","panel_ids":["R4"]},"observations":[{"text":"購入件数は895件です。","panel_ids":["R4"]}],"interpretations":[{"text":"変動があります。","uncertainty":"施策履歴がありません。","panel_ids":["R16"]}],"hypotheses":[{"text":"導線に課題がある可能性があります。","validation":"流入別に検証します。","panel_ids":["R9"]}],"actions":[{"text":"導線を確認します。","owner":"マーケティング責任者","urgency":"次回会議まで","expected_impact":"阻害箇所を特定できます。","next_step":"流入別に比較します。","success_metric":"購入件数","panel_ids":["R4"]}],"limitations":["目標値と施策履歴が未登録です。"]}
 calls=[]
 m.meeting.generate=lambda _client,_model,current:(calls.append(current["build_revision"]) or (m.meeting.normalize_report(raw,current),{"input_tokens":10,"output_tokens":5}))
 report_events=[];e.meeting_report(bundle["build_revision"],report_events.append)

--- a/tests/spikes/report-generation/meeting-report.test.ts
+++ b/tests/spikes/report-generation/meeting-report.test.ts
@@ -36,7 +36,7 @@ ${body}`,
 test('normalizes a draft into immutable evidence-linked meeting commentary', () => {
   const result = python(`
 raw={
- "executive_summary":"購入成果には追加診断が必要です。",
+ "executive_summary":{"text":"購入成果には追加診断が必要です。","panel_ids":["R4"]},
  "observations":[{"text":"購入金額は123,456.00円です。","panel_ids":["R4"]}],
  "interpretations":[{"text":"日次推移には変動があります。","uncertainty":"施策履歴が無いため原因は不明です。","panel_ids":["R16"]}],
  "hypotheses":[{"text":"導線に改善余地がある可能性があります。","validation":"流入別に追加検証します。","panel_ids":["R4","R16"]}],
@@ -143,7 +143,7 @@ print(json.dumps({"summary":accepted["executive_summary"]["text"],"observation":
 test('rejects unsupported numbers, unknown evidence, and revision mismatches', () => {
   const result = python(`
 base={
- "executive_summary":"要約です。",
+ "executive_summary":{"text":"要約です。","panel_ids":["R4"]},
  "observations":[{"text":"購入件数は895件です。","panel_ids":["R4"]}],
  "interpretations":[{"text":"解釈です。","uncertainty":"不確実です。","panel_ids":["R4"]}],
  "hypotheses":[{"text":"仮説です。","validation":"検証します。","panel_ids":["R4"]}],
@@ -157,12 +157,13 @@ bad_bundle={**bundle,"organization_context_revision":"other-v1"}
 oversized={**bundle,"metric_definitions":{"x":"a"*50000}}
 long_summary={**base,"executive_summary":{"text":"あ"*161,"panel_ids":["R4"]}}
 too_many_observations={**base,"observations":base["observations"]*4}
-for raw,current in [(bad_number,bundle),(unknown,bundle),(base,bad_bundle),({**base,"limitations":None},bundle),({**base,"limitations":["30件未満です。"]},bundle),(base,oversized),(long_summary,bundle),(too_many_observations,bundle)]:
+for raw,current in [({**base,"executive_summary":"要約です。"},bundle),(bad_number,bundle),(unknown,bundle),(base,bad_bundle),({**base,"limitations":None},bundle),({**base,"limitations":["30件未満です。"]},bundle),(base,oversized),(long_summary,bundle),(too_many_observations,bundle)]:
  try:m.normalize_report(raw,current)
  except m.ReportError as error:cases.append(str(error))
 print(json.dumps(cases,ensure_ascii=False))`);
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), [
+    '会議報告の根拠パネルが未登録または空です。',
     '会議報告に根拠パネルへ存在しない数値があります: 999',
     '会議報告の根拠パネルが未登録または空です。',
     '組織コンテキストrevisionが根拠bundleと一致しません。',
@@ -259,7 +260,7 @@ genai.types=types.SimpleNamespace(
 )
 google.genai=genai;sys.modules["google"]=google;sys.modules["google.genai"]=genai
 raw={
- "executive_summary":"追加診断が必要です。",
+ "executive_summary":{"text":"追加診断が必要です。","panel_ids":["R4"]},
  "observations":[{"text":"購入成果を確認しました。","panel_ids":["R4"]}],
  "interpretations":[{"text":"追加分析が必要です。","uncertainty":"施策履歴がありません。","panel_ids":["R4"]}],
  "hypotheses":[{"text":"導線に課題がある可能性があります。","validation":"流入別に確認します。","panel_ids":["R4"]}],
@@ -295,7 +296,7 @@ print(json.dumps({
   });
 });
 
-test('one paid response keeps valid claims and reports excluded unsupported numbers without retrying', () => {
+test('one paid response with unsupported claims fails without retrying or rewriting', () => {
   const result = python(`
 import sys,types
 google=types.ModuleType("google");genai=types.ModuleType("google.genai")
@@ -327,29 +328,41 @@ class Models:
 strict_error=""
 try:m.normalize_report(raw,bundle)
 except m.ReportError as error:strict_error=str(error)
-report,_=m.generate(types.SimpleNamespace(models=Models()),"model",bundle)
+generated_error=""
+try:m.generate(types.SimpleNamespace(models=Models()),"model",bundle)
+except m.ReportError as error:generated_error=str(error)
 print(json.dumps({
  "calls":captured["calls"],
  "strict_error":strict_error,
- "observations":[item["text"] for item in report["observations"]],
- "interpretations":[item["text"] for item in report["interpretations"]],
- "hypotheses":[item["text"] for item in report["hypotheses"]],
- "actions":[item["text"] for item in report["actions"]],
- "limitations":report["limitations"],
- "warnings":report["generation_warnings"],
+ "generated_error":generated_error,
+ "fallback":hasattr(m,"_fallback_raw_report"),
  "limitation_pattern":captured["config"].response_schema["properties"]["limitations"]["items"]["pattern"],
 },ensure_ascii=False))`);
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
   assert.equal(output.calls, 1);
   assert.equal(output.strict_error, '会議報告に根拠パネルへ存在しない数値があります: 22');
-  assert.deepEqual(output.observations, ['購入件数は895件です。']);
-  assert.deepEqual(output.hypotheses, ['導線に改善余地がある可能性があります。']);
-  assert.ok(output.interpretations.every((value: string) => !/3000|4000/.test(value)));
-  assert.ok(output.actions.every((value: string) => !/6/.test(value)));
-  assert.ok(output.limitations.every((value: string) => !/\d/.test(value)));
-  assert.deepEqual(output.warnings, [
-    'AI出力のうち、根拠を確認できない数値表現または構造を除外しました。',
-  ]);
+  assert.equal(output.generated_error, output.strict_error);
+  assert.equal(output.fallback, false);
   assert.equal(output.limitation_pattern, '^[^0-9０-９]*$');
+});
+
+test('invalid generated meeting commentary fails instead of using fixed fallback prose', () => {
+  const result = python(`
+invalid={
+ "executive_summary":{"text":"根拠外の22件を確認しました。","panel_ids":["R4"]},
+ "observations":[{"text":"根拠外の22件を確認しました。","panel_ids":["R4"]}],
+ "interpretations":[],"hypotheses":[],"actions":[],"limitations":[]
+}
+try:
+ m.normalize_report(invalid,bundle)
+except m.ReportError as error:
+ print(json.dumps({"error":str(error),"fallback":hasattr(m,"_fallback_raw_report"),"normalizer":hasattr(m,"normalize_generated_report")},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    error: '会議報告に根拠パネルへ存在しない数値があります: 22',
+    fallback: false,
+    normalizer: false,
+  });
 });


### PR DESCRIPTION
## What & why

会議報告生成から固定フォールバック文言と部分的な書き換え処理を削除します。AIが生成した報告は、要約を含む全項目で根拠パネルとの整合性を検証し、不正な数値や構造があれば再実行・代替文生成をせず失敗として扱います。

Refs: #374

## Change classification (ARC-020)

- [ ] Local (inside one module, contract unchanged)
- [x] Contract (会議報告の要約も根拠パネル参照を必須化)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: 残りの作業差分を退避した単独状態で `make format && make lint && make test` が終了コード0。固定フォールバックが存在しないこと、不正な生成内容が書き換えられず失敗すること、統合経路で要約の根拠参照が維持されることを確認。
- Not verified (GR-042): Vertex AI / BigQueryの有料実行は行っていません。

## Documentation (DOC-030)

- [x] Doc-update matrix checked; accumulated変更の文書更新はGR-020に従い後続の文書PRへ分離します。

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes: 利用者の「パターン提案・考察スキップ・フォールバックを削除する」という要望に基づく分割PRです。

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No dependency additions; no guardrail violation
