### PR TITLE
refactor(demo): remove fixed report modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,6 @@ demo: ## Generate, verify, build, and open the report demo (uses paid Vertex/Big
 		$(if $(PROJECT),--project "$(PROJECT)") \
 		$(if $(filter yes,$(ACCEPT_COST)),--accept-cost) \
 		$(if $(filter yes,$(BUILD_ONLY)),--build-only) \
-		$(if $(filter yes,$(SHOWCASE)),--showcase) \
 		$(if $(filter yes,$(DRY_RUN)),--dry-run)
 
 demo-live: ## Open the live Japanese prompt → graph/dashboard demo (each run is paid)

--- a/spikes/report-generation/demo.py
+++ b/spikes/report-generation/demo.py
@@ -159,16 +159,10 @@ def prepare_evidence() -> None:
     run(["npm", "audit", "--audit-level=critical"], cwd=EVIDENCE_DIR)
 
 
-def generate_report(
-    python: Path, project: str, question: str | None, showcase: bool
-) -> None:
+def generate_report(python: Path, project: str) -> None:
     env = os.environ.copy()
     env["GOOGLE_CLOUD_PROJECT"] = project
     command = [str(python), str(HERE / "run_report.py"), "--project", project]
-    if question is not None:
-        command.extend(["--question", question])
-    if showcase:
-        command.append("--showcase")
     run(command, env=env)
 
 
@@ -189,17 +183,9 @@ def install_generated_report() -> None:
     shutil.copy2(generated_page, EVIDENCE_DIR / "pages" / "index.md")
 
 
-def planned_steps(project: str, question: str | None, showcase: bool) -> None:
+def planned_steps(project: str) -> None:
     print(f"project: {project}")
     print(f"Evidence template: {TEMPLATE_COMMIT}")
-    if question is not None:
-        print(f"one-question mode: {question}")
-    if showcase:
-        print(
-            "showcase mode: 6 Japanese questions "
-            "(purchase KPIs + retention + engagement + funnel + 7-day trend + "
-            "navigation Sankey)"
-        )
     for step in (
         "create isolated Python venv and install pinned dependencies",
         "fetch the pinned Evidence scaffold and install the minimal audited lockfile",
@@ -216,22 +202,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--accept-cost", action="store_true")
     parser.add_argument("--build-only", action="store_true", help="build but do not start the server")
     parser.add_argument("--dry-run", action="store_true", help="show the paid workflow without changing files")
-    mode = parser.add_mutually_exclusive_group()
-    mode.add_argument(
-        "--question",
-        default=os.environ.get("QUESTION"),
-        help="run one Japanese question instead of the 15-question report",
-    )
-    mode.add_argument(
-        "--showcase",
-        action="store_true",
-        default=os.environ.get("SHOWCASE") == "yes",
-        help="generate the five-panel dashboard showcase",
-    )
-    args = parser.parse_args()
-    if args.showcase and args.question is not None:
-        parser.error("--showcase is not allowed with QUESTION or --question")
-    return args
+    return parser.parse_args()
 
 
 def main() -> int:
@@ -241,20 +212,15 @@ def main() -> int:
         print("error: --project or GOOGLE_CLOUD_PROJECT is required", file=sys.stderr)
         return 2
     try:
-        question = args.question.strip() if args.question is not None else None
-        if args.question is not None and not question:
-            raise DemoError("question must not be empty")
-        if question is not None and len(question) > 500:
-            raise DemoError("question must be at most 500 characters")
         if args.dry_run:
-            planned_steps(project, question, args.showcase)
+            planned_steps(project)
             return 0
         confirm_paid_run(args.accept_cost)
         require_tools()
         require_adc()
         python = prepare_python()
         prepare_evidence()
-        generate_report(python, project, question, args.showcase)
+        generate_report(python, project)
         install_generated_report()
         run(["npm", "run", "sources"], cwd=EVIDENCE_DIR)
         run(["npm", "run", "build"], cwd=EVIDENCE_DIR)

--- a/tests/spikes/report-generation/demo.test.ts
+++ b/tests/spikes/report-generation/demo.test.ts
@@ -1,9 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import fs, { readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import os from 'node:os';
 import path from 'node:path';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
@@ -40,67 +39,6 @@ test('dry-run reports every stage without installing or calling cloud services',
   assert.match(result.stdout, /generate and verify.*Vertex AI \+ BigQuery/);
   assert.match(result.stdout, /materialize Evidence sources and build/);
   assert.match(result.stdout, /open http:\/\/localhost:3000\//);
-});
-
-test('dry-run carries one Japanese question into the generation plan', () => {
-  const question = '2021年1月のセッション数を出して';
-  const result = demo(['--project', 'example-project', '--question', question, '--dry-run']);
-  assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, new RegExp(question));
-  assert.match(result.stdout, /one-question mode/);
-});
-
-test('dry-run exposes the advanced analysis showcase', () => {
-  const result = demo(['--project', 'example-project', '--showcase', '--dry-run']);
-  assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /showcase mode: 6 Japanese questions/);
-  assert.match(result.stdout, /purchase KPIs/);
-  assert.match(result.stdout, /funnel/);
-  assert.match(result.stdout, /7-day trend/);
-  assert.match(result.stdout, /navigation Sankey/);
-});
-
-test('one-question and showcase modes are mutually exclusive', () => {
-  const result = demo([
-    '--project',
-    'example-project',
-    '--question',
-    '2021年1月のセッション数を出して',
-    '--showcase',
-    '--dry-run',
-  ]);
-  assert.equal(result.status, 2);
-  assert.match(result.stderr, /not allowed with argument/);
-});
-
-test('SHOWCASE and QUESTION environment variables are mutually exclusive', () => {
-  const result = demo(['--project', 'example-project', '--dry-run'], {
-    ...process.env,
-    SHOWCASE: 'yes',
-    QUESTION: '2021年1月のセッション数を出して',
-  });
-  assert.equal(result.status, 2);
-  assert.match(result.stderr, /not allowed with QUESTION/);
-});
-
-test('the Make target passes QUESTION without evaluating shell syntax', () => {
-  const marker = path.join(os.tmpdir(), `repchat-question-${process.pid}`);
-  fs.rmSync(marker, { force: true });
-  try {
-    const result = spawnSync(
-      'make',
-      ['demo', 'PROJECT=example-project', 'DRY_RUN=yes', `QUESTION=セッション数$(touch ${marker})`],
-      {
-        cwd: ROOT,
-        encoding: 'utf8',
-      },
-    );
-    assert.equal(result.status, 0, result.stderr);
-    assert.equal(fs.existsSync(marker), false);
-    assert.match(result.stdout, /one-question mode/);
-  } finally {
-    fs.rmSync(marker, { force: true });
-  }
 });
 
 test('the Evidence package definition matches the minimal audited lockfile', () => {


### PR DESCRIPTION
## What & why

固定質問を渡す単一レポートモードと、固定パネルを生成するショーケースモードをデモ起動経路から削除します。レポート生成のCLIは通常の生成経路だけを持ち、固定の質問・提案パターンを選択しません。

Refs: #374

## Change classification (ARC-020)

- [x] Local (デモ起動CLIの不要な固定モードを削除)
- [ ] Contract
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: 残りの作業差分を退避した単独状態で `make format && make lint && make test` が終了コード0。dry-runの通常経路と固定モードが公開されないことを確認。
- Not verified (GR-042): Vertex AI / BigQueryの有料実行は行っていません。

## Documentation (DOC-030)

- [x] Doc-update matrix checked; accumulated変更の文書更新はGR-020に従い後続PRへ分離します。

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes: 固定文言・固定SQL・ショーケース用パターンを残さないという利用者要望に基づきます。

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No dependency additions; no guardrail violation
