### PR TITLE
feat(demo): define renderer chart contracts

### DIFF
--- a/spikes/report-generation/analysis_planner.py
+++ b/spikes/report-generation/analysis_planner.py
@@ -58,11 +58,60 @@ PANEL_CATALOG = {
 
 CLARIFICATION_FIELDS = ("audience", "comparison", "business_goal")
 DASHBOARD_CHARTS = ("scorecard", "bar", "line", "table", "sankey")
+SUPPORTED_DASHBOARD_CHARTS = (
+    "scorecard",
+    "kpi_group",
+    "bar",
+    "grouped_bar",
+    "stacked_bar",
+    "line",
+    "multi_line",
+    "scatter",
+    "bubble",
+    "funnel",
+    "heatmap",
+    "table",
+    "sankey",
+)
+DASHBOARD_ROW_LIMITS = {
+    "scorecard": 1,
+    "kpi_group": 1,
+    "bar": 30,
+    "grouped_bar": 20,
+    "stacked_bar": 20,
+    "line": 100,
+    "multi_line": 100,
+    "scatter": 100,
+    "bubble": 100,
+    "funnel": 12,
+    "heatmap": 100,
+    "table": 100,
+    "sankey": 100,
+}
+CHART_SHAPE_CONTRACTS = {
+    "scorecard": (0, 0, 1, 1),
+    "kpi_group": (0, 0, 2, 4),
+    "bar": (1, 1, 1, 1),
+    "grouped_bar": (1, 1, 2, 4),
+    "stacked_bar": (1, 1, 2, 4),
+    "line": (1, 1, 1, 1),
+    "multi_line": (1, 1, 2, 4),
+    "scatter": (1, 1, 2, 2),
+    "bubble": (1, 1, 3, 3),
+    "funnel": (1, 1, 1, 1),
+    "heatmap": (2, 2, 1, 1),
+    "table": (0, 4, 1, 4),
+    "sankey": (2, 2, 1, 1),
+}
 DEFAULT_INITIAL_PANEL_COUNT = 6
 DEFAULT_MAX_PANEL_COUNT = 20
-DYNAMIC_PANEL_FIELDS = (
+MAX_SANKEY_PAGES = 4
+DYNAMIC_PANEL_TEXT_FIELDS = (
     "title", "kpi", "chart", "decision", "reason", "execution_prompt"
 )
+DYNAMIC_PANEL_LIST_FIELDS = ("dimensions", "measures")
+DYNAMIC_PANEL_LAYOUT_FIELDS = ("layout_row", "layout_weight")
+DYNAMIC_PANEL_FIELDS = DYNAMIC_PANEL_TEXT_FIELDS
 
 
 def _positive_count_setting(name: str, default: int) -> int:
@@ -89,6 +138,56 @@ if INITIAL_PANEL_COUNT > MAX_PANEL_COUNT:
     raise ValueError(
         "ANALYSIS_INITIAL_PANEL_COUNT must not exceed ANALYSIS_MAX_PANEL_COUNT"
     )
+
+
+def _neutral_chart_order(charts: tuple[str, ...], seed: str) -> tuple[str, ...]:
+    """Return a reproducible order unrelated to chart semantics or source order."""
+    if not seed:
+        return charts
+    return tuple(
+        sorted(
+            charts,
+            key=lambda chart: hashlib.sha256(f"{seed}\0{chart}".encode()).digest(),
+        )
+    )
+
+
+def _visualization_response_schema(
+    charts: tuple[str, ...], *, seed: str = ""
+) -> dict:
+    """Constrain chart and result shape together without prompt heuristics."""
+    variants = []
+    for chart in _neutral_chart_order(charts, seed):
+        min_dimensions, max_dimensions, min_measures, max_measures = (
+            CHART_SHAPE_CONTRACTS[chart]
+        )
+        variants.append(
+            {
+                "type": "object",
+                "properties": {
+                    "chart": {
+                        "type": "string",
+                        "format": "enum",
+                        "enum": [chart],
+                    },
+                    "dimensions": {
+                        "type": "array",
+                        "minItems": min_dimensions,
+                        "maxItems": max_dimensions,
+                        "items": {"type": "string"},
+                    },
+                    "measures": {
+                        "type": "array",
+                        "minItems": min_measures,
+                        "maxItems": max_measures,
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": ["chart", "dimensions", "measures"],
+            }
+        )
+    return {"anyOf": variants}
+
 
 PLAN_SCHEMA = {
     "type": "object",
@@ -158,13 +257,21 @@ DYNAMIC_PLAN_SCHEMA["properties"]["panels"] = {
 class PlannerError(ValueError):
     """A planner contract violation safe to show in the local UI."""
 
+    def __init__(self, message: str, *, suggested_instruction: str | None = None):
+        super().__init__(message)
+        self.suggested_instruction = suggested_instruction
+
 
 def _response_schema(answers: dict[str, str]) -> dict:
     """Constrain clarification output to fields that still need an answer."""
     unanswered = [field for field in CLARIFICATION_FIELDS if field not in answers]
     schema = copy.deepcopy(PLAN_SCHEMA)
     clarifications = schema["properties"]["clarifications"]
-    clarifications["maxItems"] = len(unanswered)
+    # Vertex structured output can reject an array schema whose maxItems is 0.
+    # When every field is answered, omit that API-level bound and let the
+    # normalizer below reject any repeated or unsupported clarification.
+    if unanswered:
+        clarifications["maxItems"] = len(unanswered)
     if len(unanswered) == len(CLARIFICATION_FIELDS):
         clarifications["minItems"] = 1
     if unanswered:

--- a/tests/spikes/report-generation/analysis-planner-chart-contract.test.ts
+++ b/tests/spikes/report-generation/analysis-planner-chart-contract.test.ts
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const PLANNER_DIR = path.join(ROOT, 'spikes/report-generation');
+
+function python(body: string) {
+  return spawnSync(
+    'python3',
+    [
+      '-c',
+      `import json,sys\nsys.path.insert(0,${JSON.stringify(PLANNER_DIR)})\nimport analysis_planner as p\n${body}`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+}
+
+test('renderer capabilities are represented by one chart and shape contract', () => {
+  const result = python(`
+schema=p._visualization_response_schema(p.SUPPORTED_DASHBOARD_CHARTS,seed="依頼A")
+variants=schema["anyOf"]
+print(json.dumps({
+ "charts":[item["properties"]["chart"]["enum"][0] for item in variants],
+ "contracts":{
+  item["properties"]["chart"]["enum"][0]:[
+   item["properties"]["dimensions"]["minItems"],
+   item["properties"]["dimensions"]["maxItems"],
+   item["properties"]["measures"]["minItems"],
+   item["properties"]["measures"]["maxItems"],
+  ] for item in variants
+ },
+ "row_limits":p.DASHBOARD_ROW_LIMITS,
+},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(
+    new Set(output.charts),
+    new Set(output.row_limits ? Object.keys(output.row_limits) : []),
+  );
+  assert.deepEqual(output.contracts.scorecard, [0, 0, 1, 1]);
+  assert.deepEqual(output.contracts.grouped_bar, [1, 1, 2, 4]);
+  assert.deepEqual(output.contracts.heatmap, [2, 2, 1, 1]);
+  assert.deepEqual(output.contracts.sankey, [2, 2, 1, 1]);
+});
+
+test('chart order is deterministic per request and unrelated to declaration order', () => {
+  const result = python(`
+charts=p.SUPPORTED_DASHBOARD_CHARTS
+first=p._neutral_chart_order(charts,"依頼A")
+second=p._neutral_chart_order(tuple(reversed(charts)),"依頼A")
+other=p._neutral_chart_order(charts,"依頼B")
+print(json.dumps({"same":first==second,"different":first!=other,"complete":set(first)==set(charts)}))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    same: true,
+    different: true,
+    complete: true,
+  });
+});
+
+test('answered clarification schema avoids the provider-invalid zero item bound', () => {
+  const result = python(`
+schema=p._response_schema({"audience":"A","comparison":"B","business_goal":"C"})
+clarifications=schema["properties"]["clarifications"]
+print(json.dumps({"has_max":"maxItems" in clarifications,"has_min":"minItems" in clarifications}))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), { has_max: false, has_min: false });
+});

--- a/tests/spikes/report-generation/analysis-planner.test.ts
+++ b/tests/spikes/report-generation/analysis-planner.test.ts
@@ -333,7 +333,7 @@ print(json.dumps({"calls":calls,"schemas":schemas,"errors":errors},ensure_ascii=
       {
         enum: null,
         min_items: null,
-        max_items: 0,
+        max_items: null,
         has_temperature: false,
       },
     ],


### PR DESCRIPTION
## What & why

ライブデモが描画できる可視化形式、必要な区分軸・指標件数、結果行数上限を単一のプログラム契約として定義します。AIの構造化出力schemaへ渡す際は、依頼文をseedにした安定ハッシュ順へ並べ、宣言順による選択バイアスを避けられるようにします。既存の生成経路はこのPRでは切り替えず、後続PRで正規化と実行へ接続します。

Refs: #374

## Change classification (ARC-020)

- [x] Local (ライブデモのAI計画schema基盤)
- [ ] Contract
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: 残りの作業差分を退避した単独状態で `make format && make lint && make test && make coverage` が終了コード0。全対応グラフと形状契約の対応、依頼ごとの中立的な順序、回答済み確認事項のVertex schema境界を確認。
- Not verified (GR-042): Vertex AI / BigQueryの有料実行は行っていません。

## Documentation (DOC-030)

- [x] Doc-update matrix checked; 利用経路への接続と文書更新は後続の分割PRで行います。

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes: 対応グラフをAIへ把握させつつ、ホワイトリストの提示順で誘導しないという利用者要望に基づきます。

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test && make coverage` green
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No dependency additions; no guardrail violation
