### PR TITLE
feat(demo): execute AI-authored dashboard specifications

### DIFF
--- a/spikes/report-generation/analysis_planner.py
+++ b/spikes/report-generation/analysis_planner.py
@@ -8,56 +8,7 @@ import json
 import os
 import re
 
-ORGANIZATION_CONTEXT = {
-    "revision": "demo-org-ec-v1",
-    "state": "demo_fixture",
-    "business": "ECサイトで商品を販売する組織",
-    "goal": "購入成果を伸ばし、訪問者の継続利用を改善する",
-    "decision_cycle": "月次マーケティング会議",
-    "prohibited_interpretation": "観測相関を原因または施策効果と断定しない",
-}
-
-PANEL_CATALOG = {
-    "R4": {
-        "title": "購入件数と売上",
-        "kpi": "購入件数、購入金額",
-        "chart": "KPIカード",
-        "decision": "成果の規模を把握し、追加診断が必要か判断する",
-    },
-    "R11": {
-        "title": "リピートユーザー率",
-        "kpi": "2回以上訪問したユーザーの割合",
-        "chart": "KPIカード",
-        "decision": "一度きりの訪問に偏っていないか判断する",
-    },
-    "R12": {
-        "title": "平均エンゲージメント時間",
-        "kpi": "セッションあたり平均エンゲージメント時間",
-        "chart": "KPIカード",
-        "decision": "訪問中に十分な関与があるか判断する",
-    },
-    "R9": {
-        "title": "購入ファネル",
-        "kpi": "商品閲覧、カート追加、購入のセッション数",
-        "chart": "ファネル",
-        "decision": "購入までの減少が大きい段階を絞り込む",
-    },
-    "R16": {
-        "title": "日別セッションと7日移動平均",
-        "kpi": "日別セッション数、7日移動平均",
-        "chart": "2系列折れ線",
-        "decision": "一時的な変動と基調を区別する",
-    },
-    "R17": {
-        "title": "主要なサイト回遊",
-        "kpi": "入口から3ページ目までの主要経路",
-        "chart": "Sankey",
-        "decision": "回遊上の行き止まりや主要導線を診断する",
-    },
-}
-
 CLARIFICATION_FIELDS = ("audience", "comparison", "business_goal")
-DASHBOARD_CHARTS = ("scorecard", "bar", "line", "table", "sankey")
 SUPPORTED_DASHBOARD_CHARTS = (
     "scorecard",
     "kpi_group",
@@ -73,6 +24,7 @@ SUPPORTED_DASHBOARD_CHARTS = (
     "table",
     "sankey",
 )
+DASHBOARD_CHARTS = SUPPORTED_DASHBOARD_CHARTS
 DASHBOARD_ROW_LIMITS = {
     "scorecard": 1,
     "kpi_group": 1,
@@ -111,7 +63,11 @@ DYNAMIC_PANEL_TEXT_FIELDS = (
 )
 DYNAMIC_PANEL_LIST_FIELDS = ("dimensions", "measures")
 DYNAMIC_PANEL_LAYOUT_FIELDS = ("layout_row", "layout_weight")
-DYNAMIC_PANEL_FIELDS = DYNAMIC_PANEL_TEXT_FIELDS
+DYNAMIC_PANEL_FIELDS = (
+    DYNAMIC_PANEL_TEXT_FIELDS
+    + DYNAMIC_PANEL_LIST_FIELDS
+    + DYNAMIC_PANEL_LAYOUT_FIELDS
+)
 
 
 def _positive_count_setting(name: str, default: int) -> int:
@@ -240,16 +196,32 @@ DYNAMIC_PLAN_SCHEMA["properties"]["panels"] = {
         "properties": {
             "title": {"type": "string"},
             "kpi": {"type": "string"},
-            "chart": {
-                "type": "string",
-                "format": "enum",
-                "enum": list(DASHBOARD_CHARTS),
-            },
             "decision": {"type": "string"},
             "reason": {"type": "string"},
             "execution_prompt": {"type": "string"},
+            "visualization": _visualization_response_schema(DASHBOARD_CHARTS),
+            "layout_row": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "表示行番号。1から始めてパネル順に連続させ、同じ行は同じ値にする。1行は最大4件。",
+            },
+            "layout_weight": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100,
+                "description": "同じ表示行にあるパネル間の相対幅。",
+            },
         },
-        "required": list(DYNAMIC_PANEL_FIELDS),
+        "required": [
+            "title",
+            "kpi",
+            "decision",
+            "reason",
+            "execution_prompt",
+            "visualization",
+            "layout_row",
+            "layout_weight",
+        ],
     },
 }
 
@@ -282,48 +254,24 @@ def _response_schema(answers: dict[str, str]) -> dict:
 
 
 def _dashboard_response_schema(
-    answers: dict[str, str], *, revising: bool = False
+    answers: dict[str, str], *, revising: bool = False, seed: str = ""
 ) -> dict:
     """Constrain an initial or revised AI-authored dashboard."""
     schema = _response_schema(answers)
     schema["properties"]["panels"] = copy.deepcopy(
         DYNAMIC_PLAN_SCHEMA["properties"]["panels"]
     )
-    if revising:
-        schema["properties"]["panels"]["minItems"] = 1
-        schema["properties"]["panels"]["maxItems"] = MAX_PANEL_COUNT
-    return schema
-
-
-def planning_request(
-    objective: str, period: dict[str, str], metrics: str, answers: dict[str, str]
-) -> str:
-    """Build a bounded request from declared context, metrics, and panel catalog."""
-    catalog = "\n".join(
-        f"- {panel_id}: {item['title']} / {item['kpi']} / {item['chart']} / {item['decision']}"
-        for panel_id, item in PANEL_CATALOG.items()
+    schema["properties"]["panels"]["items"]["properties"]["visualization"] = (
+        _visualization_response_schema(DASHBOARD_CHARTS, seed=seed)
     )
-    answered = json.dumps(answers, ensure_ascii=False, sort_keys=True)
-    return f"""次の依頼から、月次ECサイト分析ダッシュボードを計画する。
-
-依頼: {objective}
-対象期間: {period['label']}
-読者回答: {answered}
-組織コンテキスト: {json.dumps(ORGANIZATION_CONTEXT, ensure_ascii=False)}
-指標定義:
-{metrics}
-
-利用できるパネル:
-{catalog}
-
-規則:
-- 目的を意思決定へ言い換え、検証可能な仮説を最大3件にする。
-- パネルは目的に必要な4〜6件だけを選び、重複を避ける。
-- KPI・グラフの選択理由をパネルごとに日本語で説明する。
-- 初回は audience / comparison / business_goal から重要な確認を1〜3件だけ質問する。
-- 読者回答にあるfieldは再質問しない。十分ならclarificationsを空にする。
-- 利用できない指標や因果関係を捏造しない。
-"""
+    if revising:
+        # Vertex can reject otherwise valid structured-output schemas as too
+        # complex when a nested array has a long item-count limit. Revisions
+        # can grow to MAX_PANEL_COUNT, so keep that policy in the strict local
+        # normalizer instead of sending minItems/maxItems to the provider.
+        schema["properties"]["panels"].pop("minItems", None)
+        schema["properties"]["panels"].pop("maxItems", None)
+    return schema
 
 
 def dashboard_planning_request(
@@ -356,33 +304,26 @@ def dashboard_planning_request(
         revision_context = f"""これは現在案への追加・変更・削除相談である。
 利用者の変更依頼: {instruction}
 現在の分析仕様: {json.dumps(current, ensure_ascii=False, sort_keys=True)}
-- 明示されていない既存パネルは維持する。
-- 追加依頼なら新しい分析仕様を追加し、既存案を置換しない。
-- 変更・削除依頼なら対象だけを変更し、重複なしの1〜{MAX_PANEL_COUNT}件にする。
+- 変更依頼の意味を解釈し、変更後の分析仕様をpanelsへすべて返す。
+- 利用者が変更または削除を求めていない既存仕様は、意味、順序、文言を維持する。
+- 新しい仕様は既存仕様と重複させず、変更後は重複なしの1〜{MAX_PANEL_COUNT}件にする。
 - 上限{MAX_PANEL_COUNT}件へ達した場合は追加せず、その理由を目的要約へ明記する。"""
     return f"""次の依頼から、月次ECサイト分析ダッシュボードを計画する。
 
 依頼: {objective}
 対象期間: {period['label']}
 読者回答: {answered}
-組織コンテキスト: {json.dumps(ORGANIZATION_CONTEXT, ensure_ascii=False)}
 {revision_context}
 スキーマ・指標定義:
 {metrics}
 
-利用できる可視化形式:
-- scorecard: 1つの成果指標
-- bar: 1つの区分軸と1つの数値
-- line: 日付と1つの数値
-- table: 意思決定に必要な最小限の列
-- sankey: source、target、sessionsで表せる段階付きフロー
-
 規則:
 - 目的を意思決定へ言い換え、検証可能な仮説を最大3件にする。
 - 固定済みの分析候補から選ばず、目的と仮説から分析仕様そのものを新規に考える。
-- 可視化は慣例で決めず、比較、構成比、時系列、偏り、フローのどれを判断するかに合わせて選ぶ。
-- 各パネルにはtitle、kpi、chart、decision、reasonと、SQL生成へ渡す具体的な1行の日本語execution_promptを書く。
-- execution_promptにはSQLを書かない。対象期間、指標、軸、比較、必要な出力列が分かる仕様にする。
+- 各パネルには構造化出力schemaで要求された分析仕様と、SQL生成へ渡す具体的な1行の日本語execution_promptを書く。
+- execution_promptにはSQLを書かない。対象期間、dimensionsとmeasuresの全項目、比較、必要な出力列が分かる仕様にする。
+- 各可視化の結果は最大行数以内で判断できる集計粒度にする。高カーディナリティの区分軸は上位件数と並び順をexecution_promptへ明記する。
+- ページ回遊のsankeyは最大{MAX_SANKEY_PAGES}ページにする。dimensionsは各ページを列挙せず遷移元・遷移先の2件にし、複数ページ分は隣接edgeの複数行としてexecution_promptへ明記する。
 - KPI・グラフの選択理由をパネルごとに日本語で説明する。
 - 初回は audience / comparison / business_goal から重要な確認を1〜3件だけ質問する。
 - 読者回答にあるfieldは再質問しない。十分ならclarificationsを空にする。
@@ -402,6 +343,65 @@ def _plan_panel_text(value, label: str, limit: int = 300) -> str:
     if len(text) > limit:
         raise PlannerError(f"分析計画の{label}が長すぎます。")
     return text
+
+
+def _panel_terms(
+    value, label: str, *, minimum: int = 0, allow_role_duplicates: bool = False
+) -> list[str]:
+    if not isinstance(value, list) or not minimum <= len(value) <= 4:
+        raise PlannerError(f"分析計画の{label}は{minimum}〜4件にしてください。")
+    terms = [_plan_panel_text(item, label, 80) for item in value]
+    if (
+        not allow_role_duplicates
+        and len({"".join(item.lower().split()) for item in terms}) != len(terms)
+    ):
+        raise PlannerError(f"分析計画の{label}に重複があります。")
+    return terms
+
+
+def _flatten_visualization(item: dict) -> dict:
+    """Flatten the provider-only chart/shape union into the stored panel contract."""
+    visualization = item.get("visualization")
+    if visualization is None:
+        return item
+    if not isinstance(visualization, dict):
+        raise PlannerError("分析仕様のvisualizationがobjectではありません。")
+    if any(field in item for field in ("chart", "dimensions", "measures")):
+        raise PlannerError("分析仕様の可視化指定が重複しています。")
+    return {
+        **item,
+        "chart": visualization.get("chart"),
+        "dimensions": visualization.get("dimensions"),
+        "measures": visualization.get("measures"),
+    }
+
+
+def _validate_chart_shape(chart: str, dimensions: list[str], measures: list[str]) -> None:
+    """Validate semantic fields against one renderer capability contract."""
+    min_dimensions, max_dimensions, min_measures, max_measures = CHART_SHAPE_CONTRACTS[
+        chart
+    ]
+    if not (
+        min_dimensions <= len(dimensions) <= max_dimensions
+        and min_measures <= len(measures) <= max_measures
+    ):
+        if chart == "scorecard":
+            raise PlannerError("scorecardは区分軸なし・指標1件にしてください。")
+        expected_dimensions = (
+            f"{min_dimensions}件"
+            if min_dimensions == max_dimensions
+            else f"{min_dimensions}〜{max_dimensions}件"
+        )
+        expected_measures = (
+            f"{min_measures}件"
+            if min_measures == max_measures
+            else f"{min_measures}〜{max_measures}件"
+        )
+        raise PlannerError(
+            f"AIが生成した{chart}仕様を描画できません。"
+            f"必要なのは区分軸{expected_dimensions}・指標{expected_measures}ですが、"
+            f"AI出力は区分軸{len(dimensions)}件・指標{len(measures)}件でした。"
+        )
 
 
 def _normalize_plan_header(
@@ -440,17 +440,35 @@ def _normalize_plan_header(
         )
     if len(clarifications) > 3 or (not answers and not clarifications):
         raise PlannerError("初回の確認事項は1〜3件にしてください。")
+    normalized_objective = _text(objective, "目的")
+    objective_summary = _text(raw.get("objective_summary"), "目的要約")
+    audience = _text(raw.get("audience"), "読者")
+    comparison = _text(raw.get("comparison"), "比較軸")
+    organization_context = {
+        "objective": normalized_objective,
+        "objective_summary": objective_summary,
+        "audience": audience,
+        "comparison": comparison,
+        "confirmed_answers": answers,
+    }
+    context_canonical = json.dumps(
+        organization_context, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    organization_context["revision"] = (
+        "context-" + hashlib.sha256(context_canonical.encode()).hexdigest()[:12]
+    )
     return {
         "status": "proposed",
-        "objective": _text(objective, "目的"),
-        "objective_summary": _text(raw.get("objective_summary"), "目的要約"),
-        "audience": _text(raw.get("audience"), "読者"),
-        "comparison": _text(raw.get("comparison"), "比較軸"),
+        "objective": normalized_objective,
+        "objective_summary": objective_summary,
+        "audience": audience,
+        "comparison": comparison,
         "period": period,
         "hypotheses": hypotheses,
         "clarifications": clarifications,
         "answers": answers,
-        "organization_context_revision": ORGANIZATION_CONTEXT["revision"],
+        "organization_context_revision": organization_context["revision"],
+        "organization_context": organization_context,
     }
 
 
@@ -460,47 +478,13 @@ def _revisioned_plan(plan: dict) -> dict:
     return plan
 
 
-def normalize_plan(
-    raw: dict,
-    objective: str,
-    period: dict[str, str],
-    answers: dict[str, str] | None = None,
-    *,
-    complete_purchase_recommendations: bool = False,
-) -> dict:
-    """Validate the fixed-catalog fixture contract used by the current demo."""
-    plan = _normalize_plan_header(raw, objective, period, answers)
-    panel_reasons, seen = {}, set()
-    for item in raw.get("panels", []):
-        panel_id = item.get("id") if isinstance(item, dict) else None
-        if panel_id not in PANEL_CATALOG or panel_id in seen:
-            raise PlannerError("分析計画に未登録または重複したパネルがあります。")
-        seen.add(panel_id)
-        panel_reasons[panel_id] = _text(item.get("reason"), "パネル選択理由")
-    if not 4 <= len(panel_reasons) <= 6:
-        raise PlannerError("分析計画のパネルは4〜6件にしてください。")
-    compact_objective = "".join(objective.split())
-    if (
-        complete_purchase_recommendations
-        and "購入" in compact_objective
-        and "改善" in compact_objective
-        and any(word in compact_objective for word in ("課題", "優先施策"))
-    ):
-        for panel_id, item in PANEL_CATALOG.items():
-            panel_reasons.setdefault(panel_id, f"{item['decision']}ため")
-    plan["panels"] = [
-        {"id": panel_id, **item, "reason": panel_reasons[panel_id]}
-        for panel_id, item in PANEL_CATALOG.items()
-        if panel_id in panel_reasons
-    ]
-    return _revisioned_plan(plan)
-
-
 def normalize_dashboard_plan(
     raw: dict,
     objective: str,
     period: dict[str, str],
     answers: dict[str, str] | None = None,
+    *,
+    allow_layout_gaps: bool = False,
 ) -> dict:
     """Validate model output and produce a deterministic proposed revision."""
     plan = _normalize_plan_header(raw, objective, period, answers)
@@ -511,16 +495,55 @@ def normalize_dashboard_plan(
     for index, item in enumerate(raw_panels, start=1):
         if not isinstance(item, dict):
             raise PlannerError("分析計画のパネルがobjectではありません。")
+        item = _flatten_visualization(item)
         panel = {
             field: _plan_panel_text(
                 item.get(field),
                 "パネル選択理由" if field == "reason" else field,
                 80 if field in {"title", "kpi", "chart"} else 300,
             )
-            for field in DYNAMIC_PANEL_FIELDS
+            for field in DYNAMIC_PANEL_TEXT_FIELDS
         }
         if panel["chart"] not in DASHBOARD_CHARTS:
             raise PlannerError("分析計画の可視化種別が未対応です。")
+        panel["dimensions"] = _panel_terms(
+            item.get("dimensions"),
+            "区分軸",
+            allow_role_duplicates=panel["chart"] == "sankey",
+        )
+        panel["measures"] = _panel_terms(item.get("measures"), "指標", minimum=1)
+        layout_row = item.get("layout_row")
+        layout_weight = item.get("layout_weight")
+        if (
+            isinstance(layout_row, bool)
+            or not isinstance(layout_row, int)
+            or layout_row < 1
+        ):
+            raise PlannerError("分析計画のlayout_rowは1以上の整数にしてください。")
+        if (
+            isinstance(layout_weight, bool)
+            or not isinstance(layout_weight, int)
+            or not 1 <= layout_weight <= 100
+        ):
+            raise PlannerError("分析計画のlayout_weightは1〜100の整数にしてください。")
+        panel["layout_row"] = layout_row
+        panel["layout_weight"] = layout_weight
+        dimensions, measures = panel["dimensions"], panel["measures"]
+        try:
+            _validate_chart_shape(panel["chart"], dimensions, measures)
+        except PlannerError as error:
+            suggestion = panel["execution_prompt"].rstrip("。")
+            if panel["chart"] == "sankey" and measures:
+                if not re.search(r"(?:上位|トップ)\s*\d+", suggestion):
+                    suggestion += "。経路は上位10件に絞って"
+                suggestion += (
+                    f"。3ページ分は遷移元・遷移先の隣接edgeとして表し、"
+                    f"区分軸2件と{measures[0]}1指標で返して"
+                )
+            raise PlannerError(
+                f"{error} 現在案は保持しています。",
+                suggested_instruction=suggestion,
+            ) from error
         prompt = panel["execution_prompt"]
         if re.search(
             r"(?:```|`|\b(?:SELECT|WITH|FROM|GROUP\s+BY)\b)",
@@ -528,36 +551,34 @@ def normalize_dashboard_plan(
             flags=re.IGNORECASE,
         ):
             raise PlannerError("分析計画の実行仕様にはSQLを書けません。")
+        compact_prompt = "".join(prompt.lower().split())
+        missing = [
+            term
+            for term in dimensions + measures
+            if "".join(term.lower().split()) not in compact_prompt
+        ]
+        if missing:
+            raise PlannerError(
+                "分析計画の実行仕様に区分軸・指標がありません: " + "、".join(missing)
+            )
         prompt_key = "".join(prompt.lower().split())
         if prompt_key in seen_prompts:
             raise PlannerError("分析計画に重複した実行仕様があります。")
         seen_prompts.add(prompt_key)
+        panel["max_result_rows"] = DASHBOARD_ROW_LIMITS[panel["chart"]]
         panels.append({"id": f"P{index}", **panel})
+    layout_rows = [panel["layout_row"] for panel in panels]
+    expected_rows = list(range(1, max(layout_rows) + 1))
+    if layout_rows != sorted(layout_rows) or (
+        not allow_layout_gaps and sorted(set(layout_rows)) != expected_rows
+    ):
+        raise PlannerError(
+            "分析計画のlayout_rowは1から始まる連続値をパネル順に指定してください。"
+        )
+    if any(layout_rows.count(row) > 4 for row in expected_rows):
+        raise PlannerError("分析計画の1行あたりのパネルは最大4件にしてください。")
     plan["panels"] = panels
     return _revisioned_plan(plan)
-
-
-def propose(client, model: str, objective: str, period: dict, metrics: str, answers: dict):
-    """Ask Vertex AI for a bounded plan and normalize its response."""
-    from google.genai import types
-    from vertex_usage import token_counts
-
-    response = client.models.generate_content(
-        model=model,
-        contents=planning_request(objective, period, metrics, answers),
-        config=types.GenerateContentConfig(
-            system_instruction="あなたは意思決定から分析仕様を設計する日本語BIプランナー。",
-            response_mime_type="application/json",
-            response_schema=_response_schema(answers),
-        ),
-    )
-    return normalize_plan(
-        json.loads(response.text),
-        objective,
-        period,
-        answers,
-        complete_purchase_recommendations=True,
-    ), token_counts(response.usage_metadata)
 
 
 def propose_dashboard(
@@ -589,50 +610,57 @@ def propose_dashboard(
             system_instruction="あなたは意思決定から分析仕様を設計する日本語BIプランナー。",
             response_mime_type="application/json",
             response_schema=_dashboard_response_schema(
-                answers, revising=current_plan is not None
+                answers,
+                revising=current_plan is not None,
+                seed=f"{objective}\n{instruction or ''}",
             ),
         ),
     )
-    plan = normalize_dashboard_plan(
-        json.loads(response.text), objective, period, answers
-    )
-    add_only = instruction and any(
-        word in instruction for word in ("追加", "他にも", "ほかにも", "増や")
-    ) and not any(
-        word in instruction for word in ("削除", "除外", "減ら", "置換", "入れ替")
-    )
-    if (
-        current_plan is not None
-        and add_only
-        and len(current_plan.get("panels", [])) < MAX_PANEL_COUNT
-        and len(plan["panels"]) <= len(current_plan.get("panels", []))
-    ):
-        raise PlannerError("追加依頼に対して分析パネルが追加されませんでした。")
-    return plan, token_counts(response.usage_metadata)
+    try:
+        response_text = response.text
+    except (AttributeError, ValueError) as error:
+        raise PlannerError(
+            "Vertex AIから分析計画JSONを受け取れませんでした。"
+            "現在案は保持し、自動再実行していません。"
+        ) from error
+    if not isinstance(response_text, str) or not response_text.strip():
+        raise PlannerError(
+            "Vertex AIから分析計画JSONを受け取れませんでした。"
+            "現在案は保持し、自動再実行していません。"
+        )
+    try:
+        raw = json.loads(response_text)
+    except json.JSONDecodeError as error:
+        raise PlannerError(
+            "Vertex AIの分析計画JSONを解釈できませんでした。"
+            "現在案は保持し、自動再実行していません。"
+        ) from error
+    return normalize_dashboard_plan(
+        raw, objective, period, answers
+    ), token_counts(response.usage_metadata)
 
 
 CONSULTATION_CHARTS = DASHBOARD_CHARTS
-CONSULTATION_FIELDS = (
+CONSULTATION_TEXT_FIELDS = (
     "title",
     "objective",
-    "metric",
-    "dimension",
     "comparison",
     "chart",
     "execution_prompt",
     "reason",
 )
+CONSULTATION_LIST_FIELDS = ("dimensions", "measures")
+CONSULTATION_FIELDS = CONSULTATION_TEXT_FIELDS + CONSULTATION_LIST_FIELDS
 
 
-def _consultation_schema() -> dict:
+def _consultation_schema(seed: str = "") -> dict:
     recommendation_properties = {
-        field: {"type": "string"} for field in CONSULTATION_FIELDS
+        field: {"type": "string"} for field in CONSULTATION_TEXT_FIELDS
+        if field != "chart"
     }
-    recommendation_properties["chart"] = {
-        "type": "string",
-        "format": "enum",
-        "enum": list(CONSULTATION_CHARTS),
-    }
+    recommendation_properties["visualization"] = _visualization_response_schema(
+        CONSULTATION_CHARTS, seed=seed
+    )
     return {
         "type": "object",
         "properties": {
@@ -644,7 +672,12 @@ def _consultation_schema() -> dict:
                 "items": {
                     "type": "object",
                     "properties": recommendation_properties,
-                    "required": list(CONSULTATION_FIELDS),
+                    "required": [
+                        field
+                        for field in CONSULTATION_TEXT_FIELDS
+                        if field != "chart"
+                    ]
+                    + ["visualization"],
                 },
             },
             "follow_up_question": {"type": "string"},
@@ -681,7 +714,8 @@ def consultation_request(
 規則:
 - 今回の発言と対話履歴を踏まえ、分析担当者として自然な日本語で応答する。
 - 分析仮説を立て、目的に役立つ新しい分析仕様を1〜4件考える。
-- 各仕様には、指標、切り口、比較軸、可視化、選択理由、SQL生成へ渡せる具体的な日本語依頼を書く。
+- 各仕様には、measures、dimensions、比較軸、可視化、選択理由、SQL生成へ渡せる具体的な日本語依頼を書く。
+- 可視化を含む分析内容は今回の目的から考え、選択理由をreasonへ書く。
 - 「他にない」など別案を求められた場合、履歴で既に提示した分析をできる限り避ける。
 - 最後に、分析目的を具体化する短い確認質問を1件だけ書く。
 - 文脈にない指標・列・因果関係・取得済みでない数値を捏造しない。
@@ -699,6 +733,64 @@ def _bounded_consultation_text(value, label: str, limit: int = 500) -> str:
     return text
 
 
+def _consultation_terms(value, label: str, *, minimum: int = 0) -> list[str]:
+    if not isinstance(value, list) or not minimum <= len(value) <= 4:
+        raise PlannerError(f"分析相談の{label}は{minimum}〜4件にしてください。")
+    terms = [_bounded_consultation_text(item, label, 80) for item in value]
+    if len({"".join(item.lower().split()) for item in terms}) != len(terms):
+        raise PlannerError(f"分析相談の{label}に重複があります。")
+    return terms
+
+
+def confirm_analysis_specification(raw: dict) -> dict:
+    """Validate and revision one AI-authored single-insight specification."""
+    if not isinstance(raw, dict):
+        raise PlannerError("分析相談の候補がobjectではありません。")
+    raw = _flatten_visualization(raw)
+    recommendation = {
+        field: _bounded_consultation_text(
+            raw.get(field),
+            "候補理由" if field == "reason" else field,
+            80 if field in {"title", "comparison", "chart"} else 500,
+        )
+        for field in CONSULTATION_TEXT_FIELDS
+    }
+    recommendation["dimensions"] = _consultation_terms(raw.get("dimensions"), "区分軸")
+    recommendation["measures"] = _consultation_terms(
+        raw.get("measures"), "指標", minimum=1
+    )
+    chart = recommendation["chart"]
+    if chart not in CONSULTATION_CHARTS:
+        raise PlannerError("分析相談の可視化種別が未対応です。")
+    dimensions = recommendation["dimensions"]
+    measures = recommendation["measures"]
+    _validate_chart_shape(chart, dimensions, measures)
+    execution_prompt = recommendation["execution_prompt"]
+    if re.search(
+        r"(?:```|`|\b(?:SELECT|WITH|FROM|GROUP\s+BY)\b)",
+        execution_prompt,
+        flags=re.IGNORECASE,
+    ):
+        raise PlannerError("分析相談の実行依頼にはSQLを書けません。")
+    compact_prompt = "".join(execution_prompt.lower().split())
+    missing = [
+        term
+        for term in dimensions + measures
+        if "".join(term.lower().split()) not in compact_prompt
+    ]
+    if missing:
+        raise PlannerError(
+            "分析相談の実行依頼に区分軸・指標がありません: " + "、".join(missing)
+        )
+    canonical = json.dumps(
+        recommendation, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    recommendation["revision"] = (
+        "insight-" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
+    )
+    return recommendation
+
+
 def normalize_consultation(raw: dict) -> dict:
     """Validate newly reasoned analysis specifications before SQL generation."""
     if not isinstance(raw, dict):
@@ -711,23 +803,8 @@ def normalize_consultation(raw: dict) -> dict:
     for item in raw_recommendations:
         if not isinstance(item, dict):
             raise PlannerError("分析相談の候補がobjectではありません。")
-        recommendation = {
-            field: _bounded_consultation_text(
-                item.get(field),
-                "候補理由" if field == "reason" else field,
-                80 if field in {"title", "metric", "dimension", "comparison"} else 500,
-            )
-            for field in CONSULTATION_FIELDS
-        }
-        if recommendation["chart"] not in CONSULTATION_CHARTS:
-            raise PlannerError("分析相談の可視化種別が未対応です。")
+        recommendation = confirm_analysis_specification(item)
         execution_prompt = recommendation["execution_prompt"]
-        if re.search(
-            r"(?:```|`|\b(?:SELECT|WITH|FROM|GROUP\s+BY)\b)",
-            execution_prompt,
-            flags=re.IGNORECASE,
-        ):
-            raise PlannerError("分析相談の実行依頼にはSQLを書けません。")
         duplicate_key = "".join(execution_prompt.lower().split())
         if duplicate_key in seen:
             raise PlannerError("分析相談に重複した候補があります。")
@@ -770,50 +847,12 @@ def propose_consultation(
                 "日本語BIアナリスト。"
             ),
             response_mime_type="application/json",
-            response_schema=_consultation_schema(),
+            response_schema=_consultation_schema(seed=f"{profile}\n{question}"),
         ),
     )
     return normalize_consultation(
         json.loads(response.text)
     ), token_counts(response.usage_metadata)
-
-
-def confirm_plan(plan: dict) -> dict:
-    """Revalidate an edited proposal and freeze a new immutable revision."""
-    answers = plan.get("answers", {})
-    if not isinstance(answers, dict):
-        raise PlannerError("確認事項の回答がobjectではありません。")
-    clarifications = plan.get("clarifications", [])
-    if not isinstance(clarifications, list):
-        raise PlannerError("確認事項が配列ではありません。")
-    for item in clarifications:
-        field = item.get("field") if isinstance(item, dict) else None
-        if field not in CLARIFICATION_FIELDS:
-            diagnostic = json.dumps(field, ensure_ascii=False)
-            raise PlannerError(f"確認事項のfieldが許可範囲外です: {diagnostic}")
-        answer = answers.get(field)
-        if not isinstance(answer, str) or not answer.strip():
-            raise PlannerError(f"確認事項{field}の回答が空です。")
-    raw = {
-        key: plan.get(key)
-        for key in ("objective_summary", "audience", "comparison", "hypotheses")
-    }
-    raw["clarifications"] = []
-    raw["panels"] = [
-        {"id": item.get("id"), "reason": item.get("reason")}
-        for item in plan.get("panels", [])
-    ]
-    confirmed = normalize_plan(
-        raw, plan.get("objective", ""), plan.get("period", {}), answers
-    )
-    if confirmed["clarifications"]:
-        raise PlannerError("未回答の確認事項があります。")
-    confirmed["status"] = "confirmed"
-    canonical = json.dumps(
-        confirmed, ensure_ascii=False, sort_keys=True, separators=(",", ":")
-    )
-    confirmed["revision"] = "plan-" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
-    return confirmed
 
 
 def confirm_dashboard_plan(plan: dict) -> dict:
@@ -842,7 +881,11 @@ def confirm_dashboard_plan(plan: dict) -> dict:
         for item in plan.get("panels", [])
     ]
     confirmed = normalize_dashboard_plan(
-        raw, plan.get("objective", ""), plan.get("period", {}), answers
+        raw,
+        plan.get("objective", ""),
+        plan.get("period", {}),
+        answers,
+        allow_layout_gaps=True,
     )
     if confirmed["clarifications"]:
         raise PlannerError("未回答の確認事項があります。")

--- a/spikes/report-generation/bitcoin_profile.py
+++ b/spikes/report-generation/bitcoin_profile.py
@@ -1,9 +1,4 @@
-"""Bounded non-GA4 profile for the live nested-schema demonstration.
-
-This is the first public-schema slice of Issue #188, not evidence that arbitrary
-private schemas work.  The profile deliberately supplies only inspected schema
-metadata and explicit metric semantics to the model.
-"""
+"""Inspected Bitcoin schema and safety rules for non-GA4 NL-to-SQL analysis."""
 
 from __future__ import annotations
 
@@ -15,37 +10,6 @@ DATASET = "bigquery-public-data.crypto_bitcoin"
 TABLE = f"{DATASET}.transactions"
 FIRST_MONTH = date(2024, 1, 1)
 LAST_MONTH = date(2024, 12, 1)
-EXAMPLE_QUESTION = (
-    "2024年1月のBitcoin取引について、各取引の異なる受取アドレス数を、"
-    "1件・2〜3件・4〜9件・10件以上に分け、取引数が多い順で出して"
-)
-REFERENCE_SQL = f"""WITH per_transaction AS (
-    SELECT
-        t.`hash`,
-        COUNT(DISTINCT address) AS address_count
-    FROM
-        `{TABLE}` AS t
-        CROSS JOIN UNNEST(t.outputs) AS output
-        CROSS JOIN UNNEST(output.addresses) AS address
-    WHERE
-        t.block_timestamp_month = DATE '2024-01-01'
-    GROUP BY
-        t.`hash`
-)
-SELECT
-    CASE
-        WHEN address_count = 1 THEN '1件'
-        WHEN address_count BETWEEN 2 AND 3 THEN '2〜3件'
-        WHEN address_count BETWEEN 4 AND 9 THEN '4〜9件'
-        ELSE '10件以上'
-    END AS address_count_band,
-    COUNT(1) AS transaction_count
-FROM
-    per_transaction
-GROUP BY
-    address_count_band
-ORDER BY
-    transaction_count DESC"""
 
 SCHEMA_DDL = f"""
 -- BigQuery public dataset; block_timestamp_month is the partition column.
@@ -73,23 +37,22 @@ CREATE TABLE `{TABLE}` (
 
 
 def prompt_rules() -> str:
-    """Return the inspected schema and the smallest explicit semantic contract."""
+    """Return inspected schema semantics and SQL safety constraints."""
     return f"""あなたは BigQuery 標準SQLで分析用クエリを書く。
 
 {SCHEMA_DDL}
 
-指標・軸の定義:
-- 取引 = 元テーブルの1行。識別子は hash。
-- 受取アドレス = outputs を展開し、さらに各 output.addresses を展開した address。
-- 取引ごとの異なる受取アドレス数 = COUNT(DISTINCT address)。
-- addresses が空または NULL の output は受取アドレス数の集計対象外。
-- 取引数 = 取引ごとの集計後の行数。outputs 展開後の行数を取引数にしない。
-- 受取アドレス数帯 = 1件、2〜3件、4〜9件、10件以上。0件は上の定義により対象外。
+スキーマ契約:
+- 取引は元テーブルの1行で、識別子は hash。
+- block_timestamp は取引時刻、block_timestamp_month は月単位のpartition列。
+- input_count、output_count、input_value、output_value、feeは元データに記録された数値列。
+- inputsとoutputsはREPEATED STRUCTで、その中のaddressesもREPEATED STRING。
+- REPEATED列を使う分析だけ、必要な階層をそれぞれUNNESTする。展開後の行数を取引数と解釈しない。
 
 規則:
+- スキーマにある列と、そこから明示的に計算できる値だけを使う。
 - テーブル参照は必ず `{TABLE}` と完全修飾する。
 - スキャン量を抑えるため、block_timestamp_month = DATE '<month-start>' を必ず使う。
-- outputs と output.addresses はそれぞれ UNNEST する。
 - hash はGoogleSQLの予約語なので、元テーブルでは t.`hash` と修飾・引用する。
   後続CTEへ渡す場合は transaction_hash という別名を使い、裸の hash は書かない。
 - SELECT * は使わず、必要な列だけを明示する。
@@ -122,41 +85,20 @@ def period_for_question(question: str) -> dict[str, str]:
     }
 
 
-def section(question: str) -> dict:
-    """Build the declared two-column result contract for the demo question."""
-    normalized = question.strip()
-    if not normalized:
-        raise ValueError("question must not be empty")
-    if len(normalized) > 500:
-        raise ValueError("question must be at most 500 characters")
-    if any(ord(char) < 32 for char in normalized):
-        raise ValueError("question must be a single line without control characters")
-    if "受取アドレス" not in normalized or "取引数" not in normalized:
-        raise ValueError(
-            "Bitcoinデモは現在「取引ごとの受取アドレス数帯別の取引数」のみ対応します。"
-        )
-    return {
-        "id": "BTC1",
-        "title": "受取アドレス数帯別の取引数",
-        "text": normalized,
-        "compare": "execution",
-        "component": "bar",
-        "verification": "execution",
-        "shape": {
-            "rows": "受取アドレス数帯ごとに1行、取引数の多い順",
-            "columns": ["受取アドレス数帯", "取引数"],
-        },
-    }
-
-
 def generation_request(item: dict, period: dict[str, str]) -> str:
-    """Build the profile-specific analysis request passed to the model."""
-    return (
+    """Attach the AI-confirmed output contract to one natural-language request."""
+    requirements = "\n".join(
+        f"- {requirement}" for requirement in item.get("generation_requirements", [])
+    )
+    request = (
         f"{item['text']}\n"
         f"（対象期間: block_timestamp_month = DATE '{period['partition']}'）\n"
-        "（出力形式: 列は `address_count_band`, `transaction_count` の順。"
-        "受取アドレス数帯ごとに1行、取引数の多い順。）"
+        "（SQL出力列: "
+        + ", ".join(f"`{column}`" for column in item["source_columns"])
+        + " の順。）\n"
+        f"（表示上の列: {'、'.join(item['shape']['columns'])}。）"
     )
+    return request + (f"\n追加制約:\n{requirements}" if requirements else "")
 
 
 def require_sql_period(sql: str, period: dict[str, str]) -> None:
@@ -172,15 +114,8 @@ def require_sql_period(sql: str, period: dict[str, str]) -> None:
         )
 
 
-def quote_reserved_hash_identifiers(sql: str) -> str:
-    """Quote bare Bitcoin hash identifiers without touching paths or literals.
-
-    GoogleSQL permits the reserved HASH token after a path separator (``t.hash``)
-    but not as the first part of an identifier.  The bounded Bitcoin profile knows
-    that a bare HASH token can only mean the transaction column, so quoting it is a
-    semantics-preserving normalization before execution.
-    """
-    output: list[str] = []
+def require_quoted_hash(sql: str) -> None:
+    """Reject rather than rewrite an unquoted reserved hash identifier."""
     index = 0
     length = len(sql)
 
@@ -202,18 +137,15 @@ def quote_reserved_hash_identifiers(sql: str) -> str:
         if sql.startswith("--", index):
             end = sql.find("\n", index + 2)
             end = length if end == -1 else end
-            output.append(sql[index:end])
             index = end
             continue
         if sql.startswith("/*", index):
             end = sql.find("*/", index + 2)
             end = length if end == -1 else end + 2
-            output.append(sql[index:end])
             index = end
             continue
         if sql[index] in {"'", '"', "`"}:
             end = quoted_end(index, sql[index])
-            output.append(sql[index:end])
             index = end
             continue
         if sql[index].isalpha() or sql[index] == "_":
@@ -221,17 +153,10 @@ def quote_reserved_hash_identifiers(sql: str) -> str:
             while end < length and (sql[end].isalnum() or sql[end] == "_"):
                 end += 1
             token = sql[index:end]
-            previous = index - 1
-            while previous >= 0 and sql[previous].isspace():
-                previous -= 1
-            if token.casefold() == "hash" and (
-                previous < 0 or sql[previous] != "."
-            ):
-                token = "`hash`"
-            output.append(token)
+            if token.casefold() == "hash":
+                raise ValueError(
+                    "Bitcoin SQLのhash列が引用されていないためBigQueryへ送信しません。"
+                )
             index = end
             continue
-        output.append(sql[index])
         index += 1
-
-    return "".join(output)

--- a/spikes/report-generation/live_demo.py
+++ b/spikes/report-generation/live_demo.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import sys
 import threading
+import traceback
 import webbrowser
 from datetime import date, datetime
 from decimal import Decimal
@@ -25,68 +26,39 @@ from demo import DemoError, VENV_DIR, prepare_python, require_adc, run
 HERE = Path(__file__).resolve().parent
 HOST, PORT = "127.0.0.1", 8765
 MAX_BODY_BYTES, MAX_PLAN_BODY_BYTES, MAX_RESULT_ROWS = 4096, 98304, 100
+MAX_QUESTION_CHARS = 500
 MAX_DASHBOARD_BODY_BYTES = MAX_PLAN_BODY_BYTES
+MAX_SANKEY_PAGES = planner.MAX_SANKEY_PAGES
 SAMPLE_FIRST_DAY = date(2020, 11, 1)
 SAMPLE_LAST_DAY = date(2021, 1, 31)
-DASHBOARD_SECTION_IDS = report.SHOWCASE_IDS
-DASHBOARD_PURPOSES = {
-    "R4": "購入成果の規模を最初に確認する",
-    "R11": "単発訪問だけでなく、ユーザーが定着しているかを確認する",
-    "R12": "訪問中に十分な関与が生まれているかを確認する",
-    "R9": "閲覧から購入までのどこで減少しているかを特定する",
-    "R16": "日々の変動と7日間の基調を分けて確認する",
-    "R17": "主要なページ遷移から回遊上の特徴を確認する",
-}
-DASHBOARD_ROW_TEMPLATES = (
-    (("R4", 50), ("R11", 25), ("R12", 25)),
-    (("R9", 40), ("R17", 60)),
-    (("R16", 100),),
-)
-
-
-def dashboard_layout_rows(panel_ids: list[str]) -> list[dict]:
-    """Return complete rows whose shares always consume the available width."""
-    requested = set(panel_ids)
-    known = {panel_id for row in DASHBOARD_ROW_TEMPLATES for panel_id, _ in row}
-    if len(requested) != len(panel_ids) or not requested <= known:
-        raise LiveDemoError("ダッシュボード行へ未登録または重複したパネルがあります。")
-    rows = []
-    covered = set()
-    for template in DASHBOARD_ROW_TEMPLATES:
-        present = [(panel_id, share) for panel_id, share in template if panel_id in requested]
-        if not present:
-            continue
-        total = sum(share for _, share in present)
-        shares = [round(share * 100 / total, 4) for _, share in present]
-        shares[-1] = round(100 - sum(shares[:-1]), 4)
-        row_ids = [panel_id for panel_id, _ in present]
-        rows.append({"panel_ids": row_ids, "shares": shares})
-        covered.update(row_ids)
-    if covered != requested:
-        raise LiveDemoError("ダッシュボード行に配置できないパネルがあります。")
-    return rows
-
-
 def dashboard_layout_rows_for_plan(panels: list[dict]) -> list[dict]:
-    """Lay out AI-authored panels without encoding any analysis topic."""
+    """Render only the row and relative-width decisions authored by the AI."""
     if not panels:
         raise LiveDemoError("ダッシュボード計画にパネルがありません。")
+    grouped: dict[int, list[dict]] = {}
+    for panel in panels:
+        row = panel.get("layout_row")
+        weight = panel.get("layout_weight")
+        if (
+            isinstance(row, bool)
+            or not isinstance(row, int)
+            or row < 1
+            or isinstance(weight, bool)
+            or not isinstance(weight, int)
+            or not 1 <= weight <= 100
+        ):
+            raise LiveDemoError("AIが考察したダッシュボード配置がありません。")
+        grouped.setdefault(row, []).append(panel)
+    row_numbers = list(grouped)
+    if row_numbers != sorted(row_numbers) or any(
+        len(group) > 4 for group in grouped.values()
+    ):
+        raise LiveDemoError("AIが考察したダッシュボード行が描画仕様と一致しません。")
     rows: list[dict] = []
-    index = 0
-    weights = {"scorecard": 40, "bar": 60, "line": 60, "table": 60, "sankey": 100}
-    while index < len(panels):
-        panel = panels[index]
-        if panel.get("chart") == "sankey":
-            group = [panel]
-            index += 1
-        else:
-            group = panels[index : index + 2]
-            if len(group) == 2 and group[1].get("chart") == "sankey":
-                group = group[:1]
-            index += len(group)
-        raw_shares = [weights.get(item.get("chart"), 60) for item in group]
-        total = sum(raw_shares)
-        shares = [round(value * 100 / total, 4) for value in raw_shares]
+    for row_number in row_numbers:
+        group = grouped[row_number]
+        total = sum(item["layout_weight"] for item in group)
+        shares = [round(item["layout_weight"] * 100 / total, 4) for item in group]
         shares[-1] = round(100 - sum(shares[:-1]), 4)
         rows.append(
             {
@@ -100,28 +72,6 @@ def dashboard_layout_rows_for_plan(panels: list[dict]) -> list[dict]:
 def running_in_demo_venv() -> bool:
     """Return whether this process is using the demo virtual environment."""
     return Path(sys.prefix).resolve() == VENV_DIR.resolve()
-
-
-def requires_analysis_consultation(question: str) -> bool:
-    """Return whether a prompt asks for advice rather than a runnable analysis.
-
-    This guard is intentionally narrow. Concrete prompts remain eligible for the
-    existing cost gate, while common Japanese discovery questions cannot fall
-    through to a default SQL template and unexpectedly spend money.
-    """
-    compact = "".join(question.split()).rstrip("?？!！。")
-    discovery = (
-        compact.startswith(("どんな", "何を", "何の", "どういう"))
-        and "分析" in compact
-        and any(word in compact for word in ("したら", "すれば", "できる"))
-    )
-    recommendation = (
-        compact.startswith(("おすすめ", "推奨"))
-        and "分析" in compact
-        and compact.endswith(("教えて", "提案して", "知りたい"))
-    )
-    consultation = compact.startswith("分析") and "相談" in compact
-    return discovery or recommendation or consultation
 
 
 def analysis_consultation_context(metrics: str, profile: str) -> str:
@@ -192,50 +142,72 @@ function populateResult(result){graph(result);$("result-data").replaceChildren(t
 function clearResult(){$("chart").replaceChildren();$("result-data").replaceChildren();selectResultTab("chart")}
 function syncClarificationAnswers(event){const inputs=event?[event.target]:[...document.querySelectorAll("[data-answer-field]")];inputs.forEach(input=>{const field=input.dataset.answerField,value=input.value.trim(),status=input.answerStatus;if(value){currentAnswers[field]=value;input.parentElement.classList.add("accepted");status.textContent=value===input.dataset.recommendedAnswer?"推奨回答を採用済み（編集可）":"編集した回答を採用（さらに編集可）";if(field==="audience")$("plan-audience").value=value;if(field==="comparison")$("plan-comparison").value=value}else{delete currentAnswers[field];input.parentElement.classList.remove("accepted");status.textContent="回答を入力するとbuildできます。"}});$("plan-build").disabled=[...document.querySelectorAll("[data-answer-field]")].some(input=>!input.value.trim())}
 function syncPlanFieldAnswer(field,value){const input=document.querySelector(`[data-answer-field="${field}"]`);if(input){input.value=value;syncClarificationAnswers({target:input})}}
-function renderAnalysisPlan(event){const plan=event.plan;currentPlan=plan;pendingPlanBase=null;pendingPlanInstruction=null;$("plan-revision-instruction").value="";dashboardStage("review");$("plan-review").className="panel";$("plan-revision").textContent=plan.revision;$("plan-summary").textContent=plan.objective_summary;$("plan-audience").value=plan.audience;$("plan-comparison").value=plan.comparison;$("plan-context").textContent=`組織コンテキスト ${plan.organization_context_revision}（ローカルデモfixture・本番メモリー未接続）`;
+function clearPlanCorrection(){$("plan-correction").className="notice warning hidden";$("plan-correction-text").textContent=""}
+function showPlanCorrection(instruction){$("plan-correction-text").textContent=instruction;$("plan-correction").className="notice warning"}
+function renderAnalysisPlan(event){const plan=event.plan;currentPlan=plan;pendingPlanBase=null;pendingPlanInstruction=null;$("plan-revision-instruction").value="";clearPlanCorrection();dashboardStage("review");$("plan-review").className="panel";$("plan-revision").textContent=plan.revision;$("plan-summary").textContent=plan.objective_summary;$("plan-audience").value=plan.audience;$("plan-comparison").value=plan.comparison;$("plan-context").textContent=`依頼と確認回答から生成したコンテキスト ${plan.organization_context_revision}`;
 const hypotheses=document.createElement("ul");plan.hypotheses.forEach(value=>hypotheses.appendChild(Object.assign(document.createElement("li"),{textContent:value})));$("plan-hypotheses").replaceChildren(hypotheses);const questions=[];plan.clarifications.forEach(item=>{const box=Object.assign(document.createElement("div"),{className:"clarification"}),label=document.createElement("label"),input=document.createElement("input"),status=document.createElement("small");label.textContent=item.question;input.value=item.recommended_answer;input.dataset.answerField=item.field;input.dataset.recommendedAnswer=item.recommended_answer;input.answerStatus=status;input.oninput=syncClarificationAnswers;currentAnswers[item.field]=input.value.trim();box.append(label,input,status);questions.push(box)});$("plan-clarifications").replaceChildren(...questions);syncClarificationAnswers();
-const choices=[];plan.panels.forEach(panel=>{const row=Object.assign(document.createElement("div"),{className:"plan-choice"}),input=Object.assign(document.createElement("input"),{type:"checkbox",checked:true}),label=document.createElement("label"),detail=document.createElement("small");input.dataset.panelId=panel.id;label.textContent=`${panel.title} — ${panel.chart}`;detail.textContent=`${panel.reason} 判断用途: ${panel.decision}`;label.append(detail);row.append(input,label);choices.push(row)});$("plan-panels").replaceChildren(...choices);$("plan-revise").className="secondary";$("dashboard-status").textContent="提案済み";$("dashboard-message").textContent=plan.clarifications.length?"推奨回答を採用済みです。そのままbuildするか、変更依頼を添えてAIへ再提案できます。":`分析仕様を確認し、必要なら追加・変更・削除を依頼できます。Vertex AI推定 ¥${event.cost_jpy}`}
+const choices=[];plan.panels.forEach(panel=>{const row=Object.assign(document.createElement("div"),{className:"plan-choice"}),input=Object.assign(document.createElement("input"),{type:"checkbox",checked:true}),label=document.createElement("label"),detail=document.createElement("small");input.dataset.panelId=panel.id;label.textContent=`${panel.title} — ${panel.chart}`;detail.textContent=`${panel.reason} 判断用途: ${panel.decision} AIレイアウト: 行${panel.layout_row}・相対幅${panel.layout_weight}`;label.append(detail);row.append(input,label);choices.push(row)});$("plan-panels").replaceChildren(...choices);$("plan-revise").className="secondary";$("dashboard-status").textContent="提案済み";$("dashboard-message").textContent=plan.clarifications.length?"推奨回答を採用済みです。そのままbuildするか、変更依頼を添えてAIへ再提案できます。":`分析仕様を確認し、必要なら追加・変更・削除を依頼できます。Vertex AI推定 ¥${event.cost_jpy}`}
 function collectAnswers(){syncClarificationAnswers();if($("plan-build").disabled)throw new Error("すべての確認事項へ回答してください。")}
 function selectedPlan(){const selected=new Set([...document.querySelectorAll("[data-panel-id]:checked")].map(input=>input.dataset.panelId));if(selected.size<1)throw new Error("ダッシュボードには1件以上のパネルを選択してください。");if(selected.size>__MAX_PANEL_COUNT__)throw new Error("ダッシュボードのパネルは最大__MAX_PANEL_COUNT__件です。");const plan=JSON.parse(JSON.stringify(currentPlan));plan.panels=plan.panels.filter(panel=>selected.has(panel.id));plan.audience=$("plan-audience").value.trim();plan.comparison=$("plan-comparison").value.trim();if(!plan.audience||!plan.comparison)throw new Error("主な読者と比較の考え方を入力してください。");plan.answers=currentAnswers;return plan}
 function citedItem(item,suffix=""){const row=document.createElement("p");row.appendChild(document.createTextNode(item.text+suffix));item.evidence_refs.forEach(ref=>row.appendChild(Object.assign(document.createElement("span"),{className:"citation",textContent:`根拠 ${ref.panel_id} / ${ref.result_revision} / SQL ${ref.sql_sha256}`})));return row}
-function renderMeetingReport(event){const report=event.report;$("report-empty").className="hidden";$("report-output").className="panel report-home";$("report-revision").textContent=report.report_revision;const warnings=report.generation_warnings||[];$("report-warning").className=warnings.length?"notice warning":"hidden";$("report-warning").textContent=warnings.join(" ");$("report-summary").replaceChildren(citedItem(report.executive_summary));const content=[];for(const [title,name,suffix]of[["観測","observations",""],["解釈","interpretations",""],["未検証の仮説","hypotheses",""],["推奨アクション","actions",""]]){const section=Object.assign(document.createElement("section"),{className:"report-section"}),heading=Object.assign(document.createElement("h3"),{textContent:title});section.append(heading);report[name].forEach(item=>{let detail=suffix;if(name==="interpretations")detail=`（不確実性: ${item.uncertainty}）`;if(name==="hypotheses")detail=`（検証: ${item.validation}）`;if(name==="actions")detail=`（期待効果: ${item.expected_impact} / 担当: ${item.owner} / 緊急度: ${item.urgency} / 次: ${item.next_step} / 成功指標: ${item.success_metric}）`;section.append(citedItem(item,detail))});content.push(section)}const limits=Object.assign(document.createElement("section"),{className:"report-section"}),limitTitle=Object.assign(document.createElement("h3"),{textContent:"限界・不足情報"}),list=document.createElement("ul");report.limitations.forEach(value=>list.appendChild(Object.assign(document.createElement("li"),{textContent:value})));limits.append(limitTitle,list);content.push(limits);$("report-sections").replaceChildren(...content)}
-function sankey(svg,rows,w,h,detail,requestedDepth){
-const instanceId="sankey-"+(sankey.instanceSequence=(sankey.instanceSequence||0)+1),palette=["#4e79a7","#f28e2b","#59a14f","#e15759","#b07aa1","#76b7b2","#edc948","#ff9da7","#9c755f","#bab0ab"],canonical=name=>name.replace(/^\d+\.\s*(入口:\s*)?/,""),links=rows.map(row=>({source:String(row[0]),target:String(row[1]),value:Math.max(0,Number(row[2]))})).filter(link=>Number.isFinite(link.value)&&link.value>0),incoming=new Map(),outgoing=new Map(),values=new Map(),levels=new Map(),colors=new Map();
-for(const link of links){outgoing.set(link.source,(outgoing.get(link.source)||0)+link.value);incoming.set(link.target,(incoming.get(link.target)||0)+link.value);for(const [name,fallback]of[[link.source,1],[link.target,2]]){const match=name.match(/^(\d+)\./);levels.set(name,match?Number(match[1]):fallback);const category=canonical(name);if(!colors.has(category))colors.set(category,palette[colors.size%palette.length])}}
+function renderMeetingReport(event){const report=event.report;$("report-empty").className="hidden";$("report-output").className="panel report-home";$("report-revision").textContent=report.report_revision;$("report-summary").replaceChildren(citedItem(report.executive_summary));const content=[];for(const [title,name,suffix]of[["観測","observations",""],["解釈","interpretations",""],["未検証の仮説","hypotheses",""],["推奨アクション","actions",""]]){const section=Object.assign(document.createElement("section"),{className:"report-section"}),heading=Object.assign(document.createElement("h3"),{textContent:title});section.append(heading);report[name].forEach(item=>{let detail=suffix;if(name==="interpretations")detail=`（不確実性: ${item.uncertainty}）`;if(name==="hypotheses")detail=`（検証: ${item.validation}）`;if(name==="actions")detail=`（期待効果: ${item.expected_impact} / 担当: ${item.owner} / 緊急度: ${item.urgency} / 次: ${item.next_step} / 成功指標: ${item.success_metric}）`;section.append(citedItem(item,detail))});content.push(section)}const limits=Object.assign(document.createElement("section"),{className:"report-section"}),limitTitle=Object.assign(document.createElement("h3"),{textContent:"限界・不足情報"}),list=document.createElement("ul");report.limitations.forEach(value=>list.appendChild(Object.assign(document.createElement("li"),{textContent:value})));limits.append(limitTitle,list);content.push(limits);$("report-sections").replaceChildren(...content)}
+function sankey(svg,rows,w,h,detail,valueLabel){
+const maxPages=__MAX_SANKEY_PAGES__,instanceId="sankey-"+(sankey.instanceSequence=(sankey.instanceSequence||0)+1),palette=["#4e79a7","#f28e2b","#59a14f","#e15759","#b07aa1","#76b7b2","#edc948","#ff9da7","#9c755f","#bab0ab"],canonical=name=>name.replace(/^\d+\.\s*(入口:\s*)?/,""),stage=(name,fallback)=>{const match=String(name).match(/^(\d+)\./);return match?Number(match[1]):fallback},links=rows.map(row=>({source:String(row[0]),target:String(row[1]),value:Math.max(0,Number(row[2]))})).filter(link=>{const sourceStage=stage(link.source,1),targetStage=stage(link.target,2);return Number.isFinite(link.value)&&link.value>0&&sourceStage>=1&&sourceStage<maxPages&&targetStage>sourceStage&&targetStage<=maxPages}),incoming=new Map(),outgoing=new Map(),values=new Map(),levels=new Map(),colors=new Map();
+if(!links.length){detail.textContent=`${maxPages}ページ以内の遷移はありませんでした。`;return}
+for(const link of links){outgoing.set(link.source,(outgoing.get(link.source)||0)+link.value);incoming.set(link.target,(incoming.get(link.target)||0)+link.value);for(const [name,inferredLevel]of[[link.source,1],[link.target,2]]){levels.set(name,stage(name,inferredLevel));const category=canonical(name);if(!colors.has(category))colors.set(category,palette[colors.size%palette.length])}}
 for(const name of levels.keys())values.set(name,Math.max(incoming.get(name)||0,outgoing.get(name)||0));
 const color=name=>colors.get(canonical(name)),stageNumbers=[...new Set(levels.values())].sort((a,b)=>a-b),groups=new Map(stageNumbers.map(stage=>[stage,[]]));
 for(const name of values.keys())groups.get(levels.get(name)).push(name);
 for(const names of groups.values())names.sort();
 const largest=Math.max(...stageNumbers.map(stage=>groups.get(stage).reduce((sum,name)=>sum+values.get(name),0)),1),maxGaps=Math.max(...stageNumbers.map(stage=>Math.max(0,groups.get(stage).length-1)),0),gap=14,scale=Math.min(1.15,(h-54-gap*maxGaps)/largest),positions=new Map();
 stageNumbers.forEach((stage,index)=>{const names=groups.get(stage),height=names.reduce((sum,name)=>sum+Math.max(10,values.get(name)*scale),0)+gap*Math.max(0,names.length-1),x=30+index*(w-150)/Math.max(stageNumbers.length-1,1);let y=(h-height)/2;for(const name of names){const nodeHeight=Math.max(10,values.get(name)*scale);positions.set(name,{x,y,height:nodeHeight,out:0,into:0});y+=nodeHeight+gap}});
-const defs=node("defs");svg.append(defs);svg.appendChild(node("title")).textContent=`入口から${stageNumbers[stageNumbers.length-1]}ページ目までの主要回遊`;
-const stageLabels={1:"入口",2:"2ページ目",3:"3ページ目"};stageNumbers.forEach((stage,index)=>{const heading=svg.appendChild(node("text",{x:30+index*(w-150)/Math.max(stageNumbers.length-1,1),y:18,class:"sankey-stage"}));heading.textContent=stageLabels[stage]||`${stage}ページ目`});
-const defaultDetail="線にマウスを重ねるか、Tabキーで選ぶと遷移元・遷移先・セッション数を確認できます。";
-links.forEach((link,index)=>{const source=positions.get(link.source),target=positions.get(link.target),width=Math.max(2,link.value*scale),y1=source.y+source.out+width/2,y2=target.y+target.into+width/2,x1=source.x+12,x2=target.x,gradientId=instanceId+"-link-"+index,gradient=node("linearGradient",{id:gradientId,gradientUnits:"userSpaceOnUse",x1,y1,x2,y2});gradient.append(node("stop",{offset:"0%","stop-color":color(link.source)}),node("stop",{offset:"100%","stop-color":color(link.target)}));defs.append(gradient);source.out+=width;target.into+=width;const description=`${canonical(link.source)} → ${canonical(link.target)}: ${chartValue(link.value,"sessions",true)}セッション`,path=node("path",{class:"sankey-link",d:"M "+x1+" "+y1+" C "+((x1+x2)/2)+" "+y1+", "+((x1+x2)/2)+" "+y2+", "+x2+" "+y2,fill:"none",stroke:"url(#"+gradientId+")","stroke-opacity":.58,"stroke-width":width,tabindex:0,"aria-label":description});path.appendChild(node("title")).textContent=description;path.onmouseenter=path.onfocus=()=>detail.textContent=description;path.onmouseleave=path.onblur=()=>detail.textContent=defaultDetail;svg.append(path)});
+const defs=node("defs");svg.append(defs);svg.appendChild(node("title")).textContent="段階間の主要な流れ";
+stageNumbers.forEach((stage,index)=>{const heading=svg.appendChild(node("text",{x:30+index*(w-150)/Math.max(stageNumbers.length-1,1),y:18,class:"sankey-stage"}));heading.textContent=`段階${stage}`});
+const defaultDetail=`線にマウスを重ねるか、Tabキーで選ぶと遷移元・遷移先・${valueLabel}を確認できます。`;
+links.forEach((link,index)=>{const source=positions.get(link.source),target=positions.get(link.target),width=Math.max(2,link.value*scale),y1=source.y+source.out+width/2,y2=target.y+target.into+width/2,x1=source.x+12,x2=target.x,gradientId=instanceId+"-link-"+index,gradient=node("linearGradient",{id:gradientId,gradientUnits:"userSpaceOnUse",x1,y1,x2,y2});gradient.append(node("stop",{offset:"0%","stop-color":color(link.source)}),node("stop",{offset:"100%","stop-color":color(link.target)}));defs.append(gradient);source.out+=width;target.into+=width;const description=`${canonical(link.source)} → ${canonical(link.target)}: ${chartValue(link.value,valueLabel)} ${valueLabel}`,path=node("path",{class:"sankey-link",d:"M "+x1+" "+y1+" C "+((x1+x2)/2)+" "+y1+", "+((x1+x2)/2)+" "+y2+", "+x2+" "+y2,fill:"none",stroke:"url(#"+gradientId+")","stroke-opacity":.58,"stroke-width":width,tabindex:0,"aria-label":description});path.appendChild(node("title")).textContent=description;path.onmouseenter=path.onfocus=()=>detail.textContent=description;path.onmouseleave=path.onblur=()=>detail.textContent=defaultDetail;svg.append(path)});
 for(const [name,pos]of positions){svg.append(node("rect",{x:pos.x,y:pos.y,width:12,height:pos.height,rx:2,fill:color(name)}));const label=svg.appendChild(node("text",{x:pos.x+18,y:pos.y+Math.min(16,pos.height/2+4)}));label.textContent=canonical(name).slice(0,32)}
-return {terminalByStage:Array.from({length:Math.max(0,requestedDepth-2)},(_,index)=>index+2).map(stage=>({stage,sessions:[...(groups.get(stage)||[])].reduce((sum,name)=>sum+Math.max(0,(incoming.get(name)||0)-(outgoing.get(name)||0)),0)})).filter(item=>item.sessions>0)}
 }
+const chartPalette=["#3973c6","#d39b2a","#2f855a","#b45f86"];
+function chartLegend(svg,columns,w,y){columns.forEach((column,index)=>{svg.append(node("rect",{x:45+index*170,y:y-7,width:14,height:4,fill:chartPalette[index%chartPalette.length]}));svg.appendChild(node("text",{x:65+index*170,y})).textContent=column})}
+function kpiGroup(r,box){const group=Object.assign(document.createElement("div"),{className:"kpi-pair"});r.columns.forEach((column,index)=>{const item=document.createElement("div"),value=document.createElement("strong"),label=document.createElement("span");value.textContent=chartValue(r.rows[0][index],column);label.textContent=column;item.append(value,label);group.append(item)});box.append(group)}
+function barChart(r,box,mode="single"){
+const rows=r.rows,columns=r.columns||["category","metric_value"],seriesCount=columns.length-1,rowHeight=mode==="grouped"?Math.max(38,seriesCount*13+15):38,w=820,h=Math.max(260,rows.length*rowHeight+55),svg=node("svg",{viewBox:`0 0 ${w} ${h}`,role:"img","aria-label":`${columns[0]}別の${columns.slice(1).join("・")}`}),plotWidth=w-280;
+box.append(svg);const max=Math.max(1,...rows.map(row=>mode==="stacked"?row.slice(1).reduce((sum,value)=>sum+Number(value),0):Math.max(...row.slice(1).map(Number))));
+rows.forEach((row,rowIndex)=>{const y=18+rowIndex*rowHeight;svg.appendChild(node("text",{x:4,y:y+16})).textContent=String(row[0]).slice(0,28);if(mode==="stacked"){let x=205;row.slice(1).forEach((value,seriesIndex)=>{const width=plotWidth*Number(value)/max,rect=node("rect",{x,y,width,height:24,fill:chartPalette[seriesIndex%chartPalette.length]});rect.appendChild(node("title")).textContent=`${row[0]} / ${columns[seriesIndex+1]}: ${chartValue(value,columns[seriesIndex+1])}`;svg.append(rect);x+=width})}else{row.slice(1).forEach((value,seriesIndex)=>{const barHeight=mode==="grouped"?10:24,barY=mode==="grouped"?y+seriesIndex*12:y,width=plotWidth*Number(value)/max,rect=node("rect",{x:205,y:barY,width,height:barHeight,rx:3,fill:chartPalette[seriesIndex%chartPalette.length]});rect.appendChild(node("title")).textContent=`${row[0]} / ${columns[seriesIndex+1]}: ${chartValue(value,columns[seriesIndex+1])}`;svg.append(rect);if(mode==="single")svg.appendChild(node("text",{x:215+width,y:y+16})).textContent=chartValue(value,columns[1])})}});if(seriesCount>1)chartLegend(svg,columns.slice(1),w,h-16)
+}
+function lineChart(r,box){
+const w=820,h=360,seriesCount=r.columns.length-1,seriesValues=Array.from({length:seriesCount},(_unused,seriesIndex)=>r.rows.map(row=>row[seriesIndex+1]===null||row[seriesIndex+1]===undefined||row[seriesIndex+1]===""?NaN:Number(row[seriesIndex+1])).filter(Number.isFinite));if(!seriesValues.some(values=>values.length)){box.appendChild(Object.assign(document.createElement("p"),{className:"notice warning",textContent:"数値が取得できる日付はありませんでした。"}));return}const scaleFor=values=>{const min=Math.min(...values),max=Math.max(...values);return{min,max,span:max-min||1}},magnitudes=seriesValues.map(values=>Math.max(0,...values.map(Math.abs))).filter(value=>value>0),independent=seriesCount>1&&magnitudes.length>1&&Math.max(...magnitudes)/Math.min(...magnitudes)>=100,globalScale=scaleFor(seriesValues.flat()),scales=independent?seriesValues.map(scaleFor):seriesValues.map(()=>globalScale),svg=node("svg",{viewBox:`0 0 ${w} ${h}`,role:"img","aria-label":`${r.columns[0]}ごとの${r.columns.slice(1).join("・")}推移${independent?"（系列ごとの独立スケール）":""}`});box.append(svg);
+for(let seriesIndex=0;seriesIndex<seriesCount;seriesIndex++){const scale=scales[seriesIndex],points=r.rows.map((row,index)=>{const value=row[seriesIndex+1]===null||row[seriesIndex+1]===undefined||row[seriesIndex+1]===""?NaN:Number(row[seriesIndex+1]);return Number.isFinite(value)?[45+index*(w-80)/Math.max(r.rows.length-1,1),25+(scale.max-value)*(h-75)/scale.span,value,row[0]]:null}),draw=segment=>{if(segment.length>1)svg.append(node("polyline",{points:segment.map(point=>point.slice(0,2).join(",")).join(" "),fill:"none",stroke:chartPalette[seriesIndex%chartPalette.length],"stroke-width":3}));segment.forEach(point=>{const circle=node("circle",{cx:point[0],cy:point[1],r:4,fill:chartPalette[seriesIndex%chartPalette.length]});circle.appendChild(node("title")).textContent=`${point[3]} / ${r.columns[seriesIndex+1]}: ${chartValue(point[2],r.columns[seriesIndex+1])}`;svg.append(circle)})};let segment=[];for(const point of [...points,null]){if(point)segment.push(point);else if(segment.length){draw(segment);segment=[]}}}if(seriesCount>1)chartLegend(svg,r.columns.slice(1),w,h-18);if(independent)box.appendChild(Object.assign(document.createElement("p"),{className:"chart-caption multi-line-scale-note",textContent:"系列の最大絶対値が100倍以上異なるため、系列ごとに独立した縦軸スケールで推移を描画しています。各点の値はマウス操作で確認できます。"}))
+}
+function scatterChart(r,box,isBubble){
+const w=820,h=390,xValues=r.rows.map(row=>Number(row[1])),yValues=r.rows.map(row=>Number(row[2])),xMin=Math.min(...xValues),xMax=Math.max(...xValues),yMin=Math.min(...yValues),yMax=Math.max(...yValues),xSpan=xMax-xMin||1,ySpan=yMax-yMin||1,sizes=isBubble?r.rows.map(row=>Math.max(0,Number(row[3]))):[],sizeMax=Math.max(...sizes,1),svg=node("svg",{viewBox:`0 0 ${w} ${h}`,role:"img","aria-label":`${r.columns[1]}と${r.columns[2]}の関係`});box.append(svg);svg.append(node("line",{x1:55,y1:h-48,x2:w-25,y2:h-48,stroke:"#98a2b3"}),node("line",{x1:55,y1:20,x2:55,y2:h-48,stroke:"#98a2b3"}));svg.appendChild(node("text",{x:w/2-40,y:h-16})).textContent=r.columns[1];svg.appendChild(node("text",{x:8,y:18})).textContent=r.columns[2];r.rows.forEach((row,index)=>{const x=55+(Number(row[1])-xMin)*(w-90)/xSpan,y=20+(yMax-Number(row[2]))*(h-68)/ySpan,radius=isBubble?5+18*Math.sqrt(sizes[index]/sizeMax):6,description=`${row[0]}: ${r.columns[1]} ${chartValue(row[1],r.columns[1])} / ${r.columns[2]} ${chartValue(row[2],r.columns[2])}${isBubble?` / ${r.columns[3]} ${chartValue(row[3],r.columns[3])}`:""}`,circle=node("circle",{cx:x,cy:y,r:radius,fill:"#3973c6","fill-opacity":.62,stroke:"#1f4e79",tabindex:0,"aria-label":description});circle.appendChild(node("title")).textContent=description;svg.append(circle);if(index<12)svg.appendChild(node("text",{x:x+radius+3,y:y+4})).textContent=String(row[0]).slice(0,18)})
+}
+function funnelChart(r,box){const funnel=Object.assign(document.createElement("div"),{className:"funnel"}),max=Math.max(...r.rows.map(row=>Number(row[1])),1);r.rows.forEach(row=>{const step=Object.assign(document.createElement("div"),{className:"funnel-step"});step.style.width=Math.max(24,Number(row[1])/max*100)+"%";step.append(document.createTextNode(String(row[0])),Object.assign(document.createElement("strong"),{textContent:chartValue(row[1],r.columns[1],true)}));funnel.append(step)});box.append(funnel)}
+function heatmapChart(r,box){const xs=[...new Set(r.rows.map(row=>String(row[0])))],ys=[...new Set(r.rows.map(row=>String(row[1])))],w=Math.max(620,90+xs.length*72),h=Math.max(260,70+ys.length*40),values=r.rows.map(row=>Number(row[2])),min=Math.min(...values),max=Math.max(...values),span=max-min||1,svg=node("svg",{viewBox:`0 0 ${w} ${h}`,role:"img","aria-label":`${r.columns[0]}と${r.columns[1]}による${r.columns[2]}のヒートマップ`}),lookup=new Map(r.rows.map(row=>[`${row[0]}\u0000${row[1]}`,Number(row[2])]));box.append(svg);xs.forEach((value,index)=>{svg.appendChild(node("text",{x:95+index*72,y:22})).textContent=value.slice(0,10)});ys.forEach((yValue,rowIndex)=>{svg.appendChild(node("text",{x:4,y:52+rowIndex*40})).textContent=yValue.slice(0,13);xs.forEach((xValue,columnIndex)=>{const metricValue=lookup.get(`${xValue}\u0000${yValue}`),opacity=metricValue===undefined?.05:.16+.84*(metricValue-min)/span,rect=node("rect",{x:90+columnIndex*72,y:30+rowIndex*40,width:68,height:34,rx:3,fill:"#3973c6","fill-opacity":opacity});rect.appendChild(node("title")).textContent=metricValue===undefined?`${xValue} / ${yValue}: データなし`:`${xValue} / ${yValue}: ${chartValue(metricValue,r.columns[2])}`;svg.append(rect)})})}
+function renderResultTable(r,box){const scroll=Object.assign(document.createElement("div"),{className:"chart-table-scroll"});scroll.appendChild(table(r.columns,r.rows));box.appendChild(scroll)}
 function graph(r,box=$("chart")){
-box.replaceChildren();
-if(!r.rows.length){box.appendChild(Object.assign(document.createElement("p"),{className:"notice warning",textContent:"該当する行はありませんでした。"}));return}
+box.replaceChildren();if(!r.rows.length){box.appendChild(Object.assign(document.createElement("p"),{className:"notice warning",textContent:"該当する行はありませんでした。"}));return}
 if(r.visualization==="scalar"){box.appendChild(Object.assign(document.createElement("div"),{className:"metric",textContent:chartValue(r.rows[0][0],r.columns[0],true)}));return}
-if(r.visualization==="kpi_pair"){const pair=Object.assign(document.createElement("div"),{className:"kpi-pair"});r.columns.forEach((column,index)=>{const item=document.createElement("div"),value=document.createElement("strong"),label=document.createElement("span");value.textContent=chartValue(r.rows[0][index],column);label.textContent=column;item.append(value,label);pair.append(item)});box.append(pair);return}
-if(r.visualization==="funnel"){const funnel=Object.assign(document.createElement("div"),{className:"funnel"}),max=Math.max(...r.rows[0].map(Number),1);r.columns.forEach((column,index)=>{const step=Object.assign(document.createElement("div"),{className:"funnel-step"}),value=Number(r.rows[0][index]);step.style.width=Math.max(34,value/max*100)+"%";step.append(document.createTextNode(column),Object.assign(document.createElement("strong"),{textContent:chartValue(r.rows[0][index],column,true)}));funnel.append(step)});box.append(funnel);return}
-if(r.visualization==="trend"){
-const w=820,h=360,svg=node("svg",{viewBox:`0 0 ${w} ${h}`}),series=[{index:1,color:"#3973c6"},{index:2,color:"#d39b2a"}],vals=series.flatMap(s=>r.rows.map(x=>Number(x[s.index]))),min=Math.min(...vals),max=Math.max(...vals),span=max-min||1;
-box.append(svg);
-series.forEach(s=>{const pts=r.rows.map((x,i)=>[45+i*(w-80)/Math.max(r.rows.length-1,1),25+(max-Number(x[s.index]))*(h-75)/span]);svg.append(node("polyline",{points:pts.map(p=>p.join(",")).join(" "),fill:"none",stroke:s.color,"stroke-width":3}));pts.forEach(p=>{svg.append(node("circle",{cx:p[0],cy:p[1],r:3,fill:s.color}))})});
-r.columns.slice(1,3).forEach((column,index)=>{svg.append(node("rect",{x:55+index*170,y:h-30,width:14,height:4,fill:series[index].color}));svg.appendChild(node("text",{x:75+index*170,y:h-24})).textContent=column});return}
-if(r.visualization==="sankey"){const depth=r.navigation_depth||Math.max(...r.rows.flatMap(row=>[row[0],row[1]]).map(value=>Number(String(value).match(/^(\d+)\./)?.[1])||1)),svg=node("svg",{viewBox:"0 0 980 460",role:"img","aria-label":`入口から${depth}ページ目までの主要回遊`}),detail=Object.assign(document.createElement("p"),{className:"chart-caption sankey-detail",textContent:"線にマウスを重ねるか、Tabキーで選ぶと遷移元・遷移先・セッション数を確認できます。"});box.append(svg,detail);const summary=sankey(svg,r.rows,980,460,detail,depth),terminalParts=summary.terminalByStage.map(item=>`${item.stage}ページ目で終了: ${chartValue(item.sessions,"sessions",true)}セッション`),terminalText=terminalParts.length?terminalParts.join("、")+"（上位12経路内。離脱ノードは描画していません）":`上位12経路はすべて${depth}ページ目まで到達しています。`;box.appendChild(Object.assign(document.createElement("p"),{className:"chart-caption sankey-terminal",textContent:terminalText}));box.appendChild(Object.assign(document.createElement("p"),{className:"chart-caption",textContent:"連続する同一ページビューは1回の滞在として統合しています。色はページ種別を示し、リンクは遷移元から遷移先の色へ変化します。"}));return}
-if(!["bar","line"].includes(r.visualization)){box.appendChild(table(r.columns,r.rows));return}
-const rows=r.rows,w=820,h=r.visualization==="bar"?Math.max(260,rows.length*38+45):360,svg=node("svg",{viewBox:`0 0 ${w} ${h}`});box.appendChild(svg);if(r.visualization==="bar"){const vals=rows.map(x=>Number(x[1])),max=Math.max(...vals,1);rows.forEach((x,i)=>{const y=20+i*38,bw=(w-260)*vals[i]/max;svg.appendChild(node("text",{x:4,y:y+16})).textContent=String(x[0]).slice(0,28);svg.append(node("rect",{x:205,y,width:bw,height:24,rx:4,fill:"#3973c6"}));svg.appendChild(node("text",{x:215+bw,y:y+16})).textContent=chartValue(x[1],r.columns?.[1]??"")})}else{const vals=rows.map(x=>Number(x[1])),min=Math.min(...vals),max=Math.max(...vals),span=max-min||1,pts=vals.map((v,i)=>[45+i*(w-80)/Math.max(rows.length-1,1),25+(max-v)*(h-75)/span]);svg.append(node("polyline",{points:pts.map(p=>p.join(",")).join(" "),fill:"none",stroke:"#3973c6","stroke-width":3}));pts.forEach(p=>svg.append(node("circle",{cx:p[0],cy:p[1],r:4,fill:"#185adb"})))}}
+if(r.visualization==="kpi_group"){kpiGroup(r,box);return}
+if(r.visualization==="bar"){barChart(r,box);return}
+if(r.visualization==="grouped_bar"){barChart(r,box,"grouped");return}
+if(r.visualization==="stacked_bar"){barChart(r,box,"stacked");return}
+if(["line","multi_line"].includes(r.visualization)){lineChart(r,box);return}
+if(r.visualization==="scatter"){scatterChart(r,box,false);return}
+if(r.visualization==="bubble"){scatterChart(r,box,true);return}
+if(r.visualization==="funnel"){funnelChart(r,box);return}
+if(r.visualization==="heatmap"){heatmapChart(r,box);return}
+if(r.visualization==="sankey"){const valueLabel=r.columns?.[2]||"値",svg=node("svg",{viewBox:"0 0 980 460",role:"img","aria-label":`${r.columns?.[0]||"source"}から${r.columns?.[1]||"target"}への主要な流れ`}),detail=Object.assign(document.createElement("p"),{className:"chart-caption sankey-detail",textContent:`線にマウスを重ねるか、Tabキーで選ぶと遷移元・遷移先・${valueLabel}を確認できます。`});box.append(svg,detail);sankey(svg,r.rows,980,460,detail,valueLabel);box.appendChild(Object.assign(document.createElement("p"),{className:"chart-caption",textContent:"色は項目を示し、リンク幅は値の大きさを示します。"}));return}
+if(r.visualization==="table"){renderResultTable(r,box);return}
+throw new Error(`未対応の可視化形式です: ${r.visualization}`)
+}
 function finish(status){$("run-status").textContent=status;stages.forEach(s=>$("s-"+s).removeAttribute("aria-current"))}
 function handle(e){if(e.type==="stage"){stage(e.stage);$("message").textContent=e.message}else if(e.type==="sql"){stage("validate");$("output").className="";renderSql($("sql"),e.sql);$("reason").textContent=e.reason}else if(e.type==="result"){stage("render");$("output").className="";$("verification").className=e.verification==="matched"?"notice":"notice warning";$("verification").textContent=e.verification_label;$("cost").textContent=`Vertex AI推定 ¥${e.cost_jpy}（BigQuery利用料は別）`;populateResult(e);$("message").textContent="生成・実行・描画が完了しました。";stages.forEach(s=>$("s-"+s).className="done");finish("完了")}else if(e.type==="refusal"){stage("render");$("output").className="";renderSql($("sql"),"");$("reason").textContent=e.reason;$("verification").className="notice warning";$("verification").textContent=`未定義のため生成しません: ${e.undefined_terms.join("、")}`;$("cost").textContent=`Vertex AI推定 ¥${e.cost_jpy}`;clearResult();$("message").textContent=`未定義のため停止: ${e.undefined_terms.join("、")}`;finish("停止")}else if(e.type==="error")throw new Error(e.message)}
-function createDashboardCard(panel){const card=Object.assign(document.createElement("section"),{className:"dashboard-card"+(panel.id==="R17"?" full":panel.id==="R9"||panel.id==="R16"?" wide":"" )}),head=document.createElement("div"),title=document.createElement("h3"),state=Object.assign(document.createElement("span"),{className:"panel-state",textContent:"待機中"}),purpose=Object.assign(document.createElement("p"),{className:"purpose",textContent:panel.purpose}),chart=Object.assign(document.createElement("div"),{className:"chart"}),inspect=Object.assign(document.createElement("button"),{className:"inspect-panel",type:"button",textContent:"詳細を確認"}),reason=document.createElement("p"),verification=Object.assign(document.createElement("p"),{className:"notice",textContent:"未実行"}),sql=Object.assign(document.createElement("pre"),{className:"sql"}),data=document.createElement("div");card.dataset.panelId=panel.id;title.textContent=panel.title;head.append(title,state);inspect.onclick=()=>openPanelInspector(panel.id);card.append(head,purpose,chart,inspect);$("dashboard-grid").append(card);dashboardPanels.set(panel.id,{card,title:panel.title,purpose:panel.purpose,state,chart,reason,verification,sql,data})}
-function renderDashboardRow(row,cards,separators,shares){const columns=[];cards.forEach((card,index)=>{columns.push(`minmax(${card.dataset.panelId==="R17"?420:card.dataset.panelId==="R9"?260:150}px,${shares[index]}fr)`);if(index<separators.length)columns.push("10px")});row.style.gridTemplateColumns=columns.join(" ");separators.forEach((separator,index)=>{const before=shares.slice(0,index).reduce((total,value)=>total+value,0),combined=shares[index]+shares[index+1],position=Math.round(before+shares[index]);separator.setAttribute("aria-valuemin",String(Math.round(before+15)));separator.setAttribute("aria-valuemax",String(Math.round(before+combined-15)));separator.setAttribute("aria-valuenow",String(position));separator.setAttribute("aria-valuetext",`${cards[index].querySelector("h3").textContent} ${Math.round(shares[index])}%、${cards[index+1].querySelector("h3").textContent} ${Math.round(shares[index+1])}%`)})}
+function createDashboardCard(panel){const card=Object.assign(document.createElement("section"),{className:"dashboard-card"}),head=document.createElement("div"),title=document.createElement("h3"),state=Object.assign(document.createElement("span"),{className:"panel-state",textContent:"待機中"}),purpose=Object.assign(document.createElement("p"),{className:"purpose",textContent:panel.purpose}),chart=Object.assign(document.createElement("div"),{className:"chart"}),inspect=Object.assign(document.createElement("button"),{className:"inspect-panel",type:"button",textContent:"詳細を確認"}),reason=document.createElement("p"),verification=Object.assign(document.createElement("p"),{className:"notice",textContent:"未実行"}),sql=Object.assign(document.createElement("pre"),{className:"sql"}),data=document.createElement("div");card.dataset.panelId=panel.id;card.dataset.chart=panel.chart;title.textContent=panel.title;head.append(title,state);inspect.onclick=()=>openPanelInspector(panel.id);card.append(head,purpose,chart,inspect);$("dashboard-grid").append(card);dashboardPanels.set(panel.id,{card,title:panel.title,purpose:panel.purpose,state,chart,reason,verification,sql,data})}
+function renderDashboardRow(row,cards,separators,shares){const columns=[];cards.forEach((_card,index)=>{columns.push(`minmax(0,${shares[index]}fr)`);if(index<separators.length)columns.push("10px")});row.style.gridTemplateColumns=columns.join(" ");separators.forEach((separator,index)=>{const before=shares.slice(0,index).reduce((total,value)=>total+value,0),combined=shares[index]+shares[index+1],position=Math.round(before+shares[index]);separator.setAttribute("aria-valuemin",String(Math.round(before+15)));separator.setAttribute("aria-valuemax",String(Math.round(before+combined-15)));separator.setAttribute("aria-valuenow",String(position));separator.setAttribute("aria-valuetext",`${cards[index].querySelector("h3").textContent} ${Math.round(shares[index])}%、${cards[index+1].querySelector("h3").textContent} ${Math.round(shares[index+1])}%`)})}
 function groupDashboardPanelRow(ids,initialShares){const cards=ids.map(id=>dashboardPanels.get(id)?.card);if(cards.some(card=>!card))return;const grid=$("dashboard-grid"),row=Object.assign(document.createElement("section"),{className:"dashboard-layout-row"}),shares=[...initialShares],separators=[];grid.insertBefore(row,cards[0]);cards.forEach((card,index)=>{row.append(card);if(index===cards.length-1)return;const separator=Object.assign(document.createElement("div"),{className:"dashboard-card-resizer",tabIndex:0,title:`${dashboardPanels.get(ids[index]).title}と${dashboardPanels.get(ids[index+1]).title}の幅を調整`});separator.setAttribute("role","separator");separator.setAttribute("aria-label",separator.title);separator.setAttribute("aria-orientation","vertical");row.append(separator);separators.push(separator)});const resize=(index,event)=>{const bounds=row.getBoundingClientRect(),usable=Math.max(bounds.width-separators.length*10,1),before=shares.slice(0,index).reduce((total,value)=>total+value,0),combined=shares[index]+shares[index+1],desired=(event.clientX-bounds.left-index*10)/usable*100-before,minLeft=15,minRight=15,left=Math.max(minLeft,Math.min(combined-minRight,desired));shares[index]=left;shares[index+1]=combined-left;renderDashboardRow(row,cards,separators,shares)};separators.forEach((separator,index)=>{const stop=event=>{separator.classList.remove("dragging");if(separator.hasPointerCapture(event.pointerId))separator.releasePointerCapture(event.pointerId)};separator.onpointerdown=event=>{separator.classList.add("dragging");separator.setPointerCapture(event.pointerId);resize(index,event)};separator.onpointermove=event=>{if(separator.classList.contains("dragging"))resize(index,event)};separator.onpointerup=stop;separator.onpointercancel=stop;separator.onkeydown=event=>{if(!["ArrowLeft","ArrowRight","Home","End"].includes(event.key))return;event.preventDefault();const combined=shares[index]+shares[index+1],left=event.key==="Home"?15:event.key==="End"?combined-15:event.key==="ArrowLeft"?shares[index]-5:shares[index]+5,next=Math.max(15,Math.min(combined-15,left));shares[index]=next;shares[index+1]=combined-next;renderDashboardRow(row,cards,separators,shares)}});renderDashboardRow(row,cards,separators,shares)}
-function handleDashboard(e){if(e.type==="dashboard_plan"){$("dashboard-empty").className="hidden";$("dashboard-output").className="";$("dashboard-title").textContent=e.period+" 月次ECサイト分析";$("dashboard-provenance").textContent=`分析仕様 ${e.plan_revision} / 組織コンテキスト ${e.organization_context_revision}。左上の成果から右下の診断へ読み進めます。`;$("dashboard-grid").replaceChildren();dashboardPanels.clear();activePanelId=null;$("inspector-empty").className="inspector-empty";$("inspector-content").className="hidden";e.panels.forEach(createDashboardCard);e.layout_rows.forEach(row=>groupDashboardPanelRow(row.panel_ids,row.shares));$("dashboard-message").textContent=`${e.panels.length}件の分析へ分解しました。順番にSQLを生成します。`;return}const panel=dashboardPanels.get(e.panel_id);if(e.type==="stage"&&panel){panel.state.textContent=`${e.panel_index}/${e.panel_count} ${e.stage==="generate"?"SQL生成中":"BigQuery実行中"}`;$("dashboard-message").textContent=`${e.title}: ${e.message}`;if(activePanelId===e.panel_id)openPanelInspector(e.panel_id);return}if(e.type==="sql"&&panel){renderSql(panel.sql,e.sql);panel.reason.textContent=e.reason;panel.state.textContent="SQL検査済み";if(activePanelId===e.panel_id)openPanelInspector(e.panel_id);return}if(e.type==="result"&&panel){graph(e,panel.chart);panel.data.replaceChildren(table(e.columns,e.rows));panel.verification.className=e.verification==="matched"?"notice":"notice warning";panel.verification.textContent=e.verification_label;panel.state.textContent="描画完了";if(activePanelId===e.panel_id)openPanelInspector(e.panel_id);return}if(e.type==="refusal"&&panel){panel.reason.textContent=e.reason;panel.verification.className="notice warning";panel.verification.textContent=`未定義のため停止: ${e.undefined_terms.join("、")}`;panel.state.textContent="停止";if(activePanelId===e.panel_id)openPanelInspector(e.panel_id);return}if(e.type==="dashboard_complete"){if(e.panel_count!==dashboardPanels.size)throw new Error(`確定した${dashboardPanels.size}件のうち${e.panel_count}件しか完了していません。`);dashboardStage("complete");$("dashboard-status").textContent="完了";$("dashboard-cost").textContent=`Vertex AI推定 ¥${e.cost_jpy}`;$("dashboard-message").textContent=`${e.panel_count}件のSQL生成・実行・描画が完了しました。`;latestBuildRevision=e.build_revision;$("report-submit").className=latestBuildRevision?"":"hidden";selectWorkspace("dashboard");enterDashboardReadingMode();return}if(e.type==="error")throw new Error(e.message)}
-function handlePlan(e){if(e.type==="plan_stage"){$("dashboard-status").textContent="相談中";$("dashboard-message").textContent=e.message}else if(e.type==="plan")renderAnalysisPlan(e);else if(e.type==="error")throw new Error(e.message)}
+function handleDashboard(e){if(e.type==="dashboard_plan"){$("dashboard-empty").className="hidden";$("dashboard-output").className="";$("dashboard-title").textContent=e.period+" 分析ダッシュボード";$("dashboard-provenance").textContent=`分析仕様 ${e.plan_revision} / 組織コンテキスト ${e.organization_context_revision}。AIが提案した分析順に表示します。`;$("dashboard-grid").replaceChildren();dashboardPanels.clear();activePanelId=null;$("inspector-empty").className="inspector-empty";$("inspector-content").className="hidden";e.panels.forEach(createDashboardCard);e.layout_rows.forEach(row=>groupDashboardPanelRow(row.panel_ids,row.shares));$("dashboard-message").textContent=`${e.panels.length}件の分析へ分解しました。順番にSQLを生成します。`;return}const panel=dashboardPanels.get(e.panel_id);if(e.type==="stage"&&panel){const stageLabel=e.stage==="generate"?"SQL生成中":e.stage==="validate"?"出力検証中":e.stage==="repair"?"SQL修正中":"BigQuery実行中";panel.state.textContent=`${e.panel_index}/${e.panel_count} ${stageLabel}`;$("dashboard-message").textContent=`${e.title}: ${e.message}`;if(activePanelId===e.panel_id)openPanelInspector(e.panel_id);return}if(e.type==="sql"&&panel){renderSql(panel.sql,e.sql);panel.reason.textContent=e.reason;panel.state.textContent="SQL検査済み";if(activePanelId===e.panel_id)openPanelInspector(e.panel_id);return}if(e.type==="result"&&panel){graph(e,panel.chart);panel.data.replaceChildren(table(e.columns,e.rows));panel.verification.className=e.verification==="matched"?"notice":"notice warning";panel.verification.textContent=e.verification_label;panel.state.textContent=e.visualization==="table"?"表を表示":["scalar","kpi_group"].includes(e.visualization)?"KPI表示完了":"グラフ描画完了";if(activePanelId===e.panel_id)openPanelInspector(e.panel_id);return}if(e.type==="refusal"&&panel){panel.reason.textContent=e.reason;panel.verification.className="notice warning";panel.verification.textContent=`未定義のため停止: ${e.undefined_terms.join("、")}`;panel.state.textContent="停止";if(activePanelId===e.panel_id)openPanelInspector(e.panel_id);return}if(e.type==="dashboard_complete"){if(e.panel_count!==dashboardPanels.size)throw new Error(`確定した${dashboardPanels.size}件のうち${e.panel_count}件しか完了していません。`);dashboardStage("complete");$("dashboard-status").textContent="完了";$("dashboard-cost").textContent=`Vertex AI推定 ¥${e.cost_jpy}`;$("dashboard-message").textContent=`${e.panel_count}件のSQL生成・実行・描画が完了しました。`;latestBuildRevision=e.build_revision;$("report-submit").className=latestBuildRevision?"":"hidden";selectWorkspace("dashboard");enterDashboardReadingMode();return}if(e.type==="error")throw new Error(e.message)}
+function handlePlan(e){if(e.type==="plan_stage"){$("dashboard-status").textContent="相談中";$("dashboard-message").textContent=e.message}else if(e.type==="plan")renderAnalysisPlan(e);else if(e.type==="error"){if(e.suggested_instruction)showPlanCorrection(e.suggested_instruction);throw new Error(e.message)}}
 function handleMeetingReport(e){if(e.type==="report_stage"){selectWorkspace("report");setReportState("生成中",e.message)}else if(e.type==="meeting_report"){renderMeetingReport(e);setReportState("要承認",`根拠付き会議報告案を生成しました。Vertex AI推定 ¥${e.cost_jpy}`);selectWorkspace("report")}else if(e.type==="error")throw new Error(e.message)}
 function startActiveRequest(){if(activeRequest)throw new Error("実行中の処理を停止してから再送してください。");const random=Math.floor(Math.random()*0xffffffff).toString(16).padStart(8,"0"),operation={requestId:`request-${Date.now()}-${random}`,controller:new AbortController(),stopping:false};activeRequest=operation;$("analysis-composer").setAttribute("aria-busy","true");$("composer-submit").textContent="■";$("composer-submit").setAttribute("aria-label","実行中の処理を停止");$("composer-input").disabled=true;$("composer-profile").disabled=true;document.querySelectorAll("[data-composer-action]").forEach(button=>button.disabled=true);return operation}
 function finishActiveRequest(operation,force=false){if(activeRequest!==operation||operation.stopping&&!force)return;activeRequest=null;$("analysis-composer").removeAttribute("aria-busy");$("composer-submit").disabled=false;$("composer-submit").textContent="↑";$("composer-submit").setAttribute("aria-label","分析指示を送信");$("composer-input").disabled=false;$("composer-profile").disabled=false;document.querySelectorAll("[data-composer-action]").forEach(button=>button.disabled=false)}
@@ -297,15 +269,15 @@ _sidebar_body = r"""
 <button id="new-analysis" class="new-analysis" type="button">新しい分析</button>
 <p class="sidebar-label">成果物</p>
 <nav class="workspace-nav artifact-tree" aria-label="分析成果物">
-<button id="view-dashboard" type="button" title="購入成果改善ダッシュボード"><span class="sidebar-title"><span>購入成果改善ダッシュボード</span></span><small>2021年1月</small></button>
+<button id="view-dashboard" type="button" title="ダッシュボード"><span class="sidebar-title"><span>ダッシュボード</span></span><small>未作成</small></button>
 <button id="view-graph" type="button" title="未保存のインサイト"><span class="sidebar-title"><span>未保存のインサイト</span></span><small>単一グラフ</small></button>
 <button id="view-report" type="button" title="会議報告"><span class="sidebar-title"><span>会議報告</span></span><small>根拠付き下書き</small></button>
 </nav>
 <p class="sidebar-label">分析スレッド</p>
 <nav class="workspace-nav thread-tree" aria-label="分析スレッド">
-<button id="view-build" class="selected" type="button" aria-current="page" title="購入成果を改善する"><span class="sidebar-title"><span>購入成果を改善する</span></span><small>現在の対話</small></button>
+<button id="view-build" class="selected" type="button" aria-current="page" title="新しい分析"><span class="sidebar-title"><span>新しい分析</span></span><small>現在の対話</small></button>
 </nav>
-<div class="sidebar-account"><span class="account-avatar">デ</span><span><strong>デモ組織</strong><small>EC月次分析</small></span></div>
+<div class="sidebar-account"><span class="account-avatar">デ</span><span><strong>デモ組織</strong><small>分析ワークスペース</small></span></div>
 </aside>"""
 HTML, _sidebar_count = _sidebar_body_pattern.subn(_sidebar_body, HTML, count=1)
 if _sidebar_count != 1:  # pragma: no cover - static template invariant
@@ -319,14 +291,13 @@ _composer_markup = r"""
 <button type="button" data-composer-action="consult">相談</button>
 <button type="button" class="selected" data-composer-action="dashboard">ダッシュボード</button>
 <button type="button" data-composer-action="insight">インサイト</button>
-<button type="button" data-composer-action="report">会議報告</button>
 </div>
 <select id="composer-profile" class="hidden" aria-label="分析対象データ">
 <option value="ga4">GA4 ECサイト</option><option value="bitcoin">Bitcoin取引</option>
 </select>
 <button id="composer-collapse" class="composer-collapse" type="button" aria-label="相談入力を小さくする">⌄</button>
 </div>
-<textarea id="composer-input" rows="2" aria-label="分析したい内容">2021年1月のECサイトで購入成果を改善するため、課題の場所と優先施策を判断できるダッシュボードを作って</textarea>
+<textarea id="composer-input" rows="2" aria-label="分析したい内容" placeholder="分析して決めたいことを入力してください"></textarea>
 <div class="composer-footer"><span id="composer-message">操作と対象を確認して送信してください。</span><button id="composer-submit" type="button" aria-label="分析指示を送信">↑</button></div>
 <button id="composer-launcher" class="composer-launcher" type="button" aria-label="AIへの相談入力を開く" aria-expanded="true" aria-controls="composer-input"><span aria-hidden="true">✦</span> AIに相談</button>
 </section>
@@ -373,7 +344,7 @@ HTML = HTML.replace(
 )
 HTML = HTML.replace(
     'build:["ダッシュボードを作成・編集","AIと分析目的を相談し、確認した仕様だけをbuildします。","相談・build"]',
-    'build:["購入成果を改善する","AIと目的・KPI・比較軸を相談し、確認した仕様だけをbuildします。","分析スレッド"]',
+    'build:["新しい分析","AIと目的・KPI・比較軸を相談し、確認した仕様だけをbuildします。","分析スレッド"]',
     1,
 )
 HTML = HTML.replace(
@@ -385,13 +356,13 @@ HTML = HTML.replace(
 # A static or proxy error page is commonly HTML. Never parse it as JSON or expose
 # its markup; explain that the browser is not connected to the live API instead.
 HTML = HTML.replace(
-    "async function stream(endpoint,question,eventHandler,profile=\"ga4\",extra={}){",
+    "async function stream(endpoint,question,eventHandler,profile=\"ga4\",extra={},operation){",
     "async function responseError(res){const type=res.headers.get(\"content-type\")||\"\";"
     "if(type.includes(\"application/json\")){try{const body=await res.json();"
     "if(body&&body.error)return body.error}catch(_error){}}"
     "return `操作可能なライブデモへ接続できません（HTTP ${res.status}）。"
     "固定表示ではなくdemo-liveを起動してください。`}"
-    "async function stream(endpoint,question,eventHandler,profile=\"ga4\",extra={}){",
+    "async function stream(endpoint,question,eventHandler,profile=\"ga4\",extra={},operation){",
     1,
 )
 HTML = HTML.replace(
@@ -463,23 +434,21 @@ h1{font-size:26px;line-height:1.25;letter-spacing:-.025em}
 .dashboard-grid{gap:14px;margin-top:14px;align-items:stretch;container-type:inline-size}
 .dashboard-card{display:flex;flex-direction:column;grid-column:span 4;min-width:0;min-height:268px;padding:18px 18px 16px;border-color:#dde3ea;border-radius:var(--radius-card);box-shadow:var(--shadow-card);overflow:hidden;transition:border-color 140ms ease,box-shadow 140ms ease,transform 140ms ease}
 .dashboard-card:hover{border-color:#bcc9d5;box-shadow:0 2px 4px #1018280d,0 14px 34px #10182812;transform:translateY(-1px)}
-.dashboard-card:nth-child(1){grid-column:span 6}
-.dashboard-card:nth-child(2),.dashboard-card:nth-child(3){grid-column:span 3}
-.dashboard-card:nth-child(4),.dashboard-card:nth-child(5){grid-column:span 6;min-height:390px}
-.dashboard-card:nth-child(6){grid-column:1/-1;min-height:470px}
 .dashboard-layout-row{grid-column:1/-1;display:grid;align-items:stretch;min-width:0}
-.dashboard-layout-row>.dashboard-card{grid-column:auto!important;min-height:390px;margin:0}
-.dashboard-layout-row:first-child>.dashboard-card{min-height:268px}
-.dashboard-card-resizer{position:relative;z-index:2;min-width:10px;cursor:col-resize;touch-action:none;outline:0}
+.dashboard-layout-row>.dashboard-card{grid-column:auto!important;min-height:268px;margin:0}
+.dashboard-card-resizer{position:relative;z-index:2;align-self:stretch;min-width:10px;cursor:col-resize;touch-action:none;outline:0}
 .dashboard-card-resizer::after{content:"";position:absolute;top:12px;bottom:12px;left:calc(50% - .5px);width:1px;border-radius:999px;background:#dfe4ea;transition:background 120ms ease,box-shadow 120ms ease}
 .dashboard-card-resizer:hover::after,.dashboard-card-resizer:focus-visible::after,.dashboard-card-resizer.dragging::after{background:#4b84b4;box-shadow:0 0 0 3px #4b84b426}
-@container (max-width:900px){.dashboard-layout-row{grid-template-columns:minmax(0,1fr)!important;gap:14px}.dashboard-layout-row>.dashboard-card{grid-column:1!important;min-height:340px}.dashboard-card-resizer{display:none}}
+.dashboard-layout-row>.dashboard-card .chart{max-height:460px;overflow:auto}
+@container (max-width:900px){.dashboard-layout-row{grid-template-columns:minmax(0,1fr)!important;gap:14px}.dashboard-layout-row>.dashboard-card{grid-column:1!important;min-height:340px}.dashboard-layout-row>.dashboard-card .chart{max-height:none;overflow:visible}.dashboard-card-resizer{display:none}}
 .dashboard-card h3{font-size:15px;line-height:1.45;letter-spacing:-.01em}
 .dashboard-card .purpose{min-height:0;margin:9px 0 16px;color:#687386;font-size:11px}
 .panel-state{display:inline-flex;align-items:center;min-height:23px;padding:3px 7px;border-radius:999px;background:var(--color-success-soft);color:var(--color-success);font-size:10px;white-space:nowrap}
-.dashboard-card .chart{min-width:0;flex:1;display:grid;align-items:center;overflow:hidden}
+.dashboard-card .chart{min-width:0;display:grid;align-items:start;overflow:visible;flex:1}
 .dashboard-card .chart svg{display:block;min-width:0;width:100%;max-width:100%}
-.dashboard-card.wide .chart svg,.dashboard-card.full .chart svg{min-width:0}
+.chart-table-scroll{align-self:start;width:100%;max-height:360px;overflow:auto}
+.chart-table-scroll table{width:max-content;min-width:100%;margin-top:0}
+.chart-table-scroll th,.chart-table-scroll td{max-width:320px;overflow-wrap:anywhere;vertical-align:top}
 .metric{align-self:center;padding:20px 6px;font-size:48px;letter-spacing:-.04em}
 .kpi-pair{gap:10px;align-self:center;width:100%}
 .kpi-pair div{padding:17px 16px;border:1px solid #edf0f3;border-radius:9px;background:#f7f9fb}
@@ -653,9 +622,9 @@ function showInsightArtifact(hasResult=false){const pane=$("panel-inspector");pa
 function hideInsightArtifact(){const pane=$("panel-inspector");pane.classList.remove("artifact-active");$("artifact-preview").className="artifact-preview hidden"}
 const consultationHistory=[];let pendingConsultation=null,consultationProfile=null;
 function appendConsultationMessage(role,text){const message=Object.assign(document.createElement("p"),{className:`consultation-message ${role}`,textContent:text});$("consultation-thread").append(message);message.scrollIntoView({block:"nearest"});return message}
-function resetConsultation(profile){consultationHistory.splice(0);$("consultation-thread").replaceChildren();$("consultation-recommendations").replaceChildren();consultationProfile=profile}
+function resetConsultation(profile){consultationHistory.splice(0);pendingInsightSpecification=null;$("consultation-thread").replaceChildren();$("consultation-recommendations").replaceChildren();consultationProfile=profile}
 function rollbackPendingConsultation(){if(!pendingConsultation)return;const pending=pendingConsultation,last=consultationHistory.at(-1);if(last?.role==="user"&&last.content===pending.question)consultationHistory.pop();pending.message.remove();$("composer-input").value=pending.question;resizeComposerInput();$("consultation-status").textContent="相談を実行しませんでした。発言を編集して再送信できます。";pendingConsultation=null;$("composer-input").focus()}
-function renderAnalysisRecommendations(recommendations){const host=$("consultation-recommendations");host.replaceChildren();const chartLabels={scorecard:"スコアカード",bar:"棒グラフ",line:"折れ線",table:"テーブル",sankey:"サンキー"};recommendations.forEach(recommendation=>{const card=Object.assign(document.createElement("button"),{className:"recommendation-card",type:"button"}),title=document.createElement("strong"),chart=Object.assign(document.createElement("span"),{className:"recommendation-chart"}),decision=Object.assign(document.createElement("span"),{className:"recommendation-decision"}),definition=document.createElement("span"),prompt=document.createElement("span");title.textContent=recommendation.title;chart.textContent=chartLabels[recommendation.chart]||recommendation.chart;decision.textContent=`判断: ${recommendation.objective}`;definition.textContent=`指標: ${recommendation.metric} / 軸: ${recommendation.dimension} / 比較: ${recommendation.comparison}`;prompt.textContent=`AIが定義した実行仕様: ${recommendation.execution_prompt}`;card.dataset.prompt=recommendation.execution_prompt;card.setAttribute("aria-pressed","false");card.append(title,chart,decision,definition,prompt);card.onclick=()=>selectAnalysisRecommendation(recommendation);host.append(card)})}
+function renderAnalysisRecommendations(recommendations){const host=$("consultation-recommendations");host.replaceChildren();const chartLabels={scorecard:"スコアカード",bar:"棒グラフ",line:"折れ線",table:"テーブル",sankey:"サンキー"};recommendations.forEach(recommendation=>{const card=Object.assign(document.createElement("button"),{className:"recommendation-card",type:"button"}),title=document.createElement("strong"),chart=Object.assign(document.createElement("span"),{className:"recommendation-chart"}),decision=Object.assign(document.createElement("span"),{className:"recommendation-decision"}),definition=document.createElement("span"),prompt=document.createElement("span");title.textContent=recommendation.title;chart.textContent=chartLabels[recommendation.chart]||recommendation.chart;decision.textContent=`判断: ${recommendation.objective}`;definition.textContent=`指標: ${recommendation.measures.join("、")} / 軸: ${recommendation.dimensions.join("、")||"なし"} / 比較: ${recommendation.comparison}`;prompt.textContent=`AIが定義した実行仕様: ${recommendation.execution_prompt}`;card.dataset.prompt=recommendation.execution_prompt;card.setAttribute("aria-pressed","false");card.append(title,chart,decision,definition,prompt);card.onclick=()=>selectAnalysisRecommendation(recommendation);host.append(card)})}
 function handleAnalysisConsultation(event){if(event.type==="consultation_stage"){$("consultation-status").textContent=event.message;return}if(event.type==="error")throw new Error(event.message);if(event.type!=="consultation")return;appendConsultationMessage("assistant",`${event.assistant_message}\n\n${event.follow_up_question}`);consultationHistory.push({role:"assistant",content:event.history_message});renderAnalysisRecommendations(event.recommendations);$("consultation-status").textContent=`AIが${event.recommendations.length}件の分析仕様を考察しました。Vertex AI推定 ¥${event.cost_jpy}。候補を選ぶか、下から追加相談できます。`;$("composer-message").textContent="相談結果を確認してください。BigQueryはまだ実行していません。";pendingConsultation=null}
 function beginAnalysisConsultation(question,profile){pendingInsightSpecification=null;hideInsightArtifact();selectWorkspace("consult");setComposerAction("consult",false);if(consultationProfile!==profile)resetConsultation(profile);$("inspector-title").textContent="分析相談";$("inspector-subtitle").textContent="BigQuery未実行";$("inspector-empty").className="inspector-empty";$("inspector-content").className="hidden";$("inspector-empty").textContent="AIが目的、指標、軸、比較、可視化を考察します。選択後にSQL生成費用を別途確認します。";const history=consultationHistory.slice(-8),message=appendConsultationMessage("user",question);consultationHistory.push({role:"user",content:question});pendingConsultation={question,profile,history,message};$("composer-input").value="";resizeComposerInput();$("consultation-status").textContent="費用確認後にVertex AIへ相談します。BigQueryは実行しません。";$("composer-message").textContent="相談費用を確認してください。";try{showCost("analysis-consult")}catch(error){rollbackPendingConsultation();$("consultation-status").textContent=error.message}}
 async function runAnalysisConsultation(){const pending=pendingConsultation;if(!pending)return;const operation=startActiveRequest();$("cost-dialog").close();$("consultation-status").textContent="AIが分析目的と利用可能なデータを照合しています。";try{await stream("/api/consult",pending.question,handleAnalysisConsultation,pending.profile,{history:pending.history},operation)}catch(error){if(error.name!=="AbortError"){rollbackPendingConsultation();$("consultation-status").textContent=error.message}}finally{finishActiveRequest(operation)}}
@@ -681,13 +650,14 @@ let composerInputWidth=0;new ResizeObserver(([entry])=>{if(entry.contentRect.wid
 setInspectorWidth(currentInspectorWidth());
 inspectorResizer.onkeydown=event=>{if(!["ArrowLeft","ArrowRight"].includes(event.key))return;event.preventDefault();setInspectorWidth(event.key==="ArrowLeft"?currentInspectorWidth()+20:currentInspectorWidth()-20)};
 window.addEventListener("resize",()=>{if(window.innerWidth>1180)setInspectorWidth(currentInspectorWidth());resizeComposerInput()});
+$("plan-correction-apply").onclick=()=>{$("plan-revision-instruction").value=$("plan-correction-text").textContent;$("plan-revision-instruction").focus()};
 $("composer-submit").onclick=submitComposer;$("composer-input").onkeydown=event=>{if((event.metaKey||event.ctrlKey)&&event.key==="Enter")submitComposer()};
 $("composer-launcher").onclick=()=>expandComposer();
 $("composer-collapse").onclick=collapseComposerFromControl;
 $("new-analysis").onclick=()=>{selectWorkspace("consult");setComposerAction("consult");$("composer-input").focus()};
 $("view-dashboard").onclick=()=>{hideInsightArtifact();selectWorkspace("dashboard");setComposerAction("dashboard",false);if(latestBuildRevision)enterDashboardReadingMode()};
 $("view-build").onclick=()=>{hideInsightArtifact();selectWorkspace("build");setComposerAction("dashboard",false)};
-$("view-report").onclick=()=>{hideInsightArtifact();selectWorkspace("report");setComposerAction("report",false)};
+$("view-report").onclick=()=>{hideInsightArtifact();selectWorkspace("report")};
 $("view-graph").onclick=()=>{selectWorkspace("graph");setComposerAction("insight",false);showInsightArtifact(!$("output").classList.contains("hidden"))};
 updatePaneButton("sidebar-toggle","left",!$("app-shell").classList.contains("sidebar-collapsed"),$("app-shell").classList.contains("sidebar-collapsed")?"ナビゲーションを展開":"ナビゲーションを折りたたむ");updatePaneButton("inspector-toggle","right",!$("app-shell").classList.contains("inspector-collapsed"),$("app-shell").classList.contains("inspector-collapsed")?"成果物パネルを展開":"成果物パネルを折りたたむ");
 const headerMeta=document.querySelector(".app-header .header-context:last-child");headerMeta.insertBefore($("workspace-state"),headerMeta.querySelector(".draft-badge"));
@@ -698,6 +668,7 @@ if(window.innerWidth<=960 && $("sidebar-toggle").getAttribute("aria-expanded")==
 HTML = HTML.replace("</script></body>", WORKSPACE_POLISH_SCRIPT + "\n</script></body>")
 HTML = HTML.replace("__INITIAL_PANEL_COUNT__", str(planner.INITIAL_PANEL_COUNT))
 HTML = HTML.replace("__MAX_PANEL_COUNT__", str(planner.MAX_PANEL_COUNT))
+HTML = HTML.replace("__MAX_SANKEY_PAGES__", str(MAX_SANKEY_PAGES))
 
 class LiveDemoError(RuntimeError):
     """A local-demo failure that is safe to show in the browser."""
@@ -731,6 +702,23 @@ def google_auth_recovery_message(error: Exception) -> str | None:
     return None
 
 
+def vertex_ai_error_message(error: Exception) -> str | None:
+    """Return a safe, actionable message for Google Gen AI provider failures."""
+    if not type(error).__module__.startswith("google.genai.errors"):
+        return None
+    code = getattr(error, "code", None)
+    status = getattr(error, "status", None)
+    diagnostic = " ".join(str(value) for value in (code, status) if value)
+    suffix = f"（{diagnostic}）" if diagnostic else ""
+    if code == 429:
+        reason = "Vertex AIの利用上限または同時実行制限に達しました"
+    elif isinstance(code, int) and code >= 500:
+        reason = "Vertex AIで一時的なサービス障害が発生しました"
+    else:
+        reason = "Vertex AIが生成リクエストを受理できませんでした"
+    return f"{reason}{suffix}。現在案は保持し、自動再実行していません。"
+
+
 def period_for_question(question: str) -> dict[str, str]:
     """Return the explicit month in a question, bounded by the demo dataset."""
     match = re.search(r"(?P<year>\d{4})年\s*(?P<month>\d{1,2})月", question)
@@ -751,82 +739,171 @@ def period_for_question(question: str) -> dict[str, str]:
     }
 
 
-def navigation_generation_requirements(depth: int) -> list[str]:
-    """Build the bounded staged-path contract for a requested Sankey depth."""
-    page_names = ["入口", *(f"{stage}ページ目" for stage in range(2, depth + 1))]
-    path_names = "・".join(page_names)
-    hops = "、".join(f"{stage}→{stage + 1}" for stage in range(1, depth))
-    prefixes = "、".join(
-        "`1. 入口: `" if stage == 1 else f"`{stage}. `"
-        for stage in range(1, depth + 1)
-    )
-    return [
-        "page_pathはpage_locationのURLからホスト・クエリ・フラグメントを除いたパスとし、"
-        "空なら`/`にする。完全なURLをsource/targetへ出さない",
-        "セッション内をevent_timestamp順、同時刻ならpage_path順に並べ、連続する同一page_pathは"
-        f"1回の滞在へ統合する。その後の最初の{depth}件を{path_names}にする",
-        f"各段階のパスはp1〜p{depth}のASCII別名にする。{depth}ページ目が存在する"
-        f"セッションだけを対象にし、上位12経路を抽出する前にp{depth} IS NOT NULLで絞る。"
-        "`(exit)`などの離脱ノードは作らない",
-        f"まず{path_names}の組ごとにセッション数を数え、セッション数降順、同数なら{path_names}昇順で"
-        f"上位12経路を確定してから、{hops}のedgeへ分割して同一edgeをSUMする",
-        f"source/targetの段階接頭辞は正確に{prefixes}とし、最終列のASCII別名は"
-        "source、target、sessionsにする",
-    ]
-
-
-def section_for_question(spec: dict, question: str) -> dict:
-    """Keep a bounded navigation contract when only the requested depth changes."""
-    selected = report.select_sections(spec, question)[0]
-    match = re.search(r"入口から(?P<depth>\d+)ページ目まで", question)
-    is_navigation = "Webサイト回遊" in question and "サンキー" in question
-    if match is None or not is_navigation:
-        return selected
-    depth = int(match.group("depth"))
-    if not 3 <= depth <= 6:
-        raise LiveDemoError("回遊Sankeyで指定できるのは入口から3〜6ページ目までです。")
-    base = next(section for section in spec["sections"] if section["id"] == "R17")
-    if selected["id"] == "R17" and depth == 3:
-        return {**selected, "navigation_depth": 3}
-    return {
-        **base,
-        "id": "Q1",
-        "title": f"入口から{depth}ページ目までの主要回遊",
-        "text": question.strip(),
-        "verification": "execution",
-        "navigation_depth": depth,
-        "require_full_navigation_depth": True,
-        "generation_requirements": navigation_generation_requirements(depth),
+def planned_analysis_section(panel: dict, section_id: str | None = None) -> dict:
+    """Translate one confirmed AI specification into a guarded render contract."""
+    component_for_chart = {
+        "scorecard": "table",
+        "kpi_group": "kpi_group",
+        "bar": "table",
+        "grouped_bar": "grouped_bar",
+        "stacked_bar": "stacked_bar",
+        "line": "line",
+        "multi_line": "multi_line",
+        "scatter": "scatter",
+        "bubble": "bubble",
+        "funnel": "funnel",
+        "heatmap": "heatmap",
+        "table": "table",
+        "sankey": "sankey",
     }
+    chart = panel.get("chart")
+    if chart not in component_for_chart:
+        raise LiveDemoError("確定した分析仕様の可視化種別が未対応です。")
+    section = {
+        "id": section_id or panel["id"],
+        "title": panel["title"],
+        "text": panel["execution_prompt"],
+        "compare": "execution",
+        "component": component_for_chart[chart],
+        "planned_visualization": chart,
+        "verification": "execution",
+        "purpose": panel.get("decision", panel.get("objective", "")),
+        "max_result_rows": planner.DASHBOARD_ROW_LIMITS[chart],
+        "dimension_count": len(panel["dimensions"]),
+        "measure_count": len(panel["measures"]),
+    }
+    dimensions = panel["dimensions"]
+    measures = panel["measures"]
+    if chart == "scorecard":
+        section["shape"] = {"rows": "1行", "columns": measures}
+        section["source_columns"] = ["metric_value"]
+    elif chart == "kpi_group":
+        section["shape"] = {"rows": "1行", "columns": measures}
+        section["source_columns"] = [
+            f"metric_{index}" for index in range(1, len(measures) + 1)
+        ]
+    elif chart == "bar":
+        section["shape"] = {
+            "rows": "区分ごとに1行",
+            "columns": dimensions + measures,
+        }
+        section["source_columns"] = ["category", "metric_value"]
+    elif chart in {"grouped_bar", "stacked_bar"}:
+        section["shape"] = {
+            "rows": "区分ごとに1行",
+            "columns": dimensions + measures,
+        }
+        section["source_columns"] = [
+            "category",
+            *[f"metric_{index}" for index in range(1, len(measures) + 1)],
+        ]
+    elif chart == "line":
+        section["shape"] = {
+            "rows": "日付ごとに1行",
+            "columns": dimensions + measures,
+        }
+        section["source_columns"] = ["event_date", "metric_value"]
+    elif chart == "multi_line":
+        section["shape"] = {
+            "rows": "日付ごとに1行",
+            "columns": dimensions + measures,
+        }
+        section["source_columns"] = [
+            "event_date",
+            *[f"metric_{index}" for index in range(1, len(measures) + 1)],
+        ]
+    elif chart in {"scatter", "bubble"}:
+        value_columns = ["x_value", "y_value"]
+        if chart == "bubble":
+            value_columns.append("size_value")
+        section["shape"] = {
+            "rows": "項目ごとに1行",
+            "columns": dimensions + measures,
+        }
+        section["source_columns"] = ["category", *value_columns]
+    elif chart == "funnel":
+        section["shape"] = {
+            "rows": "段階ごとに1行",
+            "columns": dimensions + measures,
+        }
+        section["source_columns"] = ["stage", "metric_value"]
+        section["generation_requirements"] = [
+            "stageには順序が判別できる番号接頭辞を付ける",
+        ]
+    elif chart == "heatmap":
+        section["shape"] = {
+            "rows": "2つの区分の組み合わせごとに1行",
+            "columns": dimensions + measures,
+        }
+        section["source_columns"] = ["x_category", "y_category", "metric_value"]
+    elif chart == "table":
+        section["shape"] = {
+            "rows": "区分または集計単位ごとに1行",
+            "columns": dimensions + measures,
+        }
+        section["source_columns"] = [
+            *[f"dimension_{index}" for index in range(1, len(dimensions) + 1)],
+            *[f"metric_{index}" for index in range(1, len(measures) + 1)],
+        ]
+    elif chart == "sankey":
+        display_dimensions = dimensions
+        if len({"".join(value.lower().split()) for value in dimensions}) == 1:
+            display_dimensions = [
+                f"遷移元{dimensions[0]}",
+                f"遷移先{dimensions[1]}",
+            ]
+        section["shape"] = {
+            "rows": "隣接する段階間の遷移ごとに1行",
+            "columns": display_dimensions + measures,
+        }
+        section["source_columns"] = ["source", "target", "metric_value"]
+        section["max_navigation_pages"] = MAX_SANKEY_PAGES
+        section["generation_requirements"] = [
+            "最終列のASCII別名はsource、target、metric_valueにする",
+            f"sourceとtargetには1.〜{MAX_SANKEY_PAGES}.のページ段階が判別できる番号接頭辞を付ける",
+            f"回遊は最初の{MAX_SANKEY_PAGES}ページまでとし、{MAX_SANKEY_PAGES}ページ目より後のnodeやedgeは返さない",
+            f"3〜{MAX_SANKEY_PAGES}ページの回遊もsourceとtargetの隣接edgeとして縦持ちで返す",
+            "同一sourceとtargetの組はSUMして1行に集約する",
+        ]
+    if chart not in {"line", "multi_line", "table"}:
+        nonnull_metric_columns = section["source_columns"][len(dimensions) :]
+        section["nonnull_metric_columns"] = nonnull_metric_columns
+        aliases = "、".join(nonnull_metric_columns)
+        section.setdefault("generation_requirements", []).append(
+            f"{aliases}はNULLを返さない。COUNT/COUNTIF以外の式は最終SELECT式全体を"
+            "COALESCEまたはIFNULLで包む"
+        )
+    if chart not in {"scorecard", "kpi_group"}:
+        max_rows = section["max_result_rows"]
+        if chart in {"line", "multi_line"}:
+            ordering = "event_dateの昇順"
+        elif chart == "sankey":
+            ordering = "metric_valueの降順"
+        elif chart == "funnel":
+            ordering = "stageの昇順"
+        else:
+            ordering = f"{section['source_columns'][-1]}の降順"
+        section.setdefault("generation_requirements", []).append(
+            f"最終SELECTは{ordering}でORDER BYし、LIMIT {max_rows}を明示する"
+        )
+    return section
 
 
-def dashboard_sections(
-    spec: dict, question: str, panel_ids: list[str] | None = None
-) -> tuple[dict[str, str], list[dict]]:
-    """Expand one concrete dashboard request into the validated showcase analyses."""
-    report.select_sections(spec, question)
-    if "ダッシュボード" not in question:
-        raise LiveDemoError("依頼に「ダッシュボード」を含めてください。")
-    period = period_for_question(question)
-    sections = report.select_sections(spec, None, showcase=True)
-    if tuple(section["id"] for section in sections) != DASHBOARD_SECTION_IDS:
-        raise LiveDemoError("ダッシュボード分析定義の構成が一致しません。")
-    if panel_ids is not None:
-        if len(panel_ids) != len(set(panel_ids)) or not 4 <= len(panel_ids) <= 6:
-            raise LiveDemoError("確定した分析パネルは重複なしの4〜6件にしてください。")
-        by_id = {section["id"]: section for section in sections}
-        if any(panel_id not in by_id for panel_id in panel_ids):
-            raise LiveDemoError("確定した分析計画に未登録のパネルがあります。")
-        sections = [by_id[panel_id] for panel_id in panel_ids]
-    month_pattern = re.compile(r"\d{4}年\s*\d{1,2}月")
-    for section in sections:
-        section["text"] = month_pattern.sub(period["label"], section["text"], count=1)
-        section["purpose"] = DASHBOARD_PURPOSES[section["id"]]
-        # Registered reference SQL is fixed to January 2021. Other available
-        # sample months can execute, but cannot be labelled reference-verified.
-        if period["from"] != "20210101" or period["to"] != "20210131":
-            section["verification"] = "execution"
-    return period, sections
+def analysis_section_for_specification(
+    question: str, analysis_specification: dict, profile: str
+) -> tuple[dict, dict]:
+    """Freeze one selected AI proposal before SQL generation."""
+    confirmed = planner.confirm_analysis_specification(analysis_specification)
+    if question.strip() != confirmed["execution_prompt"]:
+        raise LiveDemoError(
+            "分析依頼がAIの分析仕様から変更されています。変更内容を再度相談してください。"
+        )
+    period = (
+        bitcoin.period_for_question(question)
+        if profile == "bitcoin"
+        else period_for_question(question)
+    )
+    return period, planned_analysis_section(confirmed, "I1")
 
 
 def dashboard_sections_for_plan(question: str, plan: dict) -> tuple[dict, list[dict]]:
@@ -836,60 +913,12 @@ def dashboard_sections_for_plan(question: str, plan: dict) -> tuple[dict, list[d
     period = period_for_question(question)
     if plan.get("period") != period:
         raise LiveDemoError("確定した分析仕様の対象期間が依頼文と一致しません。")
-    component_for_chart = {
-        "scorecard": "table",
-        "bar": "table",
-        "line": "line",
-        "table": "table",
-        "sankey": "sankey",
-    }
-    sections = []
-    for panel in plan.get("panels", []):
-        chart = panel.get("chart")
-        if chart not in component_for_chart:
-            raise LiveDemoError("確定した分析仕様の可視化種別が未対応です。")
-        section = {
-            "id": panel["id"],
-            "title": panel["title"],
-            "text": panel["execution_prompt"],
-            "compare": "execution",
-            "component": component_for_chart[chart],
-            "planned_visualization": chart,
-            "verification": "execution",
-            "purpose": panel["decision"],
-        }
-        if chart == "scorecard":
-            section["shape"] = {"rows": "1行", "columns": [panel["kpi"]]}
-        elif chart == "bar":
-            section["shape"] = {"rows": "区分ごとに1行", "columns": ["区分", "値"]}
-        elif chart == "line":
-            section["shape"] = {"rows": "日付ごとに1行", "columns": ["日付", "値"]}
-        elif chart == "sankey":
-            section["shape"] = {
-                "rows": "隣接する段階間の遷移ごとに1行",
-                "columns": ["source", "target", "sessions"],
-            }
-            section["generation_requirements"] = [
-                "最終列のASCII別名はsource、target、sessionsにする",
-                "sourceとtargetは段階が判別できる接頭辞を付ける",
-                "同一sourceとtargetの組はSUMして1行に集約する",
-            ]
-        sections.append(section)
+    sections = [planned_analysis_section(panel) for panel in plan.get("panels", [])]
     if not 1 <= len(sections) <= planner.MAX_PANEL_COUNT:
         raise LiveDemoError(
             f"確定した分析パネルは1〜{planner.MAX_PANEL_COUNT}件にしてください。"
         )
     return period, sections
-
-
-def confirm_dashboard_analysis_plan(plan: dict) -> dict:
-    """Freeze dynamic plans while preserving the fixed demo fixture contract."""
-    panels = plan.get("panels", []) if isinstance(plan, dict) else []
-    if panels and all(
-        isinstance(panel, dict) and "execution_prompt" in panel for panel in panels
-    ):
-        return planner.confirm_dashboard_plan(plan)
-    return planner.confirm_plan(plan)
 
 
 def require_sql_period(sql: str, period: dict[str, str]) -> None:
@@ -906,252 +935,272 @@ def require_sql_period(sql: str, period: dict[str, str]) -> None:
         )
 
 
-def require_deterministic_navigation_order(sql: str, navigation_depth: int = 3) -> None:
-    """Require a stable top-12 journey order before executing navigation SQL."""
-
-    def order_terms(clause: str) -> list[str]:
-        terms: list[str] = []
-        start = depth = 0
-        quote: str | None = None
-        index = 0
-        while index < len(clause):
-            char = clause[index]
-            if quote:
-                if char == quote:
-                    if index + 1 < len(clause) and clause[index + 1] == quote:
-                        index += 1
-                    else:
-                        quote = None
-            elif char in "'\"`":
-                quote = char
-            elif char == "(":
-                depth += 1
-            elif char == ")":
-                depth = max(0, depth - 1)
-            elif char == "," and depth == 0:
-                terms.append(clause[start:index].strip())
-                start = index + 1
-            index += 1
-        terms.append(clause[start:].strip())
-        return [term for term in terms if term]
-
-    for limit in re.finditer(r"\bLIMIT\s+12\b", sql, flags=re.IGNORECASE):
-        prefix = sql[: limit.start()]
-        order_matches = list(
-            re.finditer(r"\bORDER\s+BY\b", prefix, flags=re.IGNORECASE)
-        )
-        if not order_matches:
-            continue
-        clause = prefix[order_matches[-1].end() :]
-        terms = order_terms(clause)
-        tie_terms = terms[1 : navigation_depth + 1]
-        tie_terms_are_ascending = len(tie_terms) == navigation_depth and not any(
-            re.search(r"\bDESC\b", term, re.IGNORECASE) for term in tie_terms
-        )
-        if (
-            len(terms) >= navigation_depth + 1
-            and re.search(r"\bDESC\b", terms[0], re.IGNORECASE)
-            and tie_terms_are_ascending
-        ):
-            return
-    raise LiveDemoError(
-        "回遊の上位12経路に同数時の順序がないためBigQueryへ送信しません。"
-    )
-
-
-def require_complete_navigation_depth(sql: str, navigation_depth: int) -> None:
-    """Require the requested final page before selecting the bounded top paths."""
-    limit = re.search(r"\bLIMIT\s+12\b", sql, flags=re.IGNORECASE)
-    prefix = sql[: limit.start()] if limit else ""
-    without_comments = re.sub(r"/\*.*?\*/|--[^\n]*", " ", prefix, flags=re.S)
-    without_literals = re.sub(r"'(?:''|[^'])*'", "''", without_comments)
-    final_page = f"p{navigation_depth}"
-    if not re.search(
-        rf"\b(?:WHERE|HAVING)\b"
-        rf"(?:(?!\b(?:GROUP\s+BY|ORDER\s+BY|LIMIT|UNION)\b)[\s\S])*?"
-        rf"\b{final_page}\s+IS\s+NOT\s+NULL\b",
-        without_literals,
-        flags=re.IGNORECASE,
-    ):
-        raise LiveDemoError(
-            f"回遊の上位12経路が{navigation_depth}ページ目到達前に抽出されるため"
-            "BigQueryへ送信しません。"
-        )
-
-
 def json_value(value):
     if isinstance(value, (date, datetime)):
         return value.isoformat()
     if isinstance(value, Decimal):
         return float(value)
     return value if value is None or isinstance(value, (str, int, float, bool)) else str(value)
-def visualization_for_result(rows: list[tuple], columns: list[str]) -> str:
-    if len(rows) == 1 and len(columns) == 1:
-        return "scalar"
-    numeric = (int, float, Decimal)
+
+
+def _top_level_select_expressions(sql: str) -> tuple[list[str], str]:
+    """Return the final SELECT expressions and its top-level suffix."""
+    structure = re.sub(
+        r"'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\"|`(?:``|[^`])*`|--[^\n]*|/\*[\s\S]*?\*/",
+        lambda match: " " * len(match.group(0)),
+        sql,
+    )
+    depth = 0
+    depths = []
+    for char in structure:
+        depths.append(depth)
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth = max(0, depth - 1)
+    tokens = [
+        (match.group(0).upper(), match.start(), match.end())
+        for match in re.finditer(r"\b[A-Za-z_][A-Za-z0-9_]*\b", structure)
+        if depths[match.start()] == 0
+    ]
+    selects = [token for token in tokens if token[0] == "SELECT"]
+    if not selects:
+        raise LiveDemoError("生成SQLの最終SELECTを解析できないためBigQueryへ送信しません。")
+    select = selects[-1]
+    following = [token for token in tokens if token[1] > select[2]]
+    boundary = next(
+        (token for token in following if token[0] in {"FROM", "UNION"}),
+        ("END", len(sql), len(sql)),
+    )
+    clause = sql[select[2] : boundary[1]]
+    expressions, start, nested = [], 0, 0
+    for index, char in enumerate(structure[select[2] : boundary[1]]):
+        if char == "(":
+            nested += 1
+        elif char == ")":
+            nested = max(0, nested - 1)
+        elif char == "," and nested == 0:
+            expressions.append(clause[start:index].strip())
+            start = index + 1
+    expressions.append(clause[start:].strip())
+    suffix_chars, nested = [], 0
+    for char in structure[boundary[1] :]:
+        if char == "(":
+            nested += 1
+            suffix_chars.append(" ")
+        elif char == ")":
+            nested = max(0, nested - 1)
+            suffix_chars.append(" ")
+        else:
+            suffix_chars.append(char if nested == 0 else " ")
+    return [expression for expression in expressions if expression], "".join(suffix_chars)
+
+
+def validate_generated_dashboard_sql(section: dict, sql: str) -> None:
+    """Reject SQL that cannot satisfy the confirmed renderer before BigQuery runs."""
+    planned = section.get("planned_visualization")
+    expected = section.get("source_columns")
+    if not planned or not expected:
+        return
+    expressions, suffix = _top_level_select_expressions(sql)
+    aliases = []
+    for expression in expressions:
+        match = re.search(r"\bAS\s+([A-Za-z_][A-Za-z0-9_]*)\s*$", expression, re.I)
+        aliases.append(match.group(1).lower() if match else "")
     if (
-        rows
-        and [column.lower() for column in columns] == ["source", "target", "sessions"]
-        and all(
-            len(row) == 3
-            and isinstance(row[0], str)
-            and isinstance(row[1], str)
-            and isinstance(row[2], numeric)
-            and math.isfinite(float(row[2]))
-            for row in rows
+        len(aliases) != len(expected)
+        or any(not alias for alias in aliases)
+        or len(set(aliases)) != len(aliases)
+    ):
+        observed = "、".join(alias or "別名なし" for alias in aliases)
+        raise LiveDemoError(
+            f"{section['title']}のSQL出力列（{observed}）は、{planned}に必要な"
+            f"{len(expected)}列の一意なASCII別名を満たさないためBigQueryへ送信しません。"
         )
-    ):
-        return "sankey"
-    if rows and len(columns) == 2 and all(
-        isinstance(row[0], (date, datetime)) and isinstance(row[1], numeric) for row in rows
-    ):
-        return "line"
-    if rows and len(columns) == 2 and len(rows) <= 30 and all(
-        isinstance(row[1], numeric) and math.isfinite(float(row[1])) for row in rows
-    ):
-        return "bar"
-    return "table"
+    nonnull_columns = section.get("nonnull_metric_columns", [])
+    unsafe_columns = []
+    for column in nonnull_columns:
+        index = expected.index(column)
+        expression = re.sub(
+            r"\bAS\s+[A-Za-z_][A-Za-z0-9_]*\s*$", "", expressions[index], flags=re.I
+        ).strip()
+        if not re.match(
+            r"^(?:(?:COUNT|COUNTIF|COALESCE|IFNULL)\s*\(|"
+            r"(?:CAST|SAFE_CAST)\s*\(\s*(?:COUNT|COUNTIF)\s*\()",
+            expression,
+            re.I,
+        ):
+            unsafe_columns.append(column)
+    if unsafe_columns:
+        raise LiveDemoError(
+            f"{section['title']}のSQL指標列（{'、'.join(unsafe_columns)}）がNULLを"
+            "返し得るためBigQueryへ送信しません。COUNT/COUNTIFを使うか、"
+            "最終SELECT式全体をCOALESCEまたはIFNULLで包んでください。"
+        )
+    max_rows = section.get("max_result_rows")
+    if planned not in {"scorecard", "kpi_group"} and isinstance(max_rows, int):
+        limit = re.search(r"\bLIMIT\s+([0-9]+)\b", suffix, re.I)
+        if (
+            not re.search(r"\bORDER\s+BY\b", suffix, re.I)
+            or not limit
+            or not 1 <= int(limit.group(1)) <= max_rows
+        ):
+            raise LiveDemoError(
+                f"{section['title']}のSQLに{planned}用のORDER BYとLIMIT "
+                f"{max_rows}以下がないためBigQueryへ送信しません。"
+            )
+    if planned in {"scorecard", "kpi_group"}:
+        aggregate_pattern = re.compile(
+            r"\b(?:COUNT|COUNTIF|SUM|AVG|MIN|MAX|ANY_VALUE|LOGICAL_AND|LOGICAL_OR|APPROX_[A-Z_]+)\s*\(",
+            re.I,
+        )
+        has_aggregate = all(aggregate_pattern.search(expression) for expression in expressions)
+        if (
+            not has_aggregate
+            or re.search(r"\bGROUP\s+BY\b", suffix, re.I)
+            or any(re.search(r"\bOVER\s*\(", expression, re.I) for expression in expressions)
+        ):
+            raise LiveDemoError(
+                f"{section['title']}のSQLが{planned}用の単一集計行になっていないため"
+                "BigQueryへ送信しません。"
+            )
 
 
-def validate_navigation_sankey(rows: list[tuple], navigation_depth: int = 3) -> None:
-    """Reject edges that do not represent collapsed adjacent page transitions."""
-    patterns = {1: re.compile(r"^1\. 入口: (.+)$")}
-    patterns.update(
-        {
-            stage: re.compile(rf"^{stage}\. (.+)$")
-            for stage in range(2, navigation_depth + 1)
-        }
+def validate_dashboard_dry_run_schema(section: dict, schema: list[tuple[str, str]]) -> None:
+    """Check BigQuery's cost-free dry-run schema against the confirmed renderer."""
+    planned = section.get("planned_visualization")
+    expected = section.get("source_columns")
+    if not planned or not expected:
+        return
+    names = [name.lower() for name, _field_type in schema]
+    types = [field_type.upper() for _name, field_type in schema]
+    numeric = {"INTEGER", "INT64", "FLOAT", "FLOAT64", "NUMERIC", "BIGNUMERIC"}
+    valid = (
+        len(names) == len(expected)
+        and all(names)
+        and len(set(names)) == len(names)
     )
-    sources = {stage: set() for stage in range(1, navigation_depth)}
-    targets = {stage: set() for stage in range(1, navigation_depth)}
-    outgoing: dict[tuple[int, str], Decimal] = {}
-    incoming: dict[tuple[int, str], Decimal] = {}
-    seen_edges: set[tuple[str, str]] = set()
-    for source, target, _sessions in rows:
-        source_stage = next(
-            (
-                stage
-                for stage in range(1, navigation_depth)
-                if patterns[stage].fullmatch(source)
-            ),
-            None,
+    if planned == "scorecard":
+        valid = valid and types[0] in numeric
+    elif planned == "kpi_group":
+        valid = valid and all(field_type in numeric for field_type in types)
+    elif planned == "bar":
+        valid = valid and types[1] in numeric
+    elif planned in {"grouped_bar", "stacked_bar"}:
+        valid = valid and all(field_type in numeric for field_type in types[1:])
+    elif planned == "line":
+        valid = valid and types[0] in {"DATE", "DATETIME", "TIMESTAMP"} and types[1] in numeric
+    elif planned == "multi_line":
+        valid = (
+            valid
+            and types[0] in {"DATE", "DATETIME", "TIMESTAMP"}
+            and all(field_type in numeric for field_type in types[1:])
         )
-        source_match = patterns[source_stage].fullmatch(source) if source_stage else None
-        target_match = (
-            patterns[source_stage + 1].fullmatch(target) if source_stage else None
+    elif planned in {"scatter", "bubble"}:
+        valid = valid and all(field_type in numeric for field_type in types[1:])
+    elif planned == "funnel":
+        valid = valid and types[1] in numeric
+    elif planned == "heatmap":
+        valid = valid and types[2] in numeric
+    elif planned == "sankey":
+        valid = valid and types[:2] == ["STRING", "STRING"] and types[2] in numeric
+    elif planned == "table":
+        dimension_count = section.get("dimension_count", 0)
+        valid = valid and all(
+            field_type in numeric
+            for field_type in types[dimension_count:]
         )
-        if source_match is None or target_match is None:
-            allowed = "または".join(
-                f"{stage}→{stage + 1}" for stage in range(1, navigation_depth)
-            )
-            raise LiveDemoError(
-                f"回遊の段階が{allowed}になっていないため描画しません。"
-            )
-        source_page, target_page = source_match.group(1), target_match.group(1)
-        if source_page == target_page:
-            raise LiveDemoError(
-                "回遊の連続する同一ページが遷移として含まれるため描画しません。"
-            )
-        edge = (source, target)
-        if edge in seen_edges:
-            raise LiveDemoError("回遊に未集約の重複edgeが含まれるため描画しません。")
-        seen_edges.add(edge)
-        sources[source_stage].add(source_page)
-        targets[source_stage].add(target_page)
-        sessions = Decimal(str(_sessions))
-        outgoing[(source_stage, source_page)] = outgoing.get(
-            (source_stage, source_page), Decimal(0)
-        ) + sessions
-        incoming[(source_stage + 1, target_page)] = incoming.get(
-            (source_stage + 1, target_page), Decimal(0)
-        ) + sessions
-    connected = bool(sources[1]) and all(
-        not sources[stage] or sources[stage].issubset(targets[stage - 1])
-        for stage in range(2, navigation_depth)
+    if not valid:
+        observed = "、".join(f"{name}:{field_type}" for name, field_type in schema)
+        raise LiveDemoError(
+            f"{section['title']}のdry run出力（{observed}）が{planned}の描画仕様と"
+            "一致しないためBigQueryを実行しません。"
+        )
+
+
+def valid_sankey_result(rows: list[tuple]) -> bool:
+    """Validate Sankey rows without inferring a visualization from their shape."""
+    numeric = (int, float, Decimal)
+
+    def stage(value: str) -> int | None:
+        match = re.match(r"^(\d+)\.", value.strip())
+        return int(match.group(1)) if match else None
+
+    return bool(rows) and all(
+        len(row) == 3
+        and isinstance(row[0], str)
+        and isinstance(row[1], str)
+        and isinstance(row[2], numeric)
+        and math.isfinite(float(row[2]))
+        and row[2] >= 0
+        and stage(row[0]) is not None
+        and stage(row[1]) == stage(row[0]) + 1
+        and stage(row[1]) <= MAX_SANKEY_PAGES
+        for row in rows
     )
-    if not connected:
-        message = (
-            "回遊の1段目と2段目が接続しないため描画しません。"
-            if navigation_depth == 3
-            else "回遊の段階間が接続しないため描画しません。"
-        )
-        raise LiveDemoError(message)
-    if navigation_depth > 3:
-        has_every_hop = all(sources[stage] for stage in range(1, navigation_depth))
-        conserves_flow = all(
-            sources[stage] == targets[stage - 1]
-            and all(
-                incoming.get((stage, page), Decimal(0))
-                == outgoing.get((stage, page), Decimal(0))
-                for page in sources[stage]
-            )
-            for stage in range(2, navigation_depth)
-        )
-        if not has_every_hop or not conserves_flow:
-            raise LiveDemoError(
-                f"回遊が要求された{navigation_depth}ページ目まで到達しないため描画しません。"
-            )
 
 
 def dashboard_visualization(section: dict, rows: list[tuple], columns: list[str]) -> str:
     """Validate a planned panel's result shape before choosing its renderer."""
-    component = section["component"]
     planned = section.get("planned_visualization")
-    if planned:
-        if planned == "table":
-            return "table"
-        observed = visualization_for_result(rows, columns)
-        expected = {"scorecard": "scalar"}.get(planned, planned)
-        if observed != expected:
-            raise LiveDemoError(
-                f"{section['title']}の結果形状がAI分析仕様の{planned}と一致しないため"
-                "描画しません。"
-            )
-        return observed
+    if not planned:
+        raise LiveDemoError(
+            f"{section['title']}にAIが確定した描画仕様がないため実行しません。"
+        )
     numeric = (int, float, Decimal)
-    valid = True
-    if component == "kpi_pair":
-        valid = (
-            len(rows) == 1
-            and len(columns) == 2
-            and len(rows[0]) == 2
-            and all(isinstance(value, numeric) for value in rows[0])
+    finite = lambda value: isinstance(value, numeric) and math.isfinite(float(value))
+    nullable_finite = lambda value: value is None or finite(value)
+    width = len(columns)
+    valid = all(len(row) == width for row in rows)
+    if planned == "scorecard":
+        valid = valid and width == 1 and (not rows or len(rows) == 1 and finite(rows[0][0]))
+    elif planned == "kpi_group":
+        valid = valid and 2 <= width <= 4 and (
+            not rows or len(rows) == 1 and all(finite(value) for value in rows[0])
         )
-    elif component == "funnel":
-        valid = (
-            len(rows) == 1
-            and len(columns) == 3
-            and len(rows[0]) == 3
-            and all(
-                isinstance(value, numeric) and math.isfinite(float(value)) and value >= 0
-                for value in rows[0]
-            )
+    elif planned == "bar":
+        valid = valid and width == 2 and all(
+            finite(row[1]) and row[1] >= 0 for row in rows
         )
-    elif component == "trend":
-        valid = (
-            bool(rows)
-            and len(columns) == 3
-            and all(
-                len(row) == 3
-                and isinstance(row[0], (date, datetime))
-                and all(
-                    isinstance(value, numeric) and math.isfinite(float(value))
-                    for value in row[1:]
-                )
-                for row in rows
-            )
+    elif planned in {"grouped_bar", "stacked_bar"}:
+        valid = valid and 3 <= width <= 5 and all(
+            all(finite(value) and value >= 0 for value in row[1:]) for row in rows
         )
-    elif component == "sankey":
-        valid = visualization_for_result(rows, columns) == "sankey"
+    elif planned == "line":
+        valid = valid and width == 2 and all(
+            isinstance(row[0], (date, datetime)) and nullable_finite(row[1]) for row in rows
+        )
+    elif planned == "multi_line":
+        valid = valid and 3 <= width <= 5 and all(
+            isinstance(row[0], (date, datetime))
+            and all(nullable_finite(value) for value in row[1:])
+            for row in rows
+        )
+    elif planned == "scatter":
+        valid = valid and width == 3 and all(
+            finite(row[1]) and finite(row[2]) for row in rows
+        )
+    elif planned == "bubble":
+        valid = valid and width == 4 and all(
+            finite(row[1]) and finite(row[2]) and finite(row[3]) and row[3] >= 0
+            for row in rows
+        )
+    elif planned == "funnel":
+        valid = valid and width == 2 and all(finite(row[1]) and row[1] >= 0 for row in rows)
+    elif planned == "heatmap":
+        valid = valid and width == 3 and all(finite(row[2]) for row in rows)
+    elif planned == "table":
+        valid = valid and width >= 1
+    elif planned == "sankey":
+        valid = valid and (not rows or valid_sankey_result(rows))
+    else:
+        valid = False
     if not valid:
         raise LiveDemoError(
-            f"{section['title']}の結果形状がダッシュボード仕様と一致しないため描画しません。"
+            f"{section['title']}の結果形状がAI分析仕様の{planned}と一致しないため"
+            "描画しません。"
         )
-    if component == "sankey" and section.get("transition_mode") == "page_navigation":
-        validate_navigation_sankey(rows, section.get("navigation_depth", 3))
-    if component in {"kpi_pair", "funnel", "trend", "sankey"}:
-        return component
-    return visualization_for_result(rows, columns)
+    return "scalar" if planned == "scorecard" else planned
 
 
 class LiveQueryEngine:
@@ -1159,7 +1208,6 @@ class LiveQueryEngine:
         from google import genai
         from google.cloud import bigquery
         self.model = model
-        self.spec = json.loads((HERE / "report.json").read_text(encoding="utf-8"))
         self.metric_definitions = json.loads(
             (HERE / "metrics.json").read_text(encoding="utf-8")
         )
@@ -1228,13 +1276,20 @@ class LiveQueryEngine:
     ) -> None:
         cancel_event = self._begin_operation(request_id)
         try:
-            if profile == "bitcoin":
-                section = bitcoin.section(question)
-                period = bitcoin.period_for_question(question)
+            if analysis_specification is not None:
+                try:
+                    period, section = analysis_section_for_specification(
+                        question, analysis_specification, profile
+                    )
+                except (ValueError, planner.PlannerError) as error:
+                    raise LiveDemoError(str(error)) from error
             else:
-                section = section_for_question(self.spec, question)
-                period = period_for_question(question)
-            self._run_section(section, period, emit, profile=profile)
+                raise LiveDemoError(
+                    "AIが作成した分析仕様を選択してからbuildしてください。"
+                )
+            self._run_section(
+                section, period, emit, profile=profile, cancel_event=cancel_event
+            )
         finally:
             self._finish_operation()
 
@@ -1285,43 +1340,24 @@ class LiveQueryEngine:
         cancel_event = self._begin_operation(request_id)
         try:
             self.latest_dashboard = None
-            try:
-                confirmed = (
-                    confirm_dashboard_analysis_plan(analysis_plan) if analysis_plan else None
+            if analysis_plan is None:
+                raise LiveDemoError(
+                    "AIが作成した分析仕様を確定してからbuildしてください。"
                 )
+            try:
+                confirmed = planner.confirm_dashboard_plan(analysis_plan)
             except planner.PlannerError as error:
                 raise LiveDemoError(str(error)) from error
-            dynamic_plan = bool(
-                confirmed
-                and all("execution_prompt" in panel for panel in confirmed["panels"])
-            )
-            if dynamic_plan:
-                period, sections = dashboard_sections_for_plan(question, confirmed)
-                layout_rows = dashboard_layout_rows_for_plan(confirmed["panels"])
-            else:
-                panel_ids = (
-                    [panel["id"] for panel in confirmed["panels"]]
-                    if confirmed
-                    else None
-                )
-                period, sections = dashboard_sections(self.spec, question, panel_ids)
-                layout_rows = dashboard_layout_rows(
-                    [section["id"] for section in sections]
-                )
-                if confirmed and confirmed["period"] != period:
-                    raise LiveDemoError(
-                        "確定した分析仕様の対象期間が依頼文と一致しません。"
-                    )
+            period, sections = dashboard_sections_for_plan(question, confirmed)
+            layout_rows = dashboard_layout_rows_for_plan(confirmed["panels"])
             emit(
                 {
                     "type": "dashboard_plan",
                     "period": period["label"],
-                    "plan_revision": confirmed["revision"] if confirmed else "legacy-demo",
-                    "organization_context_revision": (
-                        confirmed["organization_context_revision"]
-                        if confirmed
-                        else "not-attached"
-                    ),
+                    "plan_revision": confirmed["revision"],
+                    "organization_context_revision": confirmed[
+                        "organization_context_revision"
+                    ],
                     "panels": [
                         {
                             "id": section["id"],
@@ -1380,36 +1416,34 @@ class LiveQueryEngine:
                         + hashlib.sha256(result_canonical.encode()).hexdigest()[:12]
                     )
                     evidence_panels.append(evidence)
-            bundle = None
-            if confirmed:
-                bundle = {
-                    "plan_revision": confirmed["revision"],
-                    "organization_context_revision": confirmed[
-                        "organization_context_revision"
-                    ],
-                    "organization_context": planner.ORGANIZATION_CONTEXT,
-                    "analysis_specification": {
-                        "revision": confirmed["revision"],
-                        "objective": confirmed["objective_summary"],
-                        "audience": confirmed["audience"],
-                        "comparison": confirmed["comparison"],
-                        "period": confirmed["period"],
-                        "hypotheses": confirmed["hypotheses"],
-                    },
-                    "metric_definitions": self.metric_definitions,
-                    "panels": evidence_panels,
-                }
-                canonical = json.dumps(bundle, ensure_ascii=False, sort_keys=True)
-                bundle["build_revision"] = (
-                    "build-" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
-                )
-                self.latest_dashboard = bundle
+            bundle = {
+                "plan_revision": confirmed["revision"],
+                "organization_context_revision": confirmed[
+                    "organization_context_revision"
+                ],
+                "organization_context": confirmed["organization_context"],
+                "analysis_specification": {
+                    "revision": confirmed["revision"],
+                    "objective": confirmed["objective_summary"],
+                    "audience": confirmed["audience"],
+                    "comparison": confirmed["comparison"],
+                    "period": confirmed["period"],
+                    "hypotheses": confirmed["hypotheses"],
+                },
+                "metric_definitions": self.metric_definitions,
+                "panels": evidence_panels,
+            }
+            canonical = json.dumps(bundle, ensure_ascii=False, sort_keys=True)
+            bundle["build_revision"] = (
+                "build-" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
+            )
+            self.latest_dashboard = bundle
             emit(
                 {
                     "type": "dashboard_complete",
                     "panel_count": len(sections),
                     "cost_jpy": round(total_cost, 3),
-                    "build_revision": bundle["build_revision"] if bundle else None,
+                    "build_revision": bundle["build_revision"],
                 }
             )
         finally:
@@ -1494,6 +1528,15 @@ class LiveQueryEngine:
     ) -> float:
         """Generate, validate, execute, and optionally verify one panel."""
         extra = context or {}
+        if not section.get("planned_visualization"):
+            raise LiveDemoError(
+                f"{section['title']}にAIが確定した描画仕様がないため実行しません。"
+            )
+        cancel_event = (
+            cancel_event
+            or getattr(self, "active_cancel_event", None)
+            or threading.Event()
+        )
 
         def send(event: dict) -> None:
             emit({**event, **extra})
@@ -1518,6 +1561,7 @@ class LiveQueryEngine:
                 self.client, self.model, section, period, self.rules
             )
             allowed_dataset = report.DATASET
+        self._check_cancelled(cancel_event)
         cost = (
             usage["input_tokens"] * report.PRICING[self.model][0]
             + usage["output_tokens"] * report.PRICING[self.model][1]
@@ -1542,20 +1586,102 @@ class LiveQueryEngine:
         assert normalized is not None
         try:
             if profile == "bitcoin":
-                normalized = bitcoin.quote_reserved_hash_identifiers(normalized)
+                bitcoin.require_quoted_hash(normalized)
                 bitcoin.require_sql_period(normalized, period)
             else:
                 require_sql_period(normalized, period)
-                if section.get("transition_mode") == "page_navigation":
-                    require_deterministic_navigation_order(
-                        normalized, section.get("navigation_depth", 3)
-                    )
-                    if section.get("require_full_navigation_depth"):
-                        require_complete_navigation_depth(
-                            normalized, section["navigation_depth"]
-                        )
         except ValueError as error:
             raise LiveDemoError(str(error)) from error
+        self._check_cancelled(cancel_event)
+        send(
+            {
+                "type": "stage",
+                "stage": "validate",
+                "message": "描画仕様とBigQuery dry runの出力schemaを照合中です。",
+            }
+        )
+        analysis_request = (
+            bitcoin.generation_request(section, period)
+            if profile == "bitcoin"
+            else report.generation_request(section, period)
+        )
+        repair_used = False
+        dry_schema = None
+        while True:
+            diagnostic = ""
+            try:
+                validate_generated_dashboard_sql(section, normalized)
+            except LiveDemoError as validation_error:
+                diagnostic = str(validation_error)
+            if not diagnostic:
+                dry_schema, error = report.inspect_bq_schema(
+                    self.bq, normalized, allowed_dataset=allowed_dataset
+                )
+                if error:
+                    if not report.repairable_dry_run_error(error):
+                        raise LiveDemoError(f"BigQuery dry runに失敗しました: {error}")
+                    diagnostic = error
+                else:
+                    assert dry_schema is not None
+                    try:
+                        validate_dashboard_dry_run_schema(section, dry_schema)
+                    except LiveDemoError as validation_error:
+                        diagnostic = str(validation_error)
+            if not diagnostic:
+                break
+            if repair_used:
+                raise LiveDemoError(
+                    "SQL担当AIで1回修正しましたが、実行前診断を解消できなかったため"
+                    f"実行しません: {diagnostic}"
+                )
+            send(
+                {
+                    "type": "stage",
+                    "stage": "repair",
+                    "message": "実行前診断をもとにSQLを1回修正中です。",
+                }
+            )
+            repaired, repair_usage = report.repair(
+                self.client,
+                self.model,
+                analysis_request,
+                normalized,
+                diagnostic,
+                self.bitcoin_rules if profile == "bitcoin" else self.rules,
+            )
+            cost += (
+                repair_usage["input_tokens"] * report.PRICING[self.model][0]
+                + repair_usage["output_tokens"] * report.PRICING[self.model][1]
+            ) / 1e6 * report.USD_JPY
+            self._check_cancelled(cancel_event)
+            repaired_sql = (repaired.get("sql") or "").strip()
+            if not repaired_sql:
+                reason = (repaired.get("reason") or "").strip()
+                detail = f" 理由: {reason}" if reason else ""
+                raise LiveDemoError(
+                    "SQL担当AIが実行前診断を解消できなかったため実行しません。"
+                    + detail
+                )
+            normalized, validation_error = report.validate_sql(
+                repaired_sql, allowed_dataset
+            )
+            if validation_error:
+                raise LiveDemoError(
+                    f"修正SQLを安全検査で拒否しました: {validation_error}"
+                )
+            assert normalized is not None
+            try:
+                if profile == "bitcoin":
+                    bitcoin.require_quoted_hash(normalized)
+                    bitcoin.require_sql_period(normalized, period)
+                else:
+                    require_sql_period(normalized, period)
+            except ValueError as repair_error:
+                raise LiveDemoError(str(repair_error)) from repair_error
+            answer = repaired
+            repair_used = True
+        assert dry_schema is not None
+        self._check_cancelled(cancel_event)
         send(
             {
                 "type": "sql",
@@ -1571,58 +1697,31 @@ class LiveQueryEngine:
                 "message": "BigQueryで読み取り実行中です。",
             }
         )
+        max_result_rows = section.get("max_result_rows", MAX_RESULT_ROWS)
         result, error = report.exec_bq(
             self.bq,
             normalized,
-            max_results=MAX_RESULT_ROWS + 1,
+            max_results=max_result_rows + 1,
             allowed_dataset=allowed_dataset,
+            cancel_event=cancel_event,
         )
+        if error == "cancelled":
+            raise LiveDemoCancelled("処理を停止しました。")
         if error:
             raise LiveDemoError(f"BigQuery実行に失敗しました: {error}")
         assert result is not None
         rows, columns = result
-        if len(rows) > MAX_RESULT_ROWS:
+        if len(rows) > max_result_rows:
             raise LiveDemoError(
-                f"結果が{MAX_RESULT_ROWS}行を超えたため描画しません。集計条件を追加してください。"
+                f"結果が{max_result_rows}行を超えたため描画しません。"
+                "集計条件を追加してください。"
             )
         verification, label = "unverified", "実行済み・既知値未照合"
-        if section["verification"] == "reference":
-            wanted, error = report.exec_bq(
-                self.bq, section["gold_sql"], allowed_dataset=allowed_dataset
-            )
-            if error:
-                raise LiveDemoError("登録済み参照SQLの実行に失敗しました。")
-            assert wanted is not None
-            matches, detail = report.compare(section["compare"], rows, wanted[0])
-            verification = "matched" if matches else "mismatch"
-            label = (
-                "実行・参照値照合済み"
-                if matches
-                else f"参照値と不一致: {detail}"
-            )
-            if not matches:
-                raise LiveDemoError(
-                    f"{section['title']}の結果が登録済み参照値と一致しないため描画しません。"
-                )
-        if not context and section.get("transition_mode") == "page_navigation":
-            if visualization_for_result(rows, columns) != "sankey":
-                raise LiveDemoError(
-                    f"{section['title']}の結果形状が回遊仕様と一致しないため描画しません。"
-                )
-            validate_navigation_sankey(rows, section.get("navigation_depth", 3))
-        visualization = (
-            dashboard_visualization(section, rows, columns)
-            if context
-            else visualization_for_result(rows, columns)
-        )
+        visualization = dashboard_visualization(section, rows, columns)
         send(
             {
                 "type": "result",
-                "columns": (
-                    section.get("shape", {}).get("columns", columns)
-                    if context
-                    else columns
-                ),
+                "columns": section.get("shape", {}).get("columns", columns),
                 "source_columns": columns,
                 "rows": [[json_value(value) for value in row] for row in rows],
                 "visualization": visualization,
@@ -1738,7 +1837,7 @@ class LiveDemoHandler(BaseHTTPRequestHandler):
                     total_history_chars += len(turn["content"])
                 if total_history_chars > 3000:
                     raise ValueError("history is too large")
-                if not question.strip() or len(question) > report.MAX_QUESTION_CHARS:
+                if not question.strip() or len(question) > MAX_QUESTION_CHARS:
                     raise ValueError("consultation question is invalid")
             elif self.path == "/api/report":
                 if not isinstance(build_revision, str) or not re.fullmatch(
@@ -1752,41 +1851,34 @@ class LiveDemoHandler(BaseHTTPRequestHandler):
                     raise ValueError(
                         "analysis_plan and revision_instruction must be provided together"
                     )
-                report.select_sections(self.engine.spec, question)
                 period_for_question(question)
                 if analysis_plan is not None:
                     planner.confirm_dashboard_plan(analysis_plan)
             elif self.path == "/api/dashboard":
                 if profile != "ga4":
                     raise ValueError("dashboard mode currently supports only ga4")
-                confirmed = (
-                    confirm_dashboard_analysis_plan(analysis_plan)
-                    if analysis_plan
-                    else None
-                )
-                if confirmed and all(
-                    "execution_prompt" in panel for panel in confirmed["panels"]
-                ):
-                    dashboard_sections_for_plan(question, confirmed)
-                else:
-                    dashboard_sections(
-                        self.engine.spec,
-                        question,
-                        [panel["id"] for panel in confirmed["panels"]]
-                        if confirmed
-                        else None,
+                if analysis_plan is None:
+                    raise ValueError(
+                        "AIが作成した分析仕様を確定してからbuildしてください。"
                     )
-            elif requires_analysis_consultation(question):
+                confirmed = planner.confirm_dashboard_plan(analysis_plan)
+                dashboard_sections_for_plan(question, confirmed)
+            elif analysis_specification is None:
                 raise ValueError(
-                    "分析内容が具体化されていません。相談から分析候補を選び、"
-                    "期間・指標・比較軸を確定してください。"
+                    "AIが作成した分析仕様を選択してからbuildしてください。"
                 )
             elif profile == "bitcoin":
-                bitcoin.section(question)
-                bitcoin.period_for_question(question)
-            else:
-                section_for_question(self.engine.spec, question)
-                period_for_question(question)
+                confirmed = planner.confirm_analysis_specification(
+                    analysis_specification
+                )
+                analysis_section_for_specification(question, confirmed, profile)
+                analysis_specification = confirmed
+            elif analysis_specification is not None:
+                confirmed = planner.confirm_analysis_specification(
+                    analysis_specification
+                )
+                analysis_section_for_specification(question, confirmed, profile)
+                analysis_specification = confirmed
         except (ValueError, json.JSONDecodeError, LiveDemoError, planner.PlannerError) as error:
             self._send_json(400, {"error": str(error)})
             return
@@ -1845,7 +1937,22 @@ class LiveDemoHandler(BaseHTTPRequestHandler):
                 print("live query failed: Google authentication expired", flush=True)
                 emit({"type": "error", "message": recovery_message})
                 return
-            print(f"live query failed: {type(error).__name__}", flush=True)
+            provider_message = vertex_ai_error_message(error)
+            if provider_message:
+                provider_detail = " ".join(
+                    str(getattr(error, "message", "") or "").split()
+                )[:500]
+                print(
+                    "live query failed: "
+                    f"{type(error).__name__} code={getattr(error, 'code', None)} "
+                    f"status={getattr(error, 'status', None)} "
+                    f"message={provider_detail or '-'}",
+                    flush=True,
+                )
+                emit({"type": "error", "message": provider_message})
+                return
+            print("live query failed with an unexpected exception:", flush=True)
+            traceback.print_exc()
             emit({"type": "error", "message": "生成または実行に失敗しました。端末ログを確認してください。"})
     def _headers(self, content_type: str) -> None:
         self.send_header("content-type", content_type)

--- a/spikes/report-generation/run_report.py
+++ b/spikes/report-generation/run_report.py
@@ -39,7 +39,6 @@ PRICING = {
     "gemini-3.5-flash": (1.50, 9.00),
 }  # USD per 1M tokens (in, out)
 MAX_QUESTION_CHARS = 500
-SHOWCASE_IDS = ("R4", "R11", "R12", "R9", "R16", "R17")
 
 # Hand-transcribed from the public sample. Deliberately the raw export shape:
 # no semantic layer, no pre-aggregation. That is the point of the measurement.
@@ -402,30 +401,8 @@ def compare(kind: str, got, want):
     raise ValueError(kind)
 
 
-def select_sections(
-    spec: dict, question: str | None, showcase: bool = False
-) -> list[dict]:
-    """Select the full regression report or one operator-supplied question."""
-    if showcase and question is not None:
-        raise ValueError("showcase and question modes are mutually exclusive")
-    if showcase:
-        by_id = {section["id"]: section for section in spec["sections"]}
-        components = {
-            "R4": "kpi_pair",
-            "R11": "big_value",
-            "R12": "big_value",
-            "R9": "funnel",
-            "R16": "trend",
-            "R17": "sankey",
-        }
-        return [
-            {
-                **by_id[section_id],
-                "component": components[section_id],
-                "verification": "reference",
-            }
-            for section_id in SHOWCASE_IDS
-        ]
+def sections_for_run(spec: dict, question: str | None) -> list[dict]:
+    """Return the regression suite or one unmodified operator-supplied question."""
     if question is None:
         return [{**section, "verification": "reference"} for section in spec["sections"]]
 
@@ -436,10 +413,6 @@ def select_sections(
         raise ValueError(f"question must be at most {MAX_QUESTION_CHARS} characters")
     if any(ord(char) < 32 for char in normalized):
         raise ValueError("question must be a single line without control characters")
-
-    for section in spec["sections"]:
-        if section["text"].strip() == normalized:
-            return [{**section, "verification": "reference"}]
 
     return [
         {
@@ -914,7 +887,7 @@ def main() -> int:
 
     spec = json.loads((HERE / "report.json").read_text(encoding="utf-8"))
     try:
-        sections = select_sections(spec, args.question)
+        sections = sections_for_run(spec, args.question)
     except ValueError as error:
         print(str(error), file=sys.stderr)
         return 2

--- a/tests/spikes/report-generation/analysis-planner.test.ts
+++ b/tests/spikes/report-generation/analysis-planner.test.ts
@@ -23,7 +23,7 @@ genai.types=types.SimpleNamespace(GenerateContentConfig=GenerateContentConfig)
 google.genai=genai;sys.modules["google"]=google;sys.modules["google.genai"]=genai
 period={"from":"20210101","to":"20210131","label":"2021年1月"}
 def panel(index,chart="bar"):
- return {"title":f"分析{index}","kpi":f"指標{index}","chart":chart,"decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の定義済み指標{index}を区分別に出して"}
+ return {"title":f"分析{index}","kpi":f"指標{index}","chart":chart,"decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の定義済み指標{index}を区分別に出して","dimensions":["区分"],"measures":[f"定義済み指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
 base={
  "objective_summary":"購入成果の阻害箇所を特定して優先施策を決める",
  "audience":"月次マーケティング会議",
@@ -42,6 +42,7 @@ confirmed=p.confirm_dashboard_plan(second)
 errors=[]
 for changed in [
  {**base,"panels":[]},
+ {**base,"panels":[panel(index) for index in range(1,22)]},
  {**base,"panels":[*base["panels"][:5],base["panels"][0]]},
  {**base,"panels":[*base["panels"][:5],{**panel(6),"execution_prompt":"SELECT * FROM events"}]},
 ]:
@@ -51,7 +52,7 @@ print(json.dumps({
  "first_status":first["status"],"question_count":len(first["clarifications"]),
  "revision_stable":first["revision"]==p.normalize_dashboard_plan(base,first["objective"],period,{})["revision"],
  "confirmed_status":confirmed["status"],"revision_changed":confirmed["revision"]!=first["revision"],
- "context":confirmed["organization_context_revision"],"panel_ids":[item["id"] for item in confirmed["panels"]],
+ "context":confirmed["organization_context_revision"].startswith("context-") and confirmed["organization_context"]["objective"]==first["objective"],"panel_ids":[item["id"] for item in confirmed["panels"]],
  "frozen_prompt":confirmed["panels"][0]["execution_prompt"],
  "errors":errors,
 },ensure_ascii=False))`,
@@ -65,10 +66,11 @@ print(json.dumps({
     revision_stable: true,
     confirmed_status: 'confirmed',
     revision_changed: true,
-    context: 'demo-org-ec-v1',
+    context: true,
     panel_ids: ['P1', 'P2', 'P3', 'P4', 'P5', 'P6'],
     frozen_prompt: '2021年1月の定義済み指標1を区分別に出して',
     errors: [
+      '分析計画のパネルは1〜20件にしてください。',
       '分析計画のパネルは1〜20件にしてください。',
       '分析計画に重複した実行仕様があります。',
       '分析計画の実行仕様にはSQLを書けません。',
@@ -86,18 +88,228 @@ spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)}
 p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
 request=p.dashboard_planning_request("目的",{"label":"2021年1月"},"指標定義",{})
 panels=p._dashboard_response_schema({})["properties"]["panels"]
-print(json.dumps({"context":p.ORGANIZATION_CONTEXT["revision"] in request,"metrics":"指標定義" in request,"new_specs":"分析仕様そのものを新規" in request,"fixed_ids":any(panel_id in request for panel_id in p.PANEL_CATALOG),"count":[panels["minItems"],panels["maxItems"]],"questions":"確認を1〜3件" in request},ensure_ascii=False))`,
+print(json.dumps({"fixed_context":"demo-org-ec-v1" in request,"metrics":"指標定義" in request,"new_specs":"分析仕様そのものを新規" in request,"fixed_ids":any(panel_id in request for panel_id in ["R4","R11","R12","R9","R16","R17"]),"count":[panels["minItems"],panels["maxItems"]],"questions":"確認を1〜3件" in request,"sankey_limit":f"最大{p.MAX_SANKEY_PAGES}ページ" in request},ensure_ascii=False))`,
     ],
     { cwd: ROOT, encoding: 'utf8' },
   );
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
-    context: true,
+    fixed_context: false,
     metrics: true,
     new_specs: true,
     fixed_ids: false,
     count: [6, 6],
     questions: true,
+    sankey_limit: true,
+  });
+});
+
+test('program constraints allow every renderer without exposing a chart catalog in prompts', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+shapes={
+ "kpi_group":([], ["指標A","指標B"]),
+ "grouped_bar":(["区分"], ["指標A","指標B"]),
+ "stacked_bar":(["区分"], ["指標A","指標B"]),
+ "multi_line":(["日付"], ["指標A","指標B"]),
+ "scatter":(["項目"], ["指標A","指標B"]),
+ "bubble":(["項目"], ["指標A","指標B","指標C"]),
+ "funnel":(["段階"], ["指標A"]),
+ "heatmap":(["区分A","区分B"], ["指標A"]),
+}
+accepted=[]
+for chart,(dimensions,measures) in shapes.items():
+ prompt="2021年1月の"+"・".join(dimensions+measures)+"を比較する"
+ item={"title":chart,"objective":"判断する","dimensions":dimensions,"measures":measures,"comparison":"比較","chart":chart,"execution_prompt":prompt,"reason":"判断に必要"}
+ accepted.append(p.confirm_analysis_specification(item)["chart"])
+request=p.dashboard_planning_request("目的",{"label":"2021年1月"},"指標定義",{})
+dashboard_variants=p.DYNAMIC_PLAN_SCHEMA["properties"]["panels"]["items"]["properties"]["visualization"]["anyOf"]
+schema_charts=[variant["properties"]["chart"]["enum"][0] for variant in dashboard_variants]
+consultation=p.consultation_request("目的",[],"指標定義","ga4")
+consultation_variants=p._consultation_schema()["properties"]["recommendations"]["items"]["properties"]["visualization"]["anyOf"]
+consultation_charts=[variant["properties"]["chart"]["enum"][0] for variant in consultation_variants]
+seeded_orders=[]
+for index in range(8):
+ variants=p._dashboard_response_schema({},seed=f"依頼{index}")["properties"]["panels"]["items"]["properties"]["visualization"]["anyOf"]
+ seeded_orders.append([variant["properties"]["chart"]["enum"][0] for variant in variants])
+bar=next(variant for variant in dashboard_variants if variant["properties"]["chart"]["enum"]==["bar"])
+bar_shape={name:[bar["properties"][name]["minItems"],bar["properties"][name]["maxItems"]] for name in ["dimensions","measures"]}
+catalog_markers=[f"- {chart}:" for chart in p.DASHBOARD_CHARTS]
+layout_heuristics=["同時に読む組み合わせ","重要度","表示密度","chart typeだけから幅"]
+print(json.dumps({"accepted":accepted,"charts":list(p.DASHBOARD_CHARTS),"schema_charts":schema_charts,"consultation_charts":consultation_charts,"bar_shape":bar_shape,"seeded_complete":all(set(order)==set(p.DASHBOARD_CHARTS) for order in seeded_orders),"seeded_variety":len({tuple(order) for order in seeded_orders})>1,"seeded_stable":seeded_orders[0]==[variant["properties"]["chart"]["enum"][0] for variant in p._dashboard_response_schema({},seed="依頼0")["properties"]["panels"]["items"]["properties"]["visualization"]["anyOf"]],"dashboard_prompt_has_catalog":any(marker in request for marker in catalog_markers),"consultation_prompt_has_catalog":any(marker in consultation for marker in catalog_markers),"has_prompt_capability_constant":hasattr(p,"CHART_CAPABILITY_PROMPT"),"no_intent_pattern":"比較、構成比、時系列、偏り、フロー" not in request,"no_layout_heuristics":all(value not in request for value in layout_heuristics)},ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.accepted, [
+    'kpi_group',
+    'grouped_bar',
+    'stacked_bar',
+    'multi_line',
+    'scatter',
+    'bubble',
+    'funnel',
+    'heatmap',
+  ]);
+  assert.equal(output.charts.length, 13);
+  assert.deepEqual(output.schema_charts, output.charts);
+  assert.deepEqual(output.consultation_charts, output.charts);
+  assert.deepEqual(output.bar_shape, {
+    dimensions: [1, 1],
+    measures: [1, 1],
+  });
+  assert.equal(output.seeded_complete, true);
+  assert.equal(output.seeded_variety, true);
+  assert.equal(output.seeded_stable, true);
+  assert.equal(output.dashboard_prompt_has_catalog, false);
+  assert.equal(output.consultation_prompt_has_catalog, false);
+  assert.equal(output.has_prompt_capability_constant, false);
+  assert.equal(output.no_intent_pattern, true);
+  assert.equal(output.no_layout_heuristics, true);
+});
+
+test('dashboard plans reject chart shapes that cannot be rendered before build', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+period={"from":"20210101","to":"20210131","label":"2021年1月"}
+def raw(dimensions,measures):return {
+ "objective_summary":"成果を確認する","audience":"責任者","comparison":"月内比較",
+ "hypotheses":["成果に差がある"],"clarifications":[],"panels":[{
+  "title":"購入成果","kpi":"購入成果","chart":"scorecard","decision":"規模を判断する",
+  "reason":"成果確認に必要","execution_prompt":"2021年1月の購入金額と購入件数を集計する",
+  "dimensions":dimensions,"measures":measures,"layout_row":1,"layout_weight":1,
+ }]}
+answers={"audience":"責任者","comparison":"月内比較","business_goal":"成果改善"}
+errors=[]
+for dimensions,measures in [(["デバイス"],["購入金額"]),([], ["購入金額","購入件数"])]:
+ try:p.normalize_dashboard_plan(raw(dimensions,measures),"ダッシュボードを作って",period,answers)
+ except p.PlannerError as error:errors.append(str(error))
+print(json.dumps(errors,ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [
+    'scorecardは区分軸なし・指標1件にしてください。 現在案は保持しています。',
+    'scorecardは区分軸なし・指標1件にしてください。 現在案は保持しています。',
+  ]);
+});
+
+test('invalid Sankey output explains expected counts and returns an AI-authored correction', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+raw={
+ "objective_summary":"サイト回遊を改善する","audience":"責任者","comparison":"経路間比較",
+ "hypotheses":["主要経路に偏りがある"],"clarifications":[],"panels":[{
+  "title":"3ページ回遊","kpi":"セッション数","chart":"sankey","decision":"導線を改善する",
+  "reason":"流量を比較するため",
+  "execution_prompt":"2021年1月の1ページ目・2ページ目・3ページ目ごとのセッション数を集計する",
+  "dimensions":["1ページ目","2ページ目","3ページ目"],"measures":["セッション数"],"layout_row":1,"layout_weight":1
+ }]}
+answers={"audience":"責任者","comparison":"経路間比較","business_goal":"回遊改善"}
+try:p.normalize_dashboard_plan(raw,"3ページのサイト回遊も作成して",{"from":"20210101","to":"20210131","label":"2021年1月"},answers)
+except p.PlannerError as error:
+ print(json.dumps({"message":str(error),"suggestion":error.suggested_instruction},ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.match(output.message, /必要なのは区分軸2件・指標1件/);
+  assert.match(output.message, /AI出力は区分軸3件・指標1件/);
+  assert.match(output.message, /現在案は保持/);
+  assert.match(output.suggestion, /2021年1月/);
+  assert.match(output.suggestion, /上位10件/);
+  assert.match(output.suggestion, /遷移元・遷移先の隣接edge/);
+  assert.match(output.suggestion, /区分軸2件とセッション数1指標/);
+});
+
+test('add-only dashboard revisions preserve accepted panels and append a requested Sankey', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json,sys,types
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+google=types.ModuleType("google");genai=types.ModuleType("google.genai")
+class GenerateContentConfig:
+ def __init__(self,**kwargs):self.__dict__.update(kwargs)
+genai.types=types.SimpleNamespace(GenerateContentConfig=GenerateContentConfig)
+google.genai=genai;sys.modules["google"]=google;sys.modules["google.genai"]=genai
+vertex_usage=types.ModuleType("vertex_usage");vertex_usage.token_counts=lambda _usage:{"input_tokens":1,"output_tokens":1};sys.modules["vertex_usage"]=vertex_usage
+period={"from":"20210101","to":"20210131","label":"2021年1月"}
+def panel(index):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分{index}別に集計する","dimensions":[f"区分{index}"],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
+header={"objective_summary":"成果を判断する","audience":"責任者","comparison":"区分比較","hypotheses":["差がある"],"clarifications":[]}
+answers={"audience":"責任者","comparison":"区分比較","business_goal":"成果改善"}
+current=p.normalize_dashboard_plan({**header,"panels":[panel(i) for i in range(1,7)]},"ダッシュボードを作って",period,answers)
+sankey={"title":"サイト内3ページ回遊","kpi":"セッション数","chart":"sankey","decision":"主要な3ページ回遊を判断する","reason":"ページ間の流量を確認するため","execution_prompt":"2021年1月の遷移元ページから遷移先ページまで3ページのセッション数を多い順に集計する","dimensions":["遷移元ページ","遷移先ページ"],"measures":["セッション数"],"layout_row":4,"layout_weight":1}
+addition={**header,"panels":[panel(i) for i in range(1,7)]+[sankey]}
+observed_schema={}
+class Models:
+ def generate_content(self,**kwargs):
+  observed_schema.update(kwargs["config"].response_schema["properties"]["clarifications"])
+  return types.SimpleNamespace(text=json.dumps(addition,ensure_ascii=False),usage_metadata=object())
+plan,_usage=p.propose_dashboard(types.SimpleNamespace(models=Models()),"test-model",current["objective"],period,"指標定義",answers,current_plan=current,instruction="サイト回遊3ページのサンキーダイアグラムも描いて")
+panel_schema=p._dashboard_response_schema(answers,revising=True)["properties"]["panels"]
+print(json.dumps({"count":len(plan["panels"]),"titles":[item["title"] for item in plan["panels"]],"last_chart":plan["panels"][-1]["chart"],"clarification_zero_bound":observed_schema.get("maxItems")==0,"panel_bounds":[panel_schema.get("minItems"),panel_schema.get("maxItems")]},ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    count: 7,
+    titles: ['分析1', '分析2', '分析3', '分析4', '分析5', '分析6', 'サイト内3ページ回遊'],
+    last_chart: 'sankey',
+    clarification_zero_bound: false,
+    panel_bounds: [null, null],
+  });
+});
+
+test('Sankey permits one page attribute in source and target roles without weakening other charts', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+period={"from":"20210101","to":"20210131","label":"2021年1月"}
+def raw(chart):return {
+ "objective_summary":"サイト内行動を判断する","audience":"責任者","comparison":"回遊比較",
+ "hypotheses":["回遊経路に偏りがある"],"clarifications":[],"panels":[{
+  "title":"3ページ回遊","kpi":"セッション数","chart":chart,"decision":"主要経路を判断する",
+  "reason":"回遊を確認するため","execution_prompt":"2021年1月のページからページへの3段階のセッション数を集計する",
+  "dimensions":["ページ","ページ"],"measures":["セッション数"],"layout_row":1,"layout_weight":1,
+ }]}
+answers={"audience":"責任者","comparison":"回遊比較","business_goal":"エンゲージメント改善"}
+accepted=p.normalize_dashboard_plan(raw("sankey"),"2021年1月のサイト内行動を分析する",period,answers)
+try:p.normalize_dashboard_plan(raw("heatmap"),"2021年1月のサイト内行動を分析する",period,answers)
+except p.PlannerError as error:other_error=str(error)
+print(json.dumps({"dimensions":accepted["panels"][0]["dimensions"],"other_error":other_error},ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    dimensions: ['ページ', 'ページ'],
+    other_error: '分析計画の区分軸に重複があります。',
   });
 });
 
@@ -111,7 +323,7 @@ spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)}
 p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
 initial=p._dashboard_response_schema({})["properties"]["panels"]
 revision=p._dashboard_response_schema({},revising=True)["properties"]["panels"]
-print(json.dumps({"initial":p.INITIAL_PANEL_COUNT,"maximum":p.MAX_PANEL_COUNT,"initial_schema":[initial["minItems"],initial["maxItems"]],"revision_schema":[revision["minItems"],revision["maxItems"]]},ensure_ascii=False))`,
+print(json.dumps({"initial":p.INITIAL_PANEL_COUNT,"maximum":p.MAX_PANEL_COUNT,"initial_schema":[initial["minItems"],initial["maxItems"]],"revision_schema":[revision.get("minItems"),revision.get("maxItems")]},ensure_ascii=False))`,
     ],
     {
       cwd: ROOT,
@@ -128,7 +340,7 @@ print(json.dumps({"initial":p.INITIAL_PANEL_COUNT,"maximum":p.MAX_PANEL_COUNT,"i
     initial: 5,
     maximum: 15,
     initial_schema: [5, 5],
-    revision_schema: [1, 15],
+    revision_schema: [null, null],
   });
   for (const [initial, maximum, error] of [
     ['0', '20', 'ANALYSIS_INITIAL_PANEL_COUNT must be a positive integer'],
@@ -148,6 +360,27 @@ print(json.dumps({"initial":p.INITIAL_PANEL_COUNT,"maximum":p.MAX_PANEL_COUNT,"i
   }
 });
 
+test('planner has no fixed organization context or keyword-based revision mode', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+request=p.dashboard_planning_request("目的",{"label":"2021年1月"},"指標定義",{},current_plan={"objective_summary":"目的","audience":"責任者","comparison":"月内","hypotheses":[],"panels":[]},instruction="既存仕様を維持し、流入別も必要です")
+print(json.dumps({"fixed_context":hasattr(p,"ORGANIZATION_CONTEXT") or "demo-org-ec-v1" in request,"revision_heuristic":hasattr(p,"_is_add_only_instruction"),"returns_complete":"変更後の分析仕様をpanelsへすべて返す" in request},ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    fixed_context: false,
+    revision_heuristic: false,
+    returns_complete: true,
+  });
+});
+
 test('dashboard revisions preserve current specifications and accept add/change/delete instructions', () => {
   const result = spawnSync(
     'python3',
@@ -163,7 +396,7 @@ class GenerateContentConfig:
 genai.types=types.SimpleNamespace(GenerateContentConfig=GenerateContentConfig)
 google.genai=genai;sys.modules["google"]=google;sys.modules["google.genai"]=genai
 period={"from":"20210101","to":"20210131","label":"2021年1月"}
-def panel(index):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分別に出して"}
+def panel(index):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分別に出して","dimensions":["区分"],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
 raw={"objective_summary":"購入課題を判断する","audience":"責任者","comparison":"月内比較","hypotheses":["差がある"],"clarifications":[],"panels":[panel(index) for index in range(1,7)]}
 plan=p.normalize_dashboard_plan(raw,"2021年1月の購入課題を分析するダッシュボードを作って",period,{"audience":"責任者"})
 request=p.dashboard_planning_request(plan["objective"],period,"指標定義",plan["answers"],current_plan=plan,instruction="流入別パネルを追加し、分析2を変更して分析3を削除して")
@@ -176,7 +409,7 @@ class Models:
 try:p.propose_dashboard(types.SimpleNamespace(models=Models()),"test-model",plan["objective"],period,"指標定義",plan["answers"],current_plan=plan,instruction="流入別パネルを追加して")
 except p.PlannerError as error:errors.append(str(error))
 mixed,_usage=p.propose_dashboard(types.SimpleNamespace(models=Models()),"test-model",plan["objective"],period,"指標定義",plan["answers"],current_plan=plan,instruction="流入別を追加して分析3を削除して")
-print(json.dumps({"current_specs":all(value in request for value in ["現在の分析仕様","分析1","2021年1月の指標1を区分別に出して"]),"instruction":"流入別パネルを追加" in request,"operations":all(value in request for value in ["追加・変更・削除相談","明示されていない既存パネルは維持","1〜20件"]),"fixed_ids":any(panel_id in request for panel_id in p.PANEL_CATALOG),"mixed_allowed":len(mixed["panels"])==6,"errors":errors},ensure_ascii=False))`,
+print(json.dumps({"current_specs":all(value in request for value in ["現在の分析仕様","分析1","2021年1月の指標1を区分別に出して"]),"instruction":"流入別パネルを追加" in request,"operations":all(value in request for value in ["追加・変更・削除相談","変更後の分析仕様をpanelsへすべて返す","1〜20件"]),"fixed_ids":any(panel_id in request for panel_id in ["R4","R11","R12","R9","R16","R17"]),"mixed_allowed":len(mixed["panels"])==6,"errors":errors},ensure_ascii=False))`,
     ],
     { cwd: ROOT, encoding: 'utf8' },
   );
@@ -190,7 +423,6 @@ print(json.dumps({"current_specs":all(value in request for value in ["現在の�
     errors: [
       '現在案と変更依頼は一緒に指定してください。',
       '現在案と変更依頼は一緒に指定してください。',
-      '追加依頼に対して分析パネルが追加されませんでした。',
     ],
   });
 });
@@ -211,14 +443,14 @@ history=[
 raw={
  "assistant_message":"別の切り口なら流入元を比較できます。",
  "recommendations":[{
-  "title":"流入チャネル別の購入効率",
-  "objective":"集客量だけでなく購入成果につながる流入元を見つける",
-  "metric":"セッション数と購入件数",
-  "dimension":"medium",
+  "title":"流入チャネル別の集客規模",
+  "objective":"集客量が偏っている流入元を見つける",
+  "dimensions":["medium"],
+  "measures":["セッション数"],
   "comparison":"2021年1月の流入チャネル間比較",
   "chart":"bar",
-  "execution_prompt":"2021年1月のセッション数と購入件数を流入チャネル（medium）別に出して",
-  "reason":"集客の偏りと成果の両方を判断できるため"
+  "execution_prompt":"2021年1月のセッション数を流入チャネル（medium）別に出して",
+  "reason":"集客の偏りを判断できるため"
  }],
  "follow_up_question":"成果と集客のどちらを優先しますか？",
 }
@@ -229,12 +461,16 @@ for invalid in [
  {**raw,"recommendations":[raw["recommendations"][0],raw["recommendations"][0]]},
  {**raw,"recommendations":[{**raw["recommendations"][0],"execution_prompt":"SELECT * FROM events"}]},
  {**raw,"recommendations":[{**raw["recommendations"][0],"reason":""}]},
+ {**raw,"recommendations":[{**raw["recommendations"][0],"dimensions":[]}]},
 ]:
  try:p.normalize_consultation(invalid)
  except p.PlannerError as error:errors.append(str(error))
 print(json.dumps({
  "titles":[item["title"] for item in normalized["recommendations"]],
  "generated_prompt":normalized["recommendations"][0]["execution_prompt"],
+ "dimensions":normalized["recommendations"][0]["dimensions"],
+ "measures":normalized["recommendations"][0]["measures"],
+ "revision":normalized["recommendations"][0]["revision"],
  "history_in_request":all(item["content"] in request for item in history),
  "current_in_request":"他にない？" in request,
  "context_in_request":"medium" in request,
@@ -244,9 +480,14 @@ print(json.dumps({
     { cwd: ROOT, encoding: 'utf8' },
   );
   assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), {
-    titles: ['流入チャネル別の購入効率'],
-    generated_prompt: '2021年1月のセッション数と購入件数を流入チャネル（medium）別に出して',
+  const output = JSON.parse(result.stdout);
+  assert.match(output.revision, /^insight-[0-9a-f]{12}$/);
+  delete output.revision;
+  assert.deepEqual(output, {
+    titles: ['流入チャネル別の集客規模'],
+    generated_prompt: '2021年1月のセッション数を流入チャネル（medium）別に出して',
+    dimensions: ['medium'],
+    measures: ['セッション数'],
     history_in_request: true,
     current_in_request: true,
     context_in_request: true,
@@ -254,6 +495,7 @@ print(json.dumps({
       '分析相談に重複した候補があります。',
       '分析相談の実行依頼にはSQLを書けません。',
       '分析相談の候補理由が空です。',
+      'AIが生成したbar仕様を描画できません。必要なのは区分軸1件・指標1件ですが、AI出力は区分軸0件・指標1件でした。',
     ],
   });
 });
@@ -273,12 +515,13 @@ class GenerateContentConfig:
 genai.types=types.SimpleNamespace(GenerateContentConfig=GenerateContentConfig)
 google.genai=genai;sys.modules["google"]=google;sys.modules["google.genai"]=genai
 period={"from":"20210101","to":"20210131","label":"2021年1月"}
+def panel(index):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":"目的に必要","execution_prompt":f"2021年1月の指標{index}を1行で出す","dimensions":[],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
 base={
  "objective_summary":"購入成果の阻害箇所を特定して優先施策を決める",
  "audience":"月次マーケティング会議",
  "comparison":"月内の日次推移とファネル段階",
  "hypotheses":["商品閲覧からカート追加への減少が大きい"],
- "panels":[{"id":panel_id,"reason":"目的に必要"} for panel_id in ["R4","R9","R16","R17"]],
+ "panels":[panel(index) for index in range(1,7)],
 }
 responses=[
  {**base,"clarifications":[{"field":"channel","question":"流入は","recommended_answer":"organic"}]},
@@ -308,7 +551,7 @@ answer_sets=[
  {"audience":"月次マーケティング会議","comparison":"前月","business_goal":"購入成果改善"},
 ]
 for answers in answer_sets:
- try:p.propose(client,"test-model","目的",period,"指標定義",answers)
+ try:p.propose_dashboard(client,"test-model","目的",period,"指標定義",answers)
  except p.PlannerError as error:errors.append(str(error))
 print(json.dumps({"calls":calls,"schemas":schemas,"errors":errors},ensure_ascii=False))`,
     ],
@@ -364,7 +607,7 @@ raw={
  "comparison":"月内の日次推移",
  "hypotheses":["購入導線に減少箇所がある"],
  "clarifications":[],
- "panels":[{"id":panel_id,"reason":"目的に必要"} for panel_id in ["R4","R9","R16","R17"]],
+ "panels":[{"title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":"目的に必要","execution_prompt":f"2021年1月の指標{index}を1行で出す","dimensions":[],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1} for index in range(1,7)],
 }
 usage=[
  types.SimpleNamespace(prompt_token_count=10,candidates_token_count=5,thoughts_token_count=7),
@@ -379,9 +622,9 @@ class Models:
 client=types.SimpleNamespace(models=Models())
 period={"from":"20210101","to":"20210131","label":"2021年1月"}
 answers={"audience":"月次マーケティング会議"}
-first=p.propose(client,"test-model","目的",period,"指標定義",answers)[1]
-legacy=p.propose(client,"test-model","目的",period,"指標定義",answers)[1]
-print(json.dumps({"calls":calls,"first":first,"legacy":legacy},ensure_ascii=False))`,
+first=p.propose_dashboard(client,"test-model","目的",period,"指標定義",answers)[1]
+without_thoughts=p.propose_dashboard(client,"test-model","目的",period,"指標定義",answers)[1]
+print(json.dumps({"calls":calls,"first":first,"without_thoughts":without_thoughts},ensure_ascii=False))`,
     ],
     { cwd: ROOT, encoding: 'utf8' },
   );
@@ -389,11 +632,11 @@ print(json.dumps({"calls":calls,"first":first,"legacy":legacy},ensure_ascii=Fals
   assert.deepEqual(JSON.parse(result.stdout), {
     calls: 2,
     first: { input_tokens: 10, output_tokens: 12 },
-    legacy: { input_tokens: 10, output_tokens: 5 },
+    without_thoughts: { input_tokens: 10, output_tokens: 5 },
   });
 });
 
-test('confirmed plan requires a non-empty answer for every displayed clarification', () => {
+test('confirmed dynamic plan requires a non-empty answer for every displayed clarification', () => {
   const result = spawnSync(
     'python3',
     [
@@ -411,12 +654,12 @@ plan={
  "hypotheses":["導線に課題がある"],
  "clarifications":[{"field":"business_goal","question":"優先する目標は","recommended_answer":"購入件数の改善"}],
  "answers":{},
- "panels":[{"id":panel_id,"reason":"必要"} for panel_id in ["R4","R9","R16","R17"]],
+ "panels":[{"title":"購入規模","kpi":"購入件数","chart":"scorecard","decision":"成果規模を判断する","reason":"基準値に必要","execution_prompt":"2021年1月の購入件数を1行で出す","dimensions":[],"measures":["購入件数"],"layout_row":1,"layout_weight":1}],
 }
 missing=""
-try:p.confirm_plan(plan)
+try:p.confirm_dashboard_plan(plan)
 except p.PlannerError as error:missing=str(error)
-accepted=p.confirm_plan({**plan,"answers":{"business_goal":"購入件数の改善"}})
+accepted=p.confirm_dashboard_plan({**plan,"answers":{"business_goal":"購入件数の改善"}})
 print(json.dumps({"missing":missing,"status":accepted["status"],"answers":accepted["answers"]},ensure_ascii=False))`,
     ],
     { cwd: ROOT, encoding: 'utf8' },
@@ -427,4 +670,29 @@ print(json.dumps({"missing":missing,"status":accepted["status"],"answers":accept
     status: 'confirmed',
     answers: { business_goal: '購入件数の改善' },
   });
+});
+
+test('confirming a selected subset preserves AI layout without inventing replacement rows', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+period={"from":"20210101","to":"20210131","label":"2021年1月"}
+def panel(index,row):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":"目的に必要","execution_prompt":f"2021年1月の指標{index}を1行で出す","dimensions":[],"measures":[f"指標{index}"],"layout_row":row,"layout_weight":index}
+raw={"objective_summary":"成果を判断する","audience":"責任者","comparison":"月内比較","hypotheses":["差がある"],"clarifications":[],"panels":[panel(1,1),panel(2,2),panel(3,3)]}
+plan=p.normalize_dashboard_plan(raw,"ダッシュボードを作って",period,{"audience":"責任者"})
+plan["panels"]=[plan["panels"][0],plan["panels"][2]]
+confirmed=p.confirm_dashboard_plan(plan)
+print(json.dumps([[item["layout_row"],item["layout_weight"]] for item in confirmed["panels"]]))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [
+    [1, 1],
+    [3, 3],
+  ]);
 });

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -29,6 +29,25 @@ test('live dry-run describes the paid localhost workflow', () => {
   assert.match(result.stdout, /call Vertex AI and BigQuery after each submitted prompt/);
   assert.match(result.stdout, /open http:\/\/127\.0\.0\.1:8765\//);
 });
+
+test('dashboard planning errors can present and apply an AI-interpreted correction', () => {
+  const result = python(`
+error=m.LiveDemoError("描画できません",suggested_instruction="上位10経路として追加して")
+print(json.dumps({
+ "message":str(error),
+ "suggestion":error.suggested_instruction,
+ "controls":all(value in m.HTML for value in ["plan-correction","plan-correction-text","plan-correction-apply"]),
+ "handler":all(value in m.HTML for value in ["e.suggested_instruction","showPlanCorrection(e.suggested_instruction)","変更依頼欄へ反映"]),
+},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    message: '描画できません',
+    suggestion: '上位10経路として追加して',
+    controls: true,
+    handler: true,
+  });
+});
 test('live startup prepares pinned dependencies before creating the engine', () => {
   const result = python(`
 from pathlib import Path
@@ -95,7 +114,7 @@ print(json.dumps({
  "copy":all(x in html for x in ["Vertex AI 最大約¥2","BigQuery 最大20 GiB","最大約¥19","合計最大約¥21","無料枠やキャッシュで0円"]),
  "dialog":all(x in html for x in ['<dialog id="cost-dialog"','aria-labelledby="cost-title"','id="cancel-cost"','id="confirm-cost"']),
  "actions":all(x in html for x in ['$("cost-dialog").showModal()','$("cost-dialog").close()','pendingMode==="dashboard-plan"?runPlan():pendingMode==="dashboard-build"?runDashboard():pendingMode==="report"?runMeetingReport():runQuery()']),
- "dashboard":all(x in html for x in ["今回の相談 約¥1","BigQuery ¥0（仕様確定前は実行しません）","count*20","count*21"]),
+ "dashboard":all(x in html for x in ["今回の相談 約¥1","BigQuery ¥0（仕様確定前は実行しません）","count*20","count*21","dry run診断修正は各1回まで"]),
  "portable":"confirm(COST_CONFIRMATION)" not in html,
  "progress":all(x in html for x in ["生成の進行状況","実行前","問い合わせを入力し、生成ボタンを押してください。","SQLを作る","安全性を確認","データを取得","結果を可視化"])
 }))
@@ -331,12 +350,10 @@ test('live bar chart renders labels when DOM append returns undefined', () => {
     ['organic', '120', 'cpc', '80'],
   );
 });
-test('live Sankey result is classified and rendered as a diagram', () => {
+test('AI-planned Sankey result is validated and rendered as a diagram', () => {
   const classified = python(`
-print(m.visualization_for_result(
- [("1. 入口: /", "2. /shop", 120), ("2. /shop", "3. /cart", 48)],
- ["source", "target", "sessions"]
-))
+section={"title":"回遊","component":"sankey","planned_visualization":"sankey"}
+print(m.dashboard_visualization(section,[("1. 入口: /", "2. /shop", 120), ("2. /shop", "3. /cart", 48)],["source", "target", "metric_value"]))
 `);
   assert.equal(classified.status, 0, classified.stderr);
   assert.equal(classified.stdout.trim(), 'sankey');
@@ -388,10 +405,10 @@ print(m.visualization_for_result(
         ['1. 入口: /', '2. /shop', 120],
         ['2. /shop', '3. /cart', 48],
         ['3. /cart', '4. /complete', 20],
+        ['4. /complete', '5. /after', 10],
       ],
-      columns: ['source', 'target', 'sessions'],
+      columns: ['遷移元', '遷移先', 'セッション数'],
       visualization: 'sankey',
-      navigation_depth: 4,
     },
   };
   assert.doesNotThrow(() =>
@@ -419,6 +436,10 @@ print(m.visualization_for_result(
     .filter((element) => element.tag === 'path')
     .map((element) => element.attributes.stroke);
   assert.equal(gradients.length, 3, 'each transition should have a color gradient');
+  assert.ok(
+    elements.every((element) => !element.textContent.includes('/after')),
+    'pages after the fourth page must not be rendered',
+  );
   assert.ok(nodeColors.size >= 3, 'different page types should use different node colors');
   assert.ok(
     linkStrokes.every((stroke) => /^url\(#sankey-\d+-link-\d+\)$/.test(stroke ?? '')),
@@ -454,7 +475,7 @@ print(m.visualization_for_result(
     elements
       .filter((element) => element.attributes.class === 'sankey-stage')
       .map((element) => element.textContent),
-    ['入口', '2ページ目', '3ページ目', '4ページ目'],
+    ['段階1', '段階2', '段階3', '段階4'],
   );
   assert.ok(links.every((link) => link.attributes.tabindex === '0'));
   assert.ok(links.every((link) => link.attributes['aria-label']?.includes('セッション')));
@@ -465,138 +486,52 @@ print(m.visualization_for_result(
   const detail = chart.children.find((element) => element.className.includes('sankey-detail'));
   assert.ok(detail);
   links[0]?.onfocus?.();
-  assert.match(detail.textContent, /\/ → \/shop: 120セッション/);
-  const terminal = chart.children.find((element) => element.className.includes('sankey-terminal'));
-  assert.match(
-    terminal?.textContent ?? '',
-    /2ページ目で終了: 72セッション、3ページ目で終了: 28セッション/,
-  );
+  assert.match(detail.textContent, /\/ → \/shop: 120 セッション数/);
 });
 
-test('navigation SQL requires deterministic tie-breaking before BigQuery execution', () => {
+test('AI-authored Sankey keeps a bounded render contract without fixed navigation selection', () => {
   const result = python(`
-queries=[
- "SELECT p1,p2,p3,COUNT(1) AS path_sessions FROM journeys GROUP BY p1,p2,p3 ORDER BY path_sessions DESC LIMIT 12",
- "SELECT p1,p2,p3,COUNT(1) AS path_sessions FROM journeys GROUP BY p1,p2,p3 ORDER BY IF(path_sessions > 0, path_sessions, 0) DESC, p1 LIMIT 12",
- "SELECT p1,p2,p3,COUNT(1) AS path_sessions FROM journeys GROUP BY p1,p2,p3 ORDER BY path_sessions DESC, p1 DESC, p2 DESC, p3 DESC LIMIT 12",
- "SELECT p1,p2,p3,COUNT(1) AS path_sessions FROM journeys GROUP BY p1,p2,p3 ORDER BY path_sessions DESC, p1, p2, p3 LIMIT 12",
-]
-out=[]
-for sql in queries:
- try:
-  m.require_deterministic_navigation_order(sql)
-  out.append("accepted")
- except m.LiveDemoError as error:
-  out.append(str(error))
-print(json.dumps(out,ensure_ascii=False))
-`);
-  assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), [
-    '回遊の上位12経路に同数時の順序がないためBigQueryへ送信しません。',
-    '回遊の上位12経路に同数時の順序がないためBigQueryへ送信しません。',
-    '回遊の上位12経路に同数時の順序がないためBigQueryへ送信しません。',
-    'accepted',
-  ]);
-});
-
-test('custom navigation depth keeps the bounded Sankey analysis contract', () => {
-  const result = python(`
-spec=json.loads((m.HERE/"report.json").read_text())
-q3="2021年1月のWebサイト回遊を分析するため、セッション内のページビューを時系列順に並べ、入口から3ページ目までの上位12経路を集計し、段階付きのsource、target、セッション数をサンキーダイアグラム用に出して"
-q4=q3.replace("3ページ目", "4ページ目")
-q5=q3.replace("3ページ目", "5ページ目")
-sections=[m.section_for_question(spec,q) for q in [q3,q4,q5]]
-too_deep=""
-try:m.section_for_question(spec,q3.replace("3ページ目", "7ページ目"))
-except m.LiveDemoError as error:too_deep=str(error)
-print(json.dumps({"sections":[{"id":s["id"],"component":s["component"],"transition_mode":s["transition_mode"],"navigation_depth":s["navigation_depth"],"verification":s["verification"],"requirements":" ".join(s["generation_requirements"])} for s in sections],"too_deep":too_deep},ensure_ascii=False))
+panel={"id":"P1","title":"主要回遊","objective":"回遊を判断する","chart":"sankey","execution_prompt":"2021年1月のsourceからtargetへのsessionsを集計する","dimensions":["source","target"],"measures":["sessions"]}
+section=m.planned_analysis_section(panel)
+print(json.dumps({"component":section["component"],"planned":section["planned_visualization"],"verification":section["verification"],"rows":section["max_result_rows"],"pages":section["max_navigation_pages"],"requirements":" ".join(section["generation_requirements"]),"selector":hasattr(m,"section_for_question")},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
   const value = JSON.parse(result.stdout);
   assert.deepEqual(
-    value.sections.map((section: Record<string, string | number>) => ({
-      id: section.id,
-      component: section.component,
-      transition_mode: section.transition_mode,
-      navigation_depth: section.navigation_depth,
-      verification: section.verification,
-    })),
-    [
-      {
-        id: 'R17',
-        component: 'sankey',
-        transition_mode: 'page_navigation',
-        navigation_depth: 3,
-        verification: 'reference',
-      },
-      {
-        id: 'Q1',
-        component: 'sankey',
-        transition_mode: 'page_navigation',
-        navigation_depth: 4,
-        verification: 'execution',
-      },
-      {
-        id: 'Q1',
-        component: 'sankey',
-        transition_mode: 'page_navigation',
-        navigation_depth: 5,
-        verification: 'execution',
-      },
-    ],
+    {
+      component: value.component,
+      planned: value.planned,
+      verification: value.verification,
+      rows: value.rows,
+      pages: value.pages,
+      selector: value.selector,
+    },
+    {
+      component: 'sankey',
+      planned: 'sankey',
+      verification: 'execution',
+      rows: 100,
+      pages: 4,
+      selector: false,
+    },
   );
-  assert.match(value.sections[1].requirements, /4ページ目/);
-  assert.match(value.sections[1].requirements, /3→4/);
-  assert.match(value.sections[2].requirements, /5ページ目が存在するセッションだけ/);
-  assert.equal(value.too_deep, '回遊Sankeyで指定できるのは入口から3〜6ページ目までです。');
+  assert.match(value.requirements, /source、target、metric_value/);
+  assert.match(value.requirements, /最初の4ページ/);
+  assert.match(value.requirements, /1\.〜4\./);
+  assert.match(value.requirements, /LIMIT 100/);
 });
 
-test('custom navigation depth validates stable ordering and all adjacent stages', () => {
+test('Sankey labels a repeated page attribute by source and target role', () => {
   const result = python(`
-ordering=[]
-for sql in [
- "SELECT p1,p2,p3,p4,COUNT(1) AS sessions FROM journeys GROUP BY p1,p2,p3,p4 ORDER BY sessions DESC,p1,p2,p3 LIMIT 12",
- "SELECT p1,p2,p3,p4,COUNT(1) AS sessions FROM journeys GROUP BY p1,p2,p3,p4 ORDER BY sessions DESC,p1,p2,p3,p4 LIMIT 12",
-]:
- try:m.require_deterministic_navigation_order(sql,4);ordering.append("accepted")
- except m.LiveDemoError as error:ordering.append(str(error))
-completion=[]
-for sql in [
- "WITH session_paths AS (SELECT p1,p2,p3,p4,p5 FROM journeys WHERE p2 IS NOT NULL), top_paths AS (SELECT p1,p2,p3,p4,p5,COUNT(1) sessions FROM session_paths GROUP BY p1,p2,p3,p4,p5 ORDER BY sessions DESC,p1,p2,p3,p4,p5 LIMIT 12) SELECT p1,p2,p3,p4,p5,sessions FROM top_paths WHERE p5 IS NOT NULL",
- "WITH session_paths AS (SELECT p1,p2,p3,p4,p5 FROM journeys WHERE p5 IS NOT NULL), top_paths AS (SELECT p1,p2,p3,p4,p5,COUNT(1) sessions FROM session_paths GROUP BY p1,p2,p3,p4,p5 ORDER BY sessions DESC,p1,p2,p3,p4,p5 LIMIT 12) SELECT p1,p2 FROM top_paths",
-]:
- try:m.require_complete_navigation_depth(sql,5);completion.append("accepted")
- except m.LiveDemoError as error:completion.append(str(error))
-valid=[("1. 入口: /","2. /shop",10),("2. /shop","3. /cart",10),("3. /cart","4. /done",10)]
-invalid=[("1. 入口: /","2. /shop",10),("3. /cart","4. /done",4)]
-validation=[]
-for rows in [valid,invalid]:
- try:m.validate_navigation_sankey(rows,4);validation.append("accepted")
- except m.LiveDemoError as error:validation.append(str(error))
-five_page=[]
-for rows in [
- [("1. 入口: /","2. /shop",10),("2. /shop","3. /cart",10)],
- [("1. 入口: /","2. /shop",10),("2. /shop","3. /cart",9),("3. /cart","4. /checkout",9),("4. /checkout","5. /done",9)],
- [("1. 入口: /","2. /shop",10),("2. /shop","3. /cart",10),("3. /cart","4. /checkout",10),("4. /checkout","5. /done",10)],
-]:
- try:m.validate_navigation_sankey(rows,5);five_page.append("accepted")
- except m.LiveDemoError as error:five_page.append(str(error))
-print(json.dumps({"ordering":ordering,"completion":completion,"validation":validation,"five_page":five_page},ensure_ascii=False))
+panel={"id":"P1","title":"3ページ回遊","chart":"sankey","execution_prompt":"2021年1月のページからページへの3段階のセッション数を集計する","dimensions":["ページ","ページ"],"measures":["セッション数"]}
+section=m.planned_analysis_section(panel)
+print(json.dumps({"columns":section["shape"]["columns"],"source_columns":section["source_columns"],"requirements":" ".join(section["generation_requirements"])},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), {
-    ordering: ['回遊の上位12経路に同数時の順序がないためBigQueryへ送信しません。', 'accepted'],
-    completion: [
-      '回遊の上位12経路が5ページ目到達前に抽出されるためBigQueryへ送信しません。',
-      'accepted',
-    ],
-    validation: ['accepted', '回遊の段階間が接続しないため描画しません。'],
-    five_page: [
-      '回遊が要求された5ページ目まで到達しないため描画しません。',
-      '回遊が要求された5ページ目まで到達しないため描画しません。',
-      'accepted',
-    ],
-  });
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.columns, ['遷移元ページ', '遷移先ページ', 'セッション数']);
+  assert.deepEqual(output.source_columns, ['source', 'target', 'metric_value']);
+  assert.match(output.requirements, /隣接edgeとして縦持ち/);
 });
 
 test('single-graph progress shows the dynamic stop reason before stage details', () => {
@@ -611,7 +546,7 @@ test('single-graph progress shows the dynamic stop reason before stage details',
   assert.match(html, /未定義のため停止:/);
 });
 
-test('dashboard-specific KPI, funnel, and trend panels render from fixed results', () => {
+test('confirmed KPI, funnel, and multi-line panels render from guarded results', () => {
   const rendered = python('print(m.HTML)');
   assert.equal(rendered.status, 0, rendered.stderr);
   const script = rendered.stdout.split('<script>').at(-1)?.split('</script>')[0] ?? '';
@@ -655,23 +590,27 @@ test('dashboard-specific KPI, funnel, and trend panels render from fixed results
   };
   const cases = [
     {
-      visualization: 'kpi_pair',
+      visualization: 'kpi_group',
       columns: ['購入件数', '売上'],
       rows: [[895, 57350]],
       expectedTag: 'div',
     },
     {
       visualization: 'funnel',
-      columns: ['閲覧', 'カート', '購入'],
-      rows: [[23105, 4537, 1115]],
+      columns: ['段階', 'セッション数'],
+      rows: [
+        ['1. 閲覧', 23105],
+        ['2. カート', 4537],
+        ['3. 購入', 1115],
+      ],
       expectedTag: 'div',
     },
     {
-      visualization: 'trend',
+      visualization: 'multi_line',
       columns: ['日付', 'セッション', '7日移動平均'],
       rows: [
-        ['2021-01-01', 100, 90],
-        ['2021-01-02', 120, 95],
+        ['2021-01-01', 100000000, 10],
+        ['2021-01-02', 200000000, 20],
       ],
       expectedTag: 'svg',
     },
@@ -683,7 +622,163 @@ test('dashboard-specific KPI, funnel, and trend panels render from fixed results
     assert.equal(chart.children[0]?.tag, result.expectedTag);
   }
   const polylines = chart.children[0]?.children.filter((child) => child.tag === 'polyline') ?? [];
-  assert.equal(polylines.length, 2, 'trend should contain daily and moving-average series');
+  assert.equal(polylines.length, 2, 'multi-line should contain both confirmed series');
+  assert.equal(
+    polylines[0]?.attributes.points,
+    polylines[1]?.attributes.points,
+    'each series should use its own scale when their magnitudes differ',
+  );
+  assert.match(chart.children[1]?.textContent ?? '', /100倍以上.*系列ごとに独立した縦軸スケール/);
+
+  const nullableLine = new ElementStub('div');
+  vm.runInNewContext(`${functions}\ngraph(result, chart);`, {
+    ...context,
+    chart: nullableLine,
+    result: {
+      visualization: 'line',
+      columns: ['event_date', 'metric_value'],
+      rows: [
+        ['2021-01-01', 1200],
+        ['2021-01-02', null],
+        ['2021-01-03', 1800],
+      ],
+    },
+  });
+  const lineMarks = nullableLine.children[0]?.children ?? [];
+  assert.equal(
+    lineMarks.filter((child) => child.tag === 'circle').length,
+    2,
+    'a null measure should be a missing point rather than a zero-valued point',
+  );
+  assert.equal(
+    lineMarks.filter((child) => child.tag === 'polyline').length,
+    0,
+    'the line should not bridge a missing interval',
+  );
+});
+
+test('AI-selectable multi-series, relationship, and density charts render explicitly', () => {
+  const rendered = python('print(m.HTML)');
+  assert.equal(rendered.status, 0, rendered.stderr);
+  const script = rendered.stdout.split('<script>').at(-1)?.split('</script>')[0] ?? '';
+  const functions = script.slice(
+    script.indexOf('function node('),
+    script.indexOf('function finish('),
+  );
+  class ElementStub {
+    attributes: Record<string, string> = {};
+    children: ElementStub[] = [];
+    style: Record<string, string> = {};
+    textContent = '';
+    className = '';
+    tag: string;
+    constructor(tag: string) {
+      this.tag = tag;
+    }
+    setAttribute(name: string, value: unknown) {
+      this.attributes[name] = String(value);
+    }
+    append(...children: ElementStub[]) {
+      this.children.push(...children);
+    }
+    appendChild(child: ElementStub): ElementStub {
+      this.children.push(child);
+      return child;
+    }
+    replaceChildren(...children: ElementStub[]) {
+      this.children = children;
+    }
+    insertRow(): ElementStub {
+      return this.appendChild(new ElementStub('tr'));
+    }
+    insertCell(): ElementStub {
+      return this.appendChild(new ElementStub('td'));
+    }
+    createTHead(): ElementStub {
+      return this.appendChild(new ElementStub('thead'));
+    }
+    createTBody(): ElementStub {
+      return this.appendChild(new ElementStub('tbody'));
+    }
+  }
+  const context = {
+    document: {
+      createElementNS: (_namespace: string, tag: string) => new ElementStub(tag),
+      createElement: (tag: string) => new ElementStub(tag),
+      createTextNode: (value: string) =>
+        Object.assign(new ElementStub('#text'), { textContent: value }),
+    },
+    $: () => new ElementStub('div'),
+  };
+  const cases = [
+    { visualization: 'kpi_group', columns: ['購入件数', '売上'], rows: [[10, 200]], tag: 'div' },
+    {
+      visualization: 'grouped_bar',
+      columns: ['デバイス', 'セッション', '購入'],
+      rows: [['mobile', 100, 10]],
+      tag: 'svg',
+    },
+    {
+      visualization: 'stacked_bar',
+      columns: ['新規・既存', '購入', '未購入'],
+      rows: [['新規', 10, 90]],
+      tag: 'svg',
+    },
+    {
+      visualization: 'multi_line',
+      columns: ['日付', '購入', '売上'],
+      rows: [['2021-01-01', 10, 200]],
+      tag: 'svg',
+    },
+    {
+      visualization: 'scatter',
+      columns: ['ページ', '閲覧', '売上'],
+      rows: [['/shop', 100, 200]],
+      tag: 'svg',
+    },
+    {
+      visualization: 'bubble',
+      columns: ['ページ', '閲覧', '売上', '購入'],
+      rows: [['/shop', 100, 200, 10]],
+      tag: 'svg',
+    },
+    {
+      visualization: 'funnel',
+      columns: ['段階', 'セッション'],
+      rows: [
+        ['1. 閲覧', 100],
+        ['2. 購入', 10],
+      ],
+      tag: 'div',
+    },
+    {
+      visualization: 'heatmap',
+      columns: ['曜日', '時間帯', '購入'],
+      rows: [['月', '午前', 10]],
+      tag: 'svg',
+    },
+  ];
+  for (const result of cases) {
+    const chart = new ElementStub('div');
+    vm.runInNewContext(`${functions}\ngraph(result,chart);`, { ...context, result, chart });
+    assert.equal(chart.children[0]?.tag, result.tag, result.visualization);
+    if (result.visualization === 'scatter' || result.visualization === 'bubble') {
+      const points = chart.children[0]?.children.filter((child) => child.tag === 'circle') ?? [];
+      assert.equal(points.length, 1, `${result.visualization} point count`);
+      assert.equal(points[0]?.attributes.tabindex, '0');
+      assert.ok(points[0]?.attributes['aria-label']?.includes('/shop'));
+    }
+  }
+  const chart = new ElementStub('div');
+  assert.throws(
+    () =>
+      vm.runInNewContext(`${functions}\ngraph(result,chart);`, {
+        ...context,
+        result: { visualization: 'unknown', columns: ['x'], rows: [[1]] },
+        chart,
+      }),
+    /未対応の可視化形式/,
+  );
 });
 
 test('live query derives the requested month and rejects unavailable periods', () => {
@@ -720,190 +815,71 @@ print(json.dumps({"values":values,"errors":errors},ensure_ascii=False))
   });
 });
 
-test('one dashboard request expands to the six validated analyses for its month', () => {
-  const result = python(`
-spec=json.loads((m.HERE/"report.json").read_text())
-period,sections=m.dashboard_sections(spec,"2020年12月のECサイト分析ダッシュボードを作って")
-error=""
-try:
- m.dashboard_sections(spec,"2021年1月のECサイト分析をして")
-except m.LiveDemoError as caught:
- error=str(caught)
-print(json.dumps({"period":period,"ids":[s["id"] for s in sections],"requested_month":all(period["label"] in s["text"] for s in sections),"verification":[s["verification"] for s in sections],"purposes":[bool(s["purpose"]) for s in sections],"error":error},ensure_ascii=False))
-`);
-  assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), {
-    period: { from: '20201201', to: '20201231', label: '2020年12月' },
-    ids: ['R4', 'R11', 'R12', 'R9', 'R16', 'R17'],
-    requested_month: true,
-    verification: Array(6).fill('execution'),
-    purposes: Array(6).fill(true),
-    error: '依頼に「ダッシュボード」を含めてください。',
-  });
-});
-
-test('dashboard layout normalizes incomplete and single-card rows to the full width', () => {
-  const result = python(`
-layouts=m.dashboard_layout_rows(["R4","R11","R9","R16"])
-print(json.dumps(layouts,ensure_ascii=False))
-`);
-  assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), [
-    { panel_ids: ['R4', 'R11'], shares: [66.6667, 33.3333] },
-    { panel_ids: ['R9'], shares: [100] },
-    { panel_ids: ['R16'], shares: [100] },
-  ]);
-});
-
-test('dashboard engine streams six generated panels without paid dependencies', () => {
-  const result = python(`
-import threading
-from datetime import date
-e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL
-e.spec=json.loads((m.HERE/"report.json").read_text());e.rules="";e.client=e.bq=object();e.lock=threading.Lock()
-generated=[];executed=[]
-results={
- "R4": ([(895,57350)],["purchases","revenue"]),
- "R11": ([(14.56,)],["repeat_rate"]),
- "R12": ([(49.51,)],["engagement_seconds"]),
- "R9": ([(23105,4537,1115)],["viewed","carted","purchased"]),
- "R16": ([(date(2020,12,1),100,90.0)],["day","sessions","moving_average"]),
- "R17": ([("1. 入口: /","2. /shop",20)],["source","target","sessions"]),
-}
-def generate(_client,_model,section,period,_rules):
- generated.append([section["id"],period["label"]])
- order="ORDER BY value DESC, value, value, value LIMIT 12" if section["id"]=="R17" else "LIMIT 1"
- sql=f"SELECT 1 AS value FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\` WHERE _TABLE_SUFFIX BETWEEN '20201201' AND '20201231' {order} /* {section['id']} */"
- return ({"sql":sql,"reason":"理由","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
-def execute(_bq,sql,**_kwargs):
- section_id=next(section_id for section_id in m.DASHBOARD_SECTION_IDS if f"/* {section_id} */" in sql)
- executed.append(section_id)
- return (results[section_id],None)
-m.report.generate=generate;m.report.exec_bq=execute
-events=[]
-e.dashboard("2020年12月のECサイト分析ダッシュボードを作って",events.append)
-panel_results=[event for event in events if event["type"]=="result"]
-print(json.dumps({"first":events[0]["type"],"last":events[-1]["type"],"layout":events[0]["layout_rows"],"generated":generated,"executed":executed,"result_ids":[event["panel_id"] for event in panel_results],"visualizations":[event["visualization"] for event in panel_results],"first_columns":panel_results[0]["columns"],"count":events[-1]["panel_count"]},ensure_ascii=False))
-`);
-  assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), {
-    first: 'dashboard_plan',
-    last: 'dashboard_complete',
-    layout: [
-      { panel_ids: ['R4', 'R11', 'R12'], shares: [50, 25, 25] },
-      { panel_ids: ['R9', 'R17'], shares: [40, 60] },
-      { panel_ids: ['R16'], shares: [100] },
-    ],
-    generated: [
-      ['R4', '2020年12月'],
-      ['R11', '2020年12月'],
-      ['R12', '2020年12月'],
-      ['R9', '2020年12月'],
-      ['R16', '2020年12月'],
-      ['R17', '2020年12月'],
-    ],
-    executed: ['R4', 'R11', 'R12', 'R9', 'R16', 'R17'],
-    result_ids: ['R4', 'R11', 'R12', 'R9', 'R16', 'R17'],
-    visualizations: ['kpi_pair', 'scalar', 'scalar', 'funnel', 'trend', 'sankey'],
-    first_columns: ['購入件数', '購入金額'],
-    count: 6,
-  });
-});
-
 test('dashboard result-shape validation fails closed before rendering', () => {
   const result = python(`
 errors=[]
 for section,rows,columns in [
- ({"title":"購入KPI","component":"kpi_pair"},[(1,)],["only_one"]),
- ({"title":"ファネル","component":"funnel"},[(100,-1,2)],["a","b","c"]),
- ({"title":"回遊","component":"sankey"},[("/","/shop","many")],["source","target","sessions"]),
+ ({"title":"購入KPI","component":"table","planned_visualization":"kpi_group"},[(1,)],["only_one"]),
+ ({"title":"ファネル","component":"funnel","planned_visualization":"funnel"},[("閲覧",-1)],["stage","metric_value"]),
+ ({"title":"回遊","component":"sankey","planned_visualization":"sankey"},[("/","/shop","many")],["source","target","metric_value"]),
+ ({"title":"回遊4ページ超","component":"sankey","planned_visualization":"sankey"},[("4. /complete","5. /after",10)],["source","target","metric_value"]),
+ ({"title":"仕様なし","component":"table"},[(1,)],["metric_value"]),
 ]:
  try:
   m.dashboard_visualization(section,rows,columns)
  except m.LiveDemoError as error:
   errors.append(str(error))
-print(json.dumps(errors,ensure_ascii=False))
+print(json.dumps({"errors":errors,"fallback":hasattr(m,"visualization_for_result")},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), [
-    '購入KPIの結果形状がダッシュボード仕様と一致しないため描画しません。',
-    'ファネルの結果形状がダッシュボード仕様と一致しないため描画しません。',
-    '回遊の結果形状がダッシュボード仕様と一致しないため描画しません。',
-  ]);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    errors: [
+      '購入KPIの結果形状がAI分析仕様のkpi_groupと一致しないため描画しません。',
+      'ファネルの結果形状がAI分析仕様のfunnelと一致しないため描画しません。',
+      '回遊の結果形状がAI分析仕様のsankeyと一致しないため描画しません。',
+      '回遊4ページ超の結果形状がAI分析仕様のsankeyと一致しないため描画しません。',
+      '仕様なしにAIが確定した描画仕様がないため実行しません。',
+    ],
+    fallback: false,
+  });
 });
 
-test('dashboard navigation Sankey rejects repeated pages as consecutive transitions', () => {
-  const result = python(`
-section={"id":"R17","title":"回遊","component":"sankey","transition_mode":"page_navigation"}
-cases=[
- [("1. 入口: /", "2. /", 38913)],
- [("1. 入口: /", "2. /shop", 20), ("2. /shop", "3. /shop", 8)],
-]
-errors=[]
-for rows in cases:
- try:
-  m.dashboard_visualization(section,rows,["source","target","sessions"])
- except m.LiveDemoError as error:
-  errors.append(str(error))
-print(json.dumps(errors,ensure_ascii=False))
-`);
-  assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), [
-    '回遊の連続する同一ページが遷移として含まれるため描画しません。',
-    '回遊の連続する同一ページが遷移として含まれるため描画しません。',
-  ]);
-});
-
-test('dashboard navigation Sankey requires staged connected aggregated edges', () => {
-  const result = python(`
-section={"id":"R17","title":"回遊","component":"sankey","transition_mode":"page_navigation"}
-cases=[
- [("1. 入口: /", "3. /cart", 10)],
- [("1. 入口: /", "2. /shop", 10), ("1. 入口: /", "2. /shop", 5)],
- [("1. 入口: /", "2. /shop", 10), ("2. /cart", "3. /done", 5)],
-]
-errors=[]
-for rows in cases:
- try:
-  m.dashboard_visualization(section,rows,["source","target","sessions"])
- except m.LiveDemoError as error:
-  errors.append(str(error))
-print(json.dumps(errors,ensure_ascii=False))
-`);
-  assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), [
-    '回遊の段階が1→2または2→3になっていないため描画しません。',
-    '回遊に未集約の重複edgeが含まれるため描画しません。',
-    '回遊の1段目と2段目が接続しないため描画しません。',
-  ]);
-});
-
-test('reference mismatch stops before a live result is rendered', () => {
+test('live execution ignores fixed reference SQL and runs only generated SQL', () => {
   const result = python(`
 import threading
 e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL
 e.rules="";e.client=e.bq=object();e.lock=threading.Lock()
 section={
  "id":"R17","title":"回遊","text":"回遊","compare":"rows_ordered",
- "component":"sankey","verification":"reference",
+ "component":"sankey","planned_visualization":"sankey","verification":"reference",
+ "source_columns":["source","target","metric_value"],"max_result_rows":100,
  "gold_sql":"SELECT 'reference' FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\` WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131'",
 }
-generated_sql="SELECT 'generated' FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\` WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131'"
+generated_sql="SELECT '1. 入口: /' AS source, '2. /shop' AS target, 20 AS metric_value FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\` WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131' ORDER BY metric_value DESC LIMIT 100"
 m.report.generate=lambda *_args,**_kwargs:({"sql":generated_sql,"reason":"理由","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
-results=[([("1. 入口: /","2. /shop",20)],["source","target","sessions"]),([("1. 入口: /","2. /cart",20)],["source","target","sessions"])]
-m.report.exec_bq=lambda *_args,**_kwargs:(results.pop(0),None)
+m.report.inspect_bq_schema=lambda *_args,**_kwargs:([("source","STRING"),("target","STRING"),("metric_value","INT64")],None)
+calls=[]
+def exec_bq(_client,sql,**_kwargs):
+ calls.append(sql)
+ return (([("1. 入口: /","2. /shop",20)],["source","target","sessions"]),None)
+m.report.exec_bq=exec_bq
 events=[]
-try:
- e._run_section(section,{"from":"20210101","to":"20210131","label":"2021年1月"},events.append)
-except m.LiveDemoError as error:
- print(json.dumps({"error":str(error),"types":[event["type"] for event in events]},ensure_ascii=False))
-else:
- raise AssertionError("reference mismatch was rendered")
+e._run_section(section,{"from":"20210101","to":"20210131","label":"2021年1月"},events.append)
+print(json.dumps({
+ "calls":calls,
+ "types":[event["type"] for event in events],
+ "verification":events[-1]["verification"],
+ "label":events[-1]["verification_label"],
+},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
-    error: '回遊の結果が登録済み参照値と一致しないため描画しません。',
-    types: ['stage', 'sql', 'stage'],
+    calls: [
+      "SELECT '1. 入口: /' AS source, '2. /shop' AS target, 20 AS metric_value FROM `bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*` WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131' ORDER BY metric_value DESC LIMIT 100",
+    ],
+    types: ['stage', 'stage', 'sql', 'stage', 'result'],
+    verification: 'unverified',
+    label: '実行済み・既知値未照合',
   });
 });
 
@@ -917,17 +893,20 @@ e.rules=""
 e.client=e.bq=object()
 e.lock=threading.Lock()
 periods=[]
-sql="SELECT traffic_source.medium AS medium, COUNT(DISTINCT user_pseudo_id) AS sessions FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\` WHERE _TABLE_SUFFIX BETWEEN '20201201' AND '20201231' GROUP BY medium"
+question="2020年12月のセッション数を流入チャネル別に集計する"
+spec={"title":"流入別セッション","objective":"流入規模を判断する","dimensions":["流入チャネル"],"measures":["セッション数"],"comparison":"流入間","chart":"bar","execution_prompt":question,"reason":"流入差を確認するため"}
+sql="SELECT traffic_source.medium AS category, COUNT(DISTINCT user_pseudo_id) AS metric_value FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\` WHERE _TABLE_SUFFIX BETWEEN '20201201' AND '20201231' GROUP BY category ORDER BY metric_value DESC LIMIT 30"
 m.report.generate=lambda _client,_model,_section,period,_rules:(periods.append(period) or ({"sql":sql,"reason":"集計","undefined_terms":[]},{"input_tokens":1,"output_tokens":1}))
+m.report.inspect_bq_schema=lambda *_args,**_kwargs:([("category","STRING"),("metric_value","INT64")],None)
 m.report.exec_bq=lambda *_args,**_kwargs:(([('organic',10)],['medium','sessions']),None)
 events=[]
-e.query("2020年12月のセッション数を流入チャネル（medium）別に、多い順で出して",events.append)
+e.query(question,events.append,analysis_specification=spec)
 print(json.dumps({"periods":periods,"types":[event["type"] for event in events]},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
     periods: [{ from: '20201201', to: '20201231', label: '2020年12月' }],
-    types: ['stage', 'sql', 'stage', 'result'],
+    types: ['stage', 'stage', 'sql', 'stage', 'result'],
   });
 });
 
@@ -940,13 +919,15 @@ e.spec=json.loads((m.HERE/"report.json").read_text())
 e.rules=""
 e.client=e.bq=object()
 e.lock=threading.Lock()
-sql="SELECT traffic_source.medium AS medium, COUNT(DISTINCT user_pseudo_id) AS sessions FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\` WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131' GROUP BY medium"
+question="2020年12月のセッション数を流入チャネル別に集計する"
+spec={"title":"流入別セッション","objective":"流入規模を判断する","dimensions":["流入チャネル"],"measures":["セッション数"],"comparison":"流入間","chart":"bar","execution_prompt":question,"reason":"流入差を確認するため"}
+sql="SELECT traffic_source.medium AS category, COUNT(DISTINCT user_pseudo_id) AS metric_value FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\` WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131' GROUP BY category ORDER BY metric_value DESC LIMIT 30"
 m.report.generate=lambda *_args:({"sql":sql,"reason":"集計","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
 executions=[]
 m.report.exec_bq=lambda *_args,**_kwargs:(executions.append(True) or (([],[]),None))
 error=""
 try:
- e.query("2020年12月のセッション数を流入チャネル（medium）別に、多い順で出して",lambda _event:None)
+ e.query(question,lambda _event:None,analysis_specification=spec)
 except m.LiveDemoError as caught:
  error=str(caught)
 print(json.dumps({"error":error,"executions":executions},ensure_ascii=False))
@@ -978,25 +959,27 @@ print(json.dumps({
 test('live engine renders safe shapes, refuses undefined metrics, and caps fetched rows', () => {
   const result = python(`
 import threading
-from datetime import date
-from decimal import Decimal
 def engine():
  e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL
  e.spec=json.loads((m.HERE/"report.json").read_text());e.rules="";e.client=e.bq=object();e.lock=threading.Lock();return e
-sql="SELECT COUNT(DISTINCT user_pseudo_id) AS users FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\` WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131'"
+question="2021年1月のユーザー数を集計する"
+spec={"title":"ユーザー数","objective":"利用規模を判断する","dimensions":[],"measures":["ユーザー数"],"comparison":"2021年1月の全体","chart":"scorecard","execution_prompt":question,"reason":"規模を確認するため"}
+sql="SELECT COUNT(DISTINCT user_pseudo_id) AS metric_value FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\` WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131'"
 m.report.generate=lambda *_:({"sql":sql,"reason":"集計","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
+m.report.inspect_bq_schema=lambda *_args,**_kwargs:([("metric_value","INT64")],None)
 limits=[];m.report.exec_bq=lambda *_args,**kw:(limits.append(kw.get("max_results")) or (([(94790,)],["users"]),None))
-events=[];engine().query("2021年1月のユーザー数を出して",events.append)
+events=[];engine().query(question,events.append,analysis_specification=spec)
 m.report.generate=lambda *_:({"sql":"","reason":"未定義","undefined_terms":["直帰率"]},{"input_tokens":1,"output_tokens":1})
-refusal=[];engine().query("2021年1月の直帰率を出して",refusal.append)
-print(json.dumps({"shapes":[m.visualization_for_result([(1,)],["x"]),m.visualization_for_result([(date(2021,1,1),1)],["d","v"]),m.visualization_for_result([("a",Decimal("1"))],["k","v"])],"types":[x["type"] for x in events],"refusal":refusal[-1]["undefined_terms"],"limits":limits,"safe":"innerHTML" not in m.HTML and "renderSql($(\\"sql\\"),e.sql)" in m.HTML}))
+refusal_question="2021年1月の直帰率を集計する"
+refusal_spec={"title":"直帰率","objective":"直帰を判断する","dimensions":[],"measures":["直帰率"],"comparison":"2021年1月の全体","chart":"scorecard","execution_prompt":refusal_question,"reason":"規模を確認するため"}
+refusal=[];engine().query(refusal_question,refusal.append,analysis_specification=refusal_spec)
+print(json.dumps({"types":[x["type"] for x in events],"refusal":refusal[-1]["undefined_terms"],"limits":limits,"safe":"innerHTML" not in m.HTML and "renderSql($(\\"sql\\"),e.sql)" in m.HTML}))
 `);
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
-    shapes: ['scalar', 'line', 'bar'],
-    types: ['stage', 'sql', 'stage', 'result'],
+    types: ['stage', 'stage', 'sql', 'stage', 'result'],
     refusal: ['直帰率'],
-    limits: [101, null],
+    limits: [2],
     safe: true,
   });
 });
@@ -1006,16 +989,18 @@ import threading,urllib.error,urllib.request
 class E:
  spec=json.loads((m.HERE/"report.json").read_text())
  query_count=0
- def query(self,q,emit,**_kwargs):self.query_count+=1;emit({"type":"result","rows":[[118380]],"columns":["sessions"],"visualization":"scalar","verification":"matched","verification_label":"照合済み","cost_jpy":0.1})
- def dashboard(self,q,emit,*_args,**_kwargs):emit({"type":"dashboard_complete","panel_count":6,"cost_jpy":1.2})
+ def query(self,q,emit,analysis_specification=None,**_kwargs):self.query_count+=1;emit({"type":"result","rows":[[118380]],"columns":["sessions"],"visualization":"scalar","verification":"matched","verification_label":"照合済み","cost_jpy":0.1})
+ def dashboard(self,q,emit,plan,**_kwargs):emit({"type":"dashboard_complete","panel_count":len(plan["panels"]),"cost_jpy":1.2})
  def meeting_report(self,revision,emit,**_kwargs):emit({"type":"meeting_report","build_revision":revision})
 engine=E();s=m.create_server("127.0.0.1",0,engine);t=threading.Thread(target=s.serve_forever,daemon=True);t.start();base=f"http://127.0.0.1:{s.server_port}";statuses=[]
 try:
  page=urllib.request.urlopen(base+"/").read().decode()
- req=urllib.request.Request(base+"/api/query",data=json.dumps({"question":"2021年1月のセッション数を出して"}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
+ question="2021年1月のセッション数を集計する";spec={"title":"セッション数","objective":"訪問規模を判断する","dimensions":[],"measures":["セッション数"],"comparison":"2021年1月の全体","chart":"scorecard","execution_prompt":question,"reason":"規模を確認するため"}
+ req=urllib.request.Request(base+"/api/query",data=json.dumps({"question":question,"analysis_specification":spec}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
  value=json.loads(urllib.request.urlopen(req).read().decode())["rows"][0][0]
  dashboard_req=urllib.request.Request(base+"/api/dashboard",data=json.dumps({"question":"2021年1月のECサイト分析ダッシュボードを作って"}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
- dashboard_count=json.loads(urllib.request.urlopen(dashboard_req).read().decode())["panel_count"]
+ try:urllib.request.urlopen(dashboard_req)
+ except urllib.error.HTTPError as e:statuses.append(e.code)
  report_req=urllib.request.Request(base+"/api/report",data=json.dumps({"question":"会議報告案を作って","build_revision":"build-111111111111"}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
  report_revision=json.loads(urllib.request.urlopen(report_req).read().decode())["build_revision"]
  broad_req=urllib.request.Request(base+"/api/query",data=json.dumps({"question":"どんな分析をしたらいい？"}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
@@ -1026,16 +1011,15 @@ try:
  for ct,origin in [("text/plain",base),("application/json","https://attacker.example")]:
   try:urllib.request.urlopen(urllib.request.Request(base+"/api/query",data=b"{}",headers={"content-type":ct,"origin":origin},method="POST"))
   except urllib.error.HTTPError as e:statuses.append(e.code)
- print(json.dumps({"form":"日本語の問い合わせ" in page,"value":value,"dashboard_count":dashboard_count,"report_revision":report_revision,"statuses":statuses,"query_count":engine.query_count}))
+ print(json.dumps({"form":"日本語の問い合わせ" in page,"value":value,"report_revision":report_revision,"statuses":statuses,"query_count":engine.query_count}))
 finally:s.shutdown();s.server_close();t.join()
 `);
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout.split('\n').at(-2) ?? ''), {
     form: true,
     value: 118380,
-    dashboard_count: 6,
     report_revision: 'build-111111111111',
-    statuses: [400, 400, 415, 403],
+    statuses: [400, 400, 400, 415, 403],
     query_count: 1,
   });
   const bind = spawnSync(
@@ -1054,10 +1038,11 @@ RefreshError=type("RefreshError",(Exception,),{})
 RefreshError.__module__="google.auth.exceptions"
 class E:
  spec=json.loads((m.HERE/"report.json").read_text())
- def query(self,_question,_emit):raise RefreshError("sensitive credential detail")
+ def query(self,_question,_emit,analysis_specification=None):raise RefreshError("sensitive credential detail")
 s=m.create_server("127.0.0.1",0,E());t=threading.Thread(target=s.serve_forever,daemon=True);t.start();base=f"http://127.0.0.1:{s.server_port}"
 try:
- req=urllib.request.Request(base+"/api/query",data=json.dumps({"question":"2021年1月のセッション数を出して"}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
+ question="2021年1月のセッション数を集計する";spec={"title":"セッション数","objective":"訪問規模を判断する","dimensions":[],"measures":["セッション数"],"comparison":"2021年1月の全体","chart":"scorecard","execution_prompt":question,"reason":"規模を確認するため"}
+ req=urllib.request.Request(base+"/api/query",data=json.dumps({"question":question,"analysis_specification":spec}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
  event=json.loads(urllib.request.urlopen(req).read().decode())
  print(json.dumps(event,ensure_ascii=False))
 finally:s.shutdown();s.server_close();t.join()
@@ -1072,6 +1057,23 @@ finally:s.shutdown();s.server_close();t.join()
   assert.doesNotMatch(result.stdout, /sensitive credential detail/);
 });
 
+test('Vertex AI provider failures expose a bounded retry-safe message', () => {
+  const result = python(`
+ProviderError=type("ProviderError",(Exception,),{"__module__":"google.genai.errors"})
+messages=[]
+for code,status in [(400,"INVALID_ARGUMENT"),(429,"RESOURCE_EXHAUSTED"),(503,"UNAVAILABLE")]:
+ error=ProviderError();error.code=code;error.status=status
+ messages.append(m.vertex_ai_error_message(error))
+print(json.dumps(messages,ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [
+    'Vertex AIが生成リクエストを受理できませんでした（400 INVALID_ARGUMENT）。現在案は保持し、自動再実行していません。',
+    'Vertex AIの利用上限または同時実行制限に達しました（429 RESOURCE_EXHAUSTED）。現在案は保持し、自動再実行していません。',
+    'Vertex AIで一時的なサービス障害が発生しました（503 UNAVAILABLE）。現在案は保持し、自動再実行していません。',
+  ]);
+});
+
 test('dashboard HTTP boundary accepts a bounded confirmed plan larger than a simple query', () => {
   const result = python(`
 import threading,urllib.error,urllib.request
@@ -1081,15 +1083,15 @@ class E:
 s=m.create_server("127.0.0.1",0,E());t=threading.Thread(target=s.serve_forever,daemon=True);t.start();base=f"http://127.0.0.1:{s.server_port}"
 question="2021年1月のECサイトで購入成果を改善するため、課題の場所と優先施策を判断できるダッシュボードを作って"
 def plan(reason):
- return {"objective":question,"objective_summary":"購入課題を判断する","audience":"月次会議","comparison":"月内推移","period":m.period_for_question(question),"hypotheses":["購入導線に課題がある"],"clarifications":[],"answers":{"audience":"月次会議"},"panels":[{"id":panel_id,"reason":reason} for panel_id in ["R4","R9","R16","R17"]]}
+ return {"objective":question,"objective_summary":"購入課題を判断する","audience":"月次会議","comparison":"月内推移","period":m.period_for_question(question),"hypotheses":["購入導線に課題がある"],"clarifications":[],"answers":{"audience":"月次会議"},"panels":[{"title":f"分析{index}","kpi":"購入金額","chart":"table","decision":"優先施策を判断する","reason":reason,"execution_prompt":f"2021年1月の商品別購入金額を分析{index}として比較する","dimensions":["商品"],"measures":["購入金額"],"layout_row":(index+3)//4,"layout_weight":1} for index in range(1,21)]}
 def request(analysis_plan):
  data=json.dumps({"question":question,"profile":"ga4","analysis_plan":analysis_plan},ensure_ascii=False).encode()
  req=urllib.request.Request(base+"/api/dashboard",data=data,headers={"content-type":"application/json","origin":base},method="POST")
  return data,req
 try:
- bounded,bounded_req=request(plan("理由"*250))
+ bounded,bounded_req=request(plan("理由"*100))
  accepted=json.loads(urllib.request.urlopen(bounded_req).read().decode())["accepted"]
- oversized,oversized_req=request(plan("理由"*9000))
+ oversized,oversized_req=request(plan("理由"*900))
  oversized_status=0
  try:urllib.request.urlopen(oversized_req)
  except urllib.error.HTTPError as error:oversized_status=error.code
@@ -1113,7 +1115,7 @@ class E:
  def plan(self,_question,_answers,emit,analysis_plan=None,revision_instruction=None):emit({"type":"plan","count":len(analysis_plan["panels"]),"instruction":revision_instruction})
 s=m.create_server("127.0.0.1",0,E());t=threading.Thread(target=s.serve_forever,daemon=True);t.start();base=f"http://127.0.0.1:{s.server_port}"
 question="2021年1月の購入課題を分析するダッシュボードを作って"
-def panel(index):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分別に出して"}
+def panel(index):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分別に出して","dimensions":["区分"],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
 raw={"objective_summary":"購入課題を判断する","audience":"責任者","comparison":"月内比較","hypotheses":["差がある"],"clarifications":[],"panels":[panel(index) for index in range(1,7)]}
 plan=m.planner.normalize_dashboard_plan(raw,question,m.period_for_question(question),{"audience":"責任者"})
 def request(extra):
@@ -1135,26 +1137,19 @@ finally:s.shutdown();s.server_close();t.join()
   });
 });
 
-test('non-GA4 selector does not inject a fixed Bitcoin question into the UI', () => {
+test('non-GA4 profile exposes schema context without a fixed question or reference SQL', () => {
   const result = python(`
 html=m.HTML
 profile=m.bitcoin
-period=profile.period_for_question(profile.EXAMPLE_QUESTION)
-errors=[]
-for question in ["2023年12月の受取アドレス別の取引数", "2024年1月の手数料を出して"]:
- try:
-  profile.period_for_question(question)
-  profile.section(question)
- except ValueError as error:
-  errors.append(str(error))
+period=profile.period_for_question("2024年2月のBitcoin取引を分析したい")
 print(json.dumps({
- "selector":all(value in html for value in ['id="dataset-profile"','value="bitcoin"']) and "Bitcoin受取先の複雑度" not in html,
- "cost":all(value in html for value in ["BigQuery 最大20 GiB","生成SQL 1クエリ","合計最大約¥20"]),
+ "selector":all(value in html for value in ['id="dataset-profile"','value="bitcoin"']),
+ "cost":all(value in html for value in ["BigQuery 最大20 GiB","生成SQL 1クエリ","合計最大約¥21"]),
  "schema":all(value in profile.SCHEMA_DDL for value in ["outputs ARRAY<STRUCT<","addresses ARRAY<STRING>",profile.TABLE]),
- "rules":all(value in profile.prompt_rules() for value in ["outputs と output.addresses はそれぞれ UNNEST","SELECT * は使わず"]),
- "reference":all(value in profile.REFERENCE_SQL for value in ["UNNEST(t.outputs)","UNNEST(output.addresses)","block_timestamp_month = DATE '2024-01-01'"]),
+ "rules":all(value in profile.prompt_rules() for value in ["スキーマにある列","SELECT * は使わず","block_timestamp_month"]),
+ "no_fixed_symbols":not hasattr(profile,"EXAMPLE_QUESTION") and not hasattr(profile,"REFERENCE_SQL") and not hasattr(profile,"section"),
+ "no_fixed_analysis":all(value not in profile.prompt_rules()+html for value in ["受取アドレス数帯","1件・2〜3件・4〜9件・10件以上","Bitcoin受取先の複雑度"]),
  "period":period,
- "errors":errors,
 },ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
@@ -1163,52 +1158,50 @@ print(json.dumps({
     cost: true,
     schema: true,
     rules: true,
-    reference: true,
+    no_fixed_symbols: true,
+    no_fixed_analysis: true,
     period: {
-      from: '2024-01-01',
-      to: '2024-01-31',
-      partition: '2024-01-01',
-      label: '2024年1月',
+      from: '2024-02-01',
+      to: '2024-02-29',
+      partition: '2024-02-01',
+      label: '2024年2月',
     },
-    errors: [
-      'Bitcoinデモで検証する期間は2024年1月〜12月です。',
-      'Bitcoinデモは現在「取引ごとの受取アドレス数帯別の取引数」のみ対応します。',
-    ],
   });
 });
 
-test('Bitcoin query uses its own schema, partition guard, and dataset boundary', () => {
+test('Bitcoin query preserves an AI-authored chart specification through dry run and execution', () => {
   const result = python(`
 import threading
+from datetime import date
 e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL
 e.spec=json.loads((m.HERE/"report.json").read_text());e.rules="";e.bitcoin_rules=m.bitcoin.prompt_rules()
 e.client=e.bq=object();e.lock=threading.Lock();generated=[];executed=[]
-sql="""WITH per_transaction AS (
-SELECT hash, COUNT(DISTINCT address) AS address_count
+question="2024年2月のBitcoin取引について、平均手数料を日別に比較して"
+raw={"title":"日別平均手数料","objective":"手数料の月内変動を判断する","dimensions":["日別"],"measures":["平均手数料"],"comparison":"2024年2月の日別比較","chart":"line","execution_prompt":question,"reason":"変動日を特定できるため"}
+spec=m.planner.confirm_analysis_specification(raw)
+sql="""SELECT DATE(block_timestamp) AS event_date, AVG(fee) AS metric_value
 FROM \`bigquery-public-data.crypto_bitcoin.transactions\`
-CROSS JOIN UNNEST(outputs) AS output
-CROSS JOIN UNNEST(output.addresses) AS address
-WHERE block_timestamp_month = DATE '2024-01-01'
-GROUP BY hash)
-SELECT CASE WHEN address_count = 1 THEN '1件' WHEN address_count BETWEEN 2 AND 3 THEN '2〜3件' WHEN address_count BETWEEN 4 AND 9 THEN '4〜9件' ELSE '10件以上' END AS address_count_band, COUNT(1) AS transaction_count
-FROM per_transaction GROUP BY address_count_band ORDER BY transaction_count DESC"""
-m.report.generate_request=lambda _client,_model,request,rules:(generated.append([request,rules]) or ({"sql":sql,"reason":"二段階で展開","undefined_terms":[]},{"input_tokens":1,"output_tokens":1}))
+WHERE block_timestamp_month = DATE '2024-02-01'
+GROUP BY event_date ORDER BY event_date LIMIT 100"""
+m.report.generate_request=lambda _client,_model,request,rules:(generated.append([request,rules]) or ({"sql":sql,"reason":"日別に集計","undefined_terms":[]},{"input_tokens":1,"output_tokens":1}))
+m.report.inspect_bq_schema=lambda *_args,**_kwargs:([("event_date","DATE"),("metric_value","NUMERIC")],None)
 def execute(_bq,source,**kwargs):
  executed.append([source,kwargs])
- return (([("1件",10),("2〜3件",4)], ["address_count_band","transaction_count"]),None)
+ return (([(date(2024,2,1),12),(date(2024,2,2),15)], ["event_date","metric_value"]),None)
 m.report.exec_bq=execute;events=[]
-e.query(m.bitcoin.EXAMPLE_QUESTION,events.append,profile="bitcoin")
+e.query(question,events.append,profile="bitcoin",analysis_specification=spec)
 bad=sql.replace("bigquery-public-data.crypto_bitcoin", "bigquery-public-data.ga4_obfuscated_sample_ecommerce")
 _,bad_error=m.report.validate_sql(bad,m.bitcoin.DATASET)
 period_error=""
-try:m.bitcoin.require_sql_period(sql.replace("2024-01-01","2024-02-01"),m.bitcoin.period_for_question(m.bitcoin.EXAMPLE_QUESTION))
+try:m.bitcoin.require_sql_period(sql.replace("2024-02-01","2024-03-01"),m.bitcoin.period_for_question(question))
 except ValueError as error:period_error=str(error)
 print(json.dumps({
  "types":[event["type"] for event in events],
  "visualization":events[-1]["visualization"],
  "columns":events[-1]["columns"],
- "request_has_partition":"block_timestamp_month = DATE '2024-01-01'" in generated[0][0],
- "rules_has_nested":"output.addresses" in generated[0][1],
+ "request_has_partition":"block_timestamp_month = DATE '2024-02-01'" in generated[0][0],
+ "request_has_shape":all(value in generated[0][0] for value in ["event_date","metric_value","日別","平均手数料"]),
+ "rules_has_schema":"fee NUMERIC" in generated[0][1],
  "allowed":executed[0][1]["allowed_dataset"],
  "max_results":executed[0][1]["max_results"],
  "bad_error":bad_error,
@@ -1217,88 +1210,93 @@ print(json.dumps({
 `);
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
-    types: ['stage', 'sql', 'stage', 'result'],
-    visualization: 'bar',
-    columns: ['address_count_band', 'transaction_count'],
+    types: ['stage', 'stage', 'sql', 'stage', 'result'],
+    visualization: 'line',
+    columns: ['日別', '平均手数料'],
     request_has_partition: true,
-    rules_has_nested: true,
+    request_has_shape: true,
+    rules_has_schema: true,
     allowed: 'bigquery-public-data.crypto_bitcoin',
     max_results: 101,
     bad_error:
       'rejected: foreign table ref `bigquery-public-data.ga4_obfuscated_sample_ecommerce.transactions`',
-    period_error: '生成SQLの対象期間が問い合わせの2024年1月と一致しません。',
+    period_error: '生成SQLの対象期間が問い合わせの2024年2月と一致しません。',
   });
 });
 
-test('Bitcoin query quotes the reserved hash column before BigQuery execution', () => {
+test('Bitcoin query rejects an unquoted reserved hash without rewriting it', () => {
   const result = python(`
 import threading
 e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL
-e.spec=json.loads((m.HERE/"report.json").read_text());e.rules="";e.bitcoin_rules=m.bitcoin.prompt_rules()
-e.client=e.bq=object();e.lock=threading.Lock();executed=[]
-sql="""WITH tx_address_counts AS (
-    SELECT
-        t.hash,
-        COUNT(DISTINCT addr) AS unique_address_count
-    FROM \`bigquery-public-data.crypto_bitcoin.transactions\` AS t,
-        UNNEST(t.outputs) AS o,
-        UNNEST(o.addresses) AS addr
-    WHERE t.block_timestamp_month = DATE '2024-01-01'
-    GROUP BY t.hash
-),
-tx_bands AS (
-    SELECT
-        HASH,
-        CASE WHEN unique_address_count = 1 THEN '1件'
-             WHEN unique_address_count BETWEEN 2 AND 3 THEN '2〜3件'
-             WHEN unique_address_count BETWEEN 4 AND 9 THEN '4〜9件'
-             WHEN unique_address_count >= 10 THEN '10件以上'
-        END AS address_count_band
-    FROM tx_address_counts
-    WHERE unique_address_count > 0
-)
-SELECT address_count_band, COUNT(1) AS transaction_count
-FROM tx_bands
-GROUP BY address_count_band
-ORDER BY transaction_count DESC"""
-m.report.generate_request=lambda *_args:({"sql":sql,"reason":"二段階で展開","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
-def execute(_bq,source,**_kwargs):
- executed.append(source)
- return (([("1件",10)], ["address_count_band","transaction_count"]),None)
-m.report.exec_bq=execute;events=[]
-e.query(m.bitcoin.EXAMPLE_QUESTION,events.append,profile="bitcoin")
-shown=next(event["sql"] for event in events if event["type"]=="sql")
+e.rules="";e.bitcoin_rules=m.bitcoin.prompt_rules();e.client=e.bq=object();e.lock=threading.Lock()
+sql="SELECT COUNT(DISTINCT t.hash) AS metric_value FROM \`bigquery-public-data.crypto_bitcoin.transactions\` AS t WHERE t.block_timestamp_month = DATE '2024-01-01'"
+m.report.generate_request=lambda *_args:({"sql":sql,"reason":"取引を集計","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
+cloud_calls=[]
+m.report.inspect_bq_schema=lambda *_args,**_kwargs:(cloud_calls.append("dry-run") or ([("metric_value","INT64")],None))
+m.report.exec_bq=lambda *_args,**_kwargs:(cloud_calls.append("query") or (([(10,)], ["metric_value"]),None))
+question="2024年1月のBitcoin取引数を確認して"
+spec=m.planner.confirm_analysis_specification({"title":"取引数","objective":"取引規模を判断する","dimensions":[],"measures":["取引数"],"comparison":"2024年1月の全体値","chart":"scorecard","execution_prompt":question,"reason":"基準値になるため"})
+error=""
+try:e.query(question,lambda _event:None,profile="bitcoin",analysis_specification=spec)
+except m.LiveDemoError as caught:error=str(caught)
 quoted=chr(96)+"hash"+chr(96)
-protected="SELECT t.hash, 'hash', "+quoted+" -- hash\\n/* hash */ FROM source"
-protected_once=m.bitcoin.quote_reserved_hash_identifiers(protected)
-long_literal="SELECT '"+(chr(92)+"!")*2000+"hash'"
-print(json.dumps({
- "executed_quoted":("SELECT\\n        "+quoted+",") in executed[0],
- "display_quoted":quoted in shown,
- "qualified_unchanged":"t.hash" in executed[0],
- "prompt_guard":"予約語" in e.bitcoin_rules and quoted in e.bitcoin_rules,
- "protected_unchanged":protected_once==protected,
- "idempotent":m.bitcoin.quote_reserved_hash_identifiers(executed[0])==executed[0],
- "long_literal_unchanged":m.bitcoin.quote_reserved_hash_identifiers(long_literal)==long_literal,
-},ensure_ascii=False))
+m.bitcoin.require_quoted_hash("SELECT t."+quoted+", 'hash', "+quoted+" -- hash\\n/* hash */ FROM source")
+direct=[]
+for candidate in ["SELECT hash FROM source","SELECT t.hash FROM source"]:
+ try:m.bitcoin.require_quoted_hash(candidate)
+ except ValueError as caught:direct.append(str(caught))
+print(json.dumps({"error":error,"cloud_calls":cloud_calls,"prompt_guard":"予約語" in e.bitcoin_rules and quoted in e.bitcoin_rules,"direct":direct,"rewriter":hasattr(m.bitcoin,"quote_reserved_hash_identifiers")},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
-    executed_quoted: true,
-    display_quoted: true,
-    qualified_unchanged: true,
+    error: 'Bitcoin SQLのhash列が引用されていないためBigQueryへ送信しません。',
+    cloud_calls: [],
     prompt_guard: true,
-    protected_unchanged: true,
-    idempotent: true,
-    long_literal_unchanged: true,
+    direct: [
+      'Bitcoin SQLのhash列が引用されていないためBigQueryへ送信しません。',
+      'Bitcoin SQLのhash列が引用されていないためBigQueryへ送信しません。',
+    ],
+    rewriter: false,
   });
+});
+
+test('Bitcoin HTTP build requires and forwards an AI-authored analysis specification', () => {
+  const result = python(`
+import threading,urllib.error,urllib.request
+class E:
+ spec=json.loads((m.HERE/"report.json").read_text())
+ def query(self,question,emit,profile="ga4",analysis_specification=None):
+  emit({"type":"accepted","question":question,"profile":profile,"chart":analysis_specification["chart"],"revision":analysis_specification["revision"]})
+engine=E();s=m.create_server("127.0.0.1",0,engine);t=threading.Thread(target=s.serve_forever,daemon=True);t.start();base=f"http://127.0.0.1:{s.server_port}"
+question="2024年2月のBitcoin取引について、平均手数料を日別に比較して"
+spec={"title":"日別平均手数料","objective":"手数料の月内変動を判断する","dimensions":["日別"],"measures":["平均手数料"],"comparison":"2024年2月の日別比較","chart":"line","execution_prompt":question,"reason":"変動日を特定できるため"}
+def post(extra):
+ data=json.dumps({"question":question,"profile":"bitcoin",**extra},ensure_ascii=False).encode()
+ return urllib.request.Request(base+"/api/query",data=data,headers={"content-type":"application/json","origin":base},method="POST")
+try:
+ try:urllib.request.urlopen(post({}))
+ except urllib.error.HTTPError as error:missing={"status":error.code,"message":json.loads(error.read())["error"]}
+ accepted=json.loads(urllib.request.urlopen(post({"analysis_specification":spec})).read().decode())
+ print(json.dumps({"missing":missing,"accepted":accepted},ensure_ascii=False))
+finally:s.shutdown();s.server_close();t.join()
+`);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout.split('\n').at(-2) ?? '');
+  assert.deepEqual(output.missing, {
+    status: 400,
+    message: 'AIが作成した分析仕様を選択してからbuildしてください。',
+  });
+  assert.equal(output.accepted.type, 'accepted');
+  assert.equal(output.accepted.profile, 'bitcoin');
+  assert.equal(output.accepted.chart, 'line');
+  assert.match(output.accepted.revision, /^insight-[0-9a-f]{12}$/);
 });
 
 test('planning calls Vertex only and preserves AI-authored dashboard panels', () => {
   const result = python(`
 import threading
 e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.metrics="metrics";e.client=object();e.lock=threading.Lock()
-def panel(index):return {"id":f"P{index}","title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を1行で出して"}
+def panel(index):return {"id":f"P{index}","title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を1行で出して","dimensions":[],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
 raw={"status":"proposed","objective":"2021年1月の購入成果を改善するダッシュボードを作って","objective_summary":"目的","audience":"責任者","comparison":"月内比較","period":m.period_for_question("2021年1月"),"hypotheses":["仮説"],"clarifications":[],"answers":{"audience":"責任者"},"organization_context_revision":"demo-org-ec-v1","panels":[panel(index) for index in range(1,7)],"revision":"plan-test"}
 calls=[]
 m.planner.propose_dashboard=lambda *_args,**_kwargs:(calls.append("vertex") or (raw,{"input_tokens":10,"output_tokens":5}))
@@ -1317,11 +1315,35 @@ print(json.dumps({"calls":calls,"events":[event["type"] for event in events],"id
   });
 });
 
+test('dashboard build has no fixed-catalog fallback without an AI-authored plan', () => {
+  const result = python(`
+import inspect,threading
+e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.spec=json.loads((m.HERE/"report.json").read_text());e.rules="";e.client=e.bq=object();e.lock=threading.Lock();e.latest_dashboard=None
+m.report.generate=lambda *_args,**_kwargs:({"sql":"","reason":"unused","undefined_terms":["unused"]},{"input_tokens":1,"output_tokens":1})
+events=[];error=""
+try:e.dashboard("2021年1月のECサイト分析ダッシュボードを作って",events.append)
+except m.LiveDemoError as caught:error=str(caught)
+removed=all(not hasattr(m,name) for name in ["DASHBOARD_PURPOSES","DASHBOARD_ROW_TEMPLATES","dashboard_sections","dashboard_layout_rows","confirm_dashboard_analysis_plan"])
+planner_removed=all(not hasattr(m.planner,name) for name in ["PANEL_CATALOG","planning_request","normalize_plan","propose","confirm_plan"])
+layout_source=inspect.getsource(m.dashboard_layout_rows_for_plan)
+layout_is_ai_authored=all(value not in layout_source for value in ["panel.get('chart')","full_width_charts","weights ="])
+print(json.dumps({"error":error,"events":[event["type"] for event in events],"removed":removed,"planner_removed":planner_removed,"layout_is_ai_authored":layout_is_ai_authored},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    error: 'AIが作成した分析仕様を確定してからbuildしてください。',
+    events: [],
+    removed: true,
+    planner_removed: true,
+    layout_is_ai_authored: true,
+  });
+});
+
 test('planning sends the selected current plan and revision instruction back to the AI', () => {
   const result = python(`
 import threading
 e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.metrics="metrics";e.client=object();e.lock=threading.Lock()
-def panel(index):return {"id":f"P{index}","title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分別に出して"}
+def panel(index):return {"id":f"P{index}","title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分別に出して","dimensions":["区分"],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
 raw={"status":"proposed","objective":"2021年1月の購入成果を改善するダッシュボードを作って","objective_summary":"目的","audience":"責任者","comparison":"月内比較","period":m.period_for_question("2021年1月"),"hypotheses":["仮説"],"clarifications":[],"answers":{"audience":"責任者"},"organization_context_revision":"demo-org-ec-v1","panels":[panel(index) for index in range(1,7)],"revision":"plan-test"}
 calls=[]
 def propose(*_args,**kwargs):
@@ -1340,13 +1362,15 @@ print(json.dumps({"calls":calls,"events":[event["type"] for event in events]},en
 
 test('a confirmed dynamic dashboard plan builds its authored specifications', () => {
   const result = python(`
-def panel(title,chart,prompt):return {"title":title,"kpi":"定義済み指標","chart":chart,"decision":"意思決定","reason":"目的に必要","execution_prompt":prompt}
+def panel(title,chart,prompt,row,weight):
+ dimension=[] if chart=="scorecard" else (["日別"] if chart=="line" else ["medium"] if "medium" in prompt else ["デバイス"])
+ return {"title":title,"kpi":"購入件数","chart":chart,"decision":"意思決定","reason":"目的に必要","execution_prompt":prompt,"dimensions":dimension,"measures":["購入件数"],"layout_row":row,"layout_weight":weight}
 question="2021年1月の購入課題を分析するダッシュボードを作って"
 raw={"objective_summary":"購入課題を判断する","audience":"責任者","comparison":"軸間比較","hypotheses":["差がある"],"clarifications":[],"panels":[
- panel("流入別購入","bar","2021年1月の購入件数をmedium別に出して"),
- panel("日別購入","line","2021年1月の日別購入件数を出して"),
- panel("デバイス別購入","bar","2021年1月の購入件数をデバイス別に出して"),
- panel("購入規模","scorecard","2021年1月の購入件数を出して"),
+ panel("流入別購入","bar","2021年1月の購入件数をmedium別に出して",1,1),
+ panel("日別購入","line","2021年1月の日別購入件数を出して",1,3),
+ panel("デバイス別購入","bar","2021年1月の購入件数をデバイス別に出して",2,1),
+ panel("購入規模","scorecard","2021年1月の購入件数を出して",2,1),
 ]}
 plan=m.planner.normalize_dashboard_plan(raw,question,m.period_for_question(question),{"audience":"責任者"})
 confirmed=m.planner.confirm_dashboard_plan(plan)
@@ -1365,8 +1389,8 @@ print(json.dumps({"period":period["label"],"ids":[item["id"] for item in section
       '2021年1月の購入件数を出して',
     ],
     layouts: [
-      { panel_ids: ['P1', 'P2'], shares: [50, 50] },
-      { panel_ids: ['P3', 'P4'], shares: [60, 40] },
+      { panel_ids: ['P1', 'P2'], shares: [25, 75] },
+      { panel_ids: ['P3', 'P4'], shares: [50, 50] },
     ],
   });
 });
@@ -1377,14 +1401,82 @@ section={"title":"流入別の比較表","component":"table","planned_visualizat
 rows=[("organic",120),("cpc",80)]
 print(json.dumps({
  "planned":m.dashboard_visualization(section,rows,["medium","sessions"]),
- "automatic":m.visualization_for_result(rows,["medium","sessions"]),
+ "automatic_fallback":hasattr(m,"visualization_for_result"),
 },ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
     planned: 'table',
-    automatic: 'bar',
+    automatic_fallback: false,
   });
+});
+
+test('expanded AI chart contracts preserve aliases through dry run and rendering', () => {
+  const result = python(`
+from datetime import date
+specs={
+ "kpi_group":([], ["購入件数","購入金額"], [(10,200)], ["INT64","NUMERIC"]),
+ "grouped_bar":(["デバイス"], ["セッション数","購入件数"], [("mobile",100,10)], ["STRING","INT64","INT64"]),
+ "stacked_bar":(["新規区分"], ["購入","未購入"], [("新規",10,90)], ["STRING","INT64","INT64"]),
+ "multi_line":(["日付"], ["購入件数","購入金額"], [(date(2021,1,1),10,200)], ["DATE","INT64","NUMERIC"]),
+ "scatter":(["ページ"], ["閲覧数","購入金額"], [("/shop",100,200)], ["STRING","INT64","NUMERIC"]),
+ "bubble":(["ページ"], ["閲覧数","購入金額","購入件数"], [("/shop",100,200,10)], ["STRING","INT64","NUMERIC","INT64"]),
+ "funnel":(["段階"], ["セッション数"], [("1. 閲覧",100)], ["STRING","INT64"]),
+ "heatmap":(["曜日","時間帯"], ["購入件数"], [("月","午前",10)], ["STRING","STRING","INT64"]),
+}
+observed={}
+for chart,(dimensions,measures,rows,types) in specs.items():
+ panel={"id":"P1","title":chart,"chart":chart,"decision":"判断","execution_prompt":"仕様","dimensions":dimensions,"measures":measures}
+ section=m.planned_analysis_section(panel)
+ schema=list(zip(section["source_columns"],types))
+ m.validate_dashboard_dry_run_schema(section,schema)
+ observed[chart]={"aliases":section["source_columns"],"render":m.dashboard_visualization(section,rows,dimensions+measures),"limit":section["max_result_rows"]}
+bad=m.planned_analysis_section({"id":"P1","title":"bubble","chart":"bubble","decision":"判断","execution_prompt":"仕様","dimensions":["ページ"],"measures":["閲覧数","購入金額","購入件数"]})
+try:m.dashboard_visualization(bad,[("/shop",100,200,-1)],["ページ","閲覧数","購入金額","購入件数"])
+except m.LiveDemoError as error:bad_error=str(error)
+bad_bar=m.planned_analysis_section({"id":"P2","title":"bar","chart":"bar","decision":"判断","execution_prompt":"仕様","dimensions":["区分"],"measures":["指標"]})
+try:m.dashboard_visualization(bad_bar,[("差分",-1)],["区分","指標"])
+except m.LiveDemoError as error:bad_bar_error=str(error)
+print(json.dumps({"observed":observed,"bad_error":bad_error,"bad_bar_error":bad_bar_error},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.observed, {
+    kpi_group: { aliases: ['metric_1', 'metric_2'], render: 'kpi_group', limit: 1 },
+    grouped_bar: {
+      aliases: ['category', 'metric_1', 'metric_2'],
+      render: 'grouped_bar',
+      limit: 20,
+    },
+    stacked_bar: {
+      aliases: ['category', 'metric_1', 'metric_2'],
+      render: 'stacked_bar',
+      limit: 20,
+    },
+    multi_line: {
+      aliases: ['event_date', 'metric_1', 'metric_2'],
+      render: 'multi_line',
+      limit: 100,
+    },
+    scatter: {
+      aliases: ['category', 'x_value', 'y_value'],
+      render: 'scatter',
+      limit: 100,
+    },
+    bubble: {
+      aliases: ['category', 'x_value', 'y_value', 'size_value'],
+      render: 'bubble',
+      limit: 100,
+    },
+    funnel: { aliases: ['stage', 'metric_value'], render: 'funnel', limit: 12 },
+    heatmap: {
+      aliases: ['x_category', 'y_category', 'metric_value'],
+      render: 'heatmap',
+      limit: 100,
+    },
+  });
+  assert.match(output.bad_error, /結果形状がAI分析仕様のbubbleと一致しない/);
+  assert.match(output.bad_bar_error, /結果形状がAI分析仕様のbarと一致しない/);
 });
 
 test('dashboard rendering rejects a result shape that differs from the AI specification', () => {
@@ -1397,6 +1489,267 @@ except m.LiveDemoError as error:print(str(error))
   assert.match(result.stdout, /結果形状がAI分析仕様のscorecardと一致しない/);
 });
 
+test('a planned line remains drawable when dates are missing or the result is empty', () => {
+  const result = python(`
+from datetime import date
+from decimal import Decimal
+section={"title":"日別購入金額推移","component":"line","planned_visualization":"line"}
+print(json.dumps({
+ "nullable":m.dashboard_visualization(section,[(date(2021,1,1),Decimal("1200")),(date(2021,1,2),None)],["event_date","metric_value"]),
+ "empty":m.dashboard_visualization(section,[],["event_date","metric_value"]),
+},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    nullable: 'line',
+    empty: 'line',
+  });
+});
+
+test('dashboard rejects generated SQL whose declared output cannot match the chart before execution', () => {
+  const result = python(`
+section={"title":"購入規模","component":"table","planned_visualization":"scorecard","source_columns":["metric_value"]}
+tick=chr(96);table=tick+"bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*"+tick
+good="SELECT SUM(purchases) AS metric_value FROM (SELECT medium, COUNT(*) AS purchases FROM "+table+" GROUP BY medium)"
+m.validate_generated_dashboard_sql(section,good)
+bad="SELECT medium AS category, COUNT(*) AS metric_value FROM "+table+" GROUP BY medium"
+try:m.validate_generated_dashboard_sql(section,bad)
+except m.LiveDemoError as error:print(str(error))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /scorecardに必要な1列の一意なASCII別名を満たさないためBigQueryへ送信しません/,
+  );
+});
+
+test('stacked bars accept semantic SQL aliases while preserving column order and types', () => {
+  const result = python(`
+panel={"id":"P1","title":"デバイス別新規・リピートセッション構成","chart":"stacked_bar","decision":"デバイス別の定着度を判断する","execution_prompt":"2021年1月のデバイス別に新規セッション数とリピートセッション数を比較する","dimensions":["デバイス"],"measures":["新規セッション数","リピートセッション数"]}
+section=m.planned_analysis_section(panel)
+tick=chr(96);table=tick+"bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*"+tick
+sql="SELECT device.category AS device_category, COUNTIF(is_new) AS new_sessions, COUNTIF(NOT is_new) AS repeat_sessions FROM "+table+" GROUP BY device_category ORDER BY new_sessions DESC LIMIT 20"
+m.validate_generated_dashboard_sql(section,sql)
+m.validate_dashboard_dry_run_schema(section,[("device_category","STRING"),("new_sessions","INT64"),("repeat_sessions","INT64")])
+errors=[]
+for invalid_sql in [
+ "SELECT device.category AS device_category, COUNTIF(is_new) AS sessions FROM "+table+" GROUP BY device_category ORDER BY sessions DESC LIMIT 20",
+ "SELECT device.category, COUNTIF(is_new) AS new_sessions, COUNTIF(NOT is_new) AS repeat_sessions FROM "+table+" GROUP BY device.category ORDER BY new_sessions DESC LIMIT 20",
+]:
+ try:m.validate_generated_dashboard_sql(section,invalid_sql)
+ except m.LiveDemoError as error:errors.append(str(error))
+try:m.validate_dashboard_dry_run_schema(section,[("device_category","STRING"),("new_sessions","STRING"),("repeat_sessions","INT64")])
+except m.LiveDemoError as error:errors.append(str(error))
+print(json.dumps({"accepted":True,"errors":errors,"display_columns":section["shape"]["columns"]},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.accepted, true);
+  assert.deepEqual(output.display_columns, [
+    'デバイス',
+    '新規セッション数',
+    'リピートセッション数',
+  ]);
+  assert.equal(output.errors.length, 3);
+  assert.match(output.errors[0], /必要な3列/);
+  assert.match(output.errors[1], /別名なし/);
+  assert.match(output.errors[2], /dry run出力/);
+});
+
+test('grouped bars require non-null metric expressions before BigQuery execution', () => {
+  const result = python(`
+panel={"id":"P1","title":"イベント別エンゲージメント時間とユーザー数","chart":"grouped_bar","decision":"行動を判断する","execution_prompt":"2021年1月のイベント別にエンゲージメント時間とユーザー数を比較する","dimensions":["イベント"],"measures":["エンゲージメント時間","ユーザー数"]}
+section=m.planned_analysis_section(panel)
+tick=chr(96);table=tick+"bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*"+tick
+unsafe="SELECT event_name AS category, SUM(engagement_time) AS metric_1, COUNT(DISTINCT user_pseudo_id) AS metric_2 FROM "+table+" GROUP BY category ORDER BY metric_1 DESC LIMIT 20"
+safe="SELECT event_name AS category, COALESCE(SUM(engagement_time), 0) AS metric_1, COUNT(DISTINCT user_pseudo_id) AS metric_2 FROM "+table+" GROUP BY category ORDER BY metric_1 DESC LIMIT 20"
+error=""
+try:m.validate_generated_dashboard_sql(section,unsafe)
+except m.LiveDemoError as caught:error=str(caught)
+m.validate_generated_dashboard_sql(section,safe)
+print(json.dumps({"error":error,"safe":True,"requirements":section["generation_requirements"],"nonnull":section["nonnull_metric_columns"]},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.match(output.error, /NULLを返し得るためBigQueryへ送信しません/);
+  assert.equal(output.safe, true);
+  assert.deepEqual(output.nonnull, ['metric_1', 'metric_2']);
+  assert.ok(output.requirements.some((value: string) => value.includes('COALESCE')));
+});
+
+test('a single-row KPI group does not require meaningless ordering or a row limit', () => {
+  const result = python(`
+section={"title":"サイト全体エンゲージメント概要","component":"kpi_group","planned_visualization":"kpi_group","source_columns":["metric_1","metric_2","metric_3","metric_4"],"max_result_rows":1}
+tick=chr(96);table=tick+"bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*"+tick
+sql="SELECT COUNT(DISTINCT user_pseudo_id) AS metric_1, COUNT(*) AS metric_2, SUM(engagement_time) AS metric_3, AVG(engagement_time) AS metric_4 FROM "+table
+m.validate_generated_dashboard_sql(section,sql)
+print("accepted")
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), 'accepted');
+});
+
+test('dynamic dashboard SQL is bounded to the renderer row limit before BigQuery execution', () => {
+  const result = python(`
+def panel(title,chart,dimensions):
+ return {"id":"P1","title":title,"kpi":"購入金額","chart":chart,"decision":"優先施策を判断する","reason":"比較に必要","execution_prompt":"2021年1月の"+"・".join(dimensions+["購入金額"])+"を比較する","dimensions":dimensions,"measures":["購入金額"]}
+question="2021年1月の購入成果を改善するダッシュボードを作って"
+limits={}
+for chart,dimensions in [("bar",["商品"]),("line",["日別"]),("table",["商品"]),("sankey",["source","target"])]:
+ plan={"period":m.period_for_question(question),"panels":[panel(chart,chart,dimensions)]}
+ _period,sections=m.dashboard_sections_for_plan(question,plan)
+ limits[chart]=sections[0]["max_result_rows"]
+section={"id":"P1","title":"商品別購入金額","text":"2021年1月の商品別購入金額を比較する","compare":"execution","component":"table","planned_visualization":"table","verification":"execution","shape":{"rows":"商品ごとに1行","columns":["商品","購入金額"]},"source_columns":["dimension_1","metric_1"],"dimension_count":1,"max_result_rows":100}
+tick=chr(96);table=tick+"bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*"+tick
+unbounded="SELECT item_name AS dimension_1, SUM(revenue) AS metric_1 FROM "+table+" WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131' GROUP BY item_name ORDER BY metric_1 DESC"
+try:m.validate_generated_dashboard_sql(section,unbounded)
+except m.LiveDemoError as error:rejected=str(error)
+else:rejected="accepted"
+bounded=unbounded+" LIMIT 100"
+m.validate_generated_dashboard_sql(section,bounded)
+e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.rules="";e.client=e.bq=object()
+m.report.generate=lambda *_args,**_kwargs:({"sql":unbounded,"reason":"商品別比較","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
+m.report.repair=lambda *_args,**_kwargs:({"sql":bounded,"reason":"行数上限を修正","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
+executions=[]
+m.report.inspect_bq_schema=lambda *_args,**_kwargs:(executions.append("dry-run") or ([('dimension_1','STRING'),('metric_1','NUMERIC')],None))
+m.report.exec_bq=lambda *_args,**_kwargs:(executions.append("query") or (([("商品A",10)],["dimension_1","metric_1"]),None))
+try:e._run_section(section,{"from":"20210101","to":"20210131","label":"2021年1月"},lambda _event:None,{"panel_id":"P1"})
+except m.LiveDemoError as error:build_error=str(error)
+else:build_error=""
+print(json.dumps({"limits":limits,"unbounded":rejected,"bounded":"accepted","build_error":build_error,"executions":executions},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    limits: { bar: 30, line: 100, table: 100, sankey: 100 },
+    unbounded:
+      '商品別購入金額のSQLにtable用のORDER BYとLIMIT 100以下がないためBigQueryへ送信しません。',
+    bounded: 'accepted',
+    build_error: '',
+    executions: ['dry-run', 'query'],
+  });
+});
+
+test('dashboard dry-run schema mismatch stops before the paid query execution', () => {
+  const result = python(`
+e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.rules="";e.client=e.bq=object()
+section={"id":"P1","title":"購入規模","text":"2021年1月の購入件数を集計する","compare":"execution","component":"table","planned_visualization":"scorecard","verification":"execution","shape":{"rows":"1行","columns":["購入件数"]},"source_columns":["metric_value"]}
+tick=chr(96);sql="SELECT COUNT(*) AS metric_value FROM "+tick+"bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*"+tick+" WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131'"
+m.report.generate=lambda *_args,**_kwargs:({"sql":sql,"reason":"集計","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
+m.report.repair=lambda *_args,**_kwargs:({"sql":sql,"reason":"型を修正できない","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
+m.report.inspect_bq_schema=lambda *_args,**_kwargs:([("metric_value","STRING")],None)
+executions=[];m.report.exec_bq=lambda *_args,**_kwargs:(executions.append(True) or (([],[]),None))
+try:e._run_section(section,{"from":"20210101","to":"20210131","label":"2021年1月"},lambda _event:None,{"panel_id":"P1"})
+except m.LiveDemoError as error:print(json.dumps({"error":str(error),"executions":executions},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    error:
+      'SQL担当AIで1回修正しましたが、実行前診断を解消できなかったため実行しません: 購入規模のdry run出力（metric_value:STRING）がscorecardの描画仕様と一致しないためBigQueryを実行しません。',
+    executions: [],
+  });
+});
+
+test('a missing stacked-bar dimension alias is repaired before BigQuery dry run', () => {
+  const result = python(`
+e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.rules="rules";e.bitcoin_rules="bitcoin";e.client=e.bq=object()
+panel={"id":"P1","title":"デバイス別 エンゲージメント時間と購入件数の比較","chart":"stacked_bar","decision":"デバイス差を判断する","execution_prompt":"2021年1月のデバイス別エンゲージメント時間と購入件数を比較する","dimensions":["デバイス"],"measures":["エンゲージメント時間","購入件数"]}
+section=m.planned_analysis_section(panel)
+tick=chr(96);table=tick+"bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*"+tick
+initial="SELECT device.category, COALESCE(SUM(1), 0) AS metric_1, COUNTIF(event_name = 'purchase') AS metric_2 FROM "+table+" WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131' GROUP BY device.category ORDER BY metric_2 DESC LIMIT 20"
+repaired="SELECT device.category AS dimension_1, COALESCE(SUM(1), 0) AS metric_1, COUNTIF(event_name = 'purchase') AS metric_2 FROM "+table+" WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131' GROUP BY dimension_1 ORDER BY metric_2 DESC LIMIT 20"
+m.report.generate=lambda *_args,**_kwargs:({"sql":initial,"reason":"初回","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
+repairs=[]
+m.report.repair=lambda _client,_model,_request,sql,diagnostic,_rules:(repairs.append([sql,diagnostic]) or ({"sql":repaired,"reason":"区分軸の別名を修正","undefined_terms":[]},{"input_tokens":1,"output_tokens":1}))
+dry_runs=[];m.report.inspect_bq_schema=lambda _bq,sql,**_kwargs:(dry_runs.append(sql) or ([('dimension_1','STRING'),('metric_1','INT64'),('metric_2','INT64')],None))
+executed=[];m.report.exec_bq=lambda _bq,sql,**_kwargs:(executed.append(sql) or (([('mobile',100,5)],['dimension_1','metric_1','metric_2']),None))
+events=[];e._run_section(section,{"from":"20210101","to":"20210131","label":"2021年1月"},events.append)
+print(json.dumps({"repairs":repairs,"dry_runs":dry_runs,"executed":executed,"stages":[event.get("stage") for event in events if event["type"]=="stage"],"reason":next(event["reason"] for event in events if event["type"]=="sql")},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.repairs.length, 1);
+  assert.match(output.repairs[0][1], /SQL出力列（別名なし、metric_1、metric_2）/);
+  assert.deepEqual(output.dry_runs, [output.executed[0]]);
+  assert.match(output.executed[0], /device\.category AS dimension_1/);
+  assert.deepEqual(output.stages, ['generate', 'validate', 'repair', 'execute']);
+  assert.equal(output.reason, '区分軸の別名を修正');
+});
+
+test('a BigQuery compiler diagnostic is repaired once before paid execution', () => {
+  const result = python(`
+e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.rules="rules";e.bitcoin_rules="bitcoin";e.client=e.bq=object()
+panel={"id":"P1","title":"主要ページ間回遊フロー","chart":"scorecard","decision":"回遊を判断する","execution_prompt":"2021年1月の回遊セッション数を集計する","dimensions":[],"measures":["セッション数"]}
+section=m.planned_analysis_section(panel)
+tick=chr(96);table=tick+"bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*"+tick
+initial="SELECT COUNT(*) AS metric_value FROM "+table+" WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131'"
+repaired="WITH base AS (SELECT user_pseudo_id FROM "+table+" WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131') SELECT COUNT(*) AS metric_value FROM base"
+m.report.generate=lambda *_args,**_kwargs:({"sql":initial,"reason":"初回","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
+repairs=[]
+m.report.repair=lambda _client,_model,request,sql,diagnostic,rules:(repairs.append([request,sql,diagnostic,rules]) or ({"sql":repaired,"reason":"相関をCTEへ変換","undefined_terms":[]},{"input_tokens":2,"output_tokens":2}))
+dry_runs=[]
+def inspect(_bq,sql,**_kwargs):
+ dry_runs.append(sql)
+ return (None,"bq dry-run error: BadRequest: Correlated subqueries that reference other tables are not supported") if len(dry_runs)==1 else ([('metric_value','INT64')],None)
+m.report.inspect_bq_schema=inspect
+executed=[]
+m.report.exec_bq=lambda _bq,sql,**_kwargs:(executed.append(sql) or (([(12,)],["metric_value"]),None))
+events=[]
+cost=e._run_section(section,{"from":"20210101","to":"20210131","label":"2021年1月"},events.append)
+print(json.dumps({"repairs":repairs,"dry_runs":dry_runs,"executed":executed,"stages":[event.get("stage") for event in events if event["type"]=="stage"],"reason":next(event["reason"] for event in events if event["type"]=="sql"),"cost_positive":cost>0},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.repairs.length, 1);
+  assert.match(output.repairs[0][0], /2021年1月の回遊セッション数/);
+  assert.match(output.repairs[0][2], /Correlated subqueries/);
+  assert.equal(output.repairs[0][3], 'rules');
+  assert.equal(output.dry_runs.length, 2);
+  assert.equal(output.dry_runs[0], output.repairs[0][1]);
+  assert.equal(output.dry_runs[1], output.executed[0]);
+  assert.deepEqual(output.executed, [output.dry_runs[1]]);
+  assert.deepEqual(output.stages, ['generate', 'validate', 'repair', 'execute']);
+  assert.equal(output.reason, '相関をCTEへ変換');
+  assert.equal(output.cost_positive, true);
+});
+
+test('cancelling an active request releases the server operation lock', () => {
+  const result = python(`
+import threading,time
+e=object.__new__(m.LiveQueryEngine);e.lock=threading.Lock();e.operation_state_lock=threading.Lock();e.active_request_id=e.active_cancel_event=e.active_done_event=None
+token=e._begin_operation("request-123456789012-abcd");cancelled=[]
+thread=threading.Thread(target=lambda:cancelled.append(e.cancel("request-123456789012-abcd")));thread.start()
+for _ in range(100):
+ if token.is_set():break
+ time.sleep(.001)
+observed=token.is_set();e._finish_operation();thread.join()
+available=e.lock.acquire(blocking=False)
+if available:e.lock.release()
+print(json.dumps({"observed":observed,"cancelled":cancelled,"available":available}))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    observed: true,
+    cancelled: [true],
+    available: true,
+  });
+});
+
+test('composer becomes a stop control and prevents a second submission while streaming', () => {
+  const rendered = python('print(m.HTML)');
+  assert.equal(rendered.status, 0, rendered.stderr);
+  const script = rendered.stdout.split('<script>').at(-1)?.split('</script>')[0] ?? '';
+  for (const expected of [
+    'new AbortController()',
+    'function stopActiveRequest()',
+    '$("composer-submit").textContent="■"',
+    '$("composer-input").disabled=true',
+    'if(activeRequest){stopActiveRequest();return}',
+    'request_id:operation.requestId',
+  ]) {
+    assert.ok(script.includes(expected), `missing in-flight composer contract: ${expected}`);
+  }
+});
+
 test('dashboard UI separates consultation from confirmed paid build', () => {
   const result = python(`
 html=m.HTML
@@ -1405,7 +1758,7 @@ print(json.dumps({
  "review":all(value in html for value in ['id="plan-review"','id="plan-clarifications"','id="plan-panels"','id="plan-revision"']),
  "flow":all(value in html for value in ['/api/plan','answers:currentAnswers','analysis_plan:pendingPlan','selected.size<1']),
  "iterative":all(value in html for value in ['id="plan-revision-instruction"','analysis_plan:pendingPlanBase','revision_instruction:pendingPlanInstruction','追加・変更・削除']),
- "memory":all(value in html for value in ["organization_context_revision","ローカルデモfixture・本番メモリー未接続"]),
+ "memory":all(value in html for value in ["organization_context_revision","依頼と確認回答から生成したコンテキスト"]),
 }))
 `);
   assert.equal(result.status, 0, result.stderr);
@@ -1450,19 +1803,19 @@ print(json.dumps({"initial":m.planner.INITIAL_PANEL_COUNT,"maximum":m.planner.MA
 
 test('an AI-authored dashboard supports twenty panels without hardcoded topics', () => {
   const result = python(`
-def panel(index):return {"id":f"P{index}","title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の定義済み指標{index}を1行で出して"}
+def panel(index):return {"id":f"P{index}","title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の定義済み指標{index}を1行で出して","dimensions":[],"measures":[f"定義済み指標{index}"],"layout_row":(index+3)//4,"layout_weight":((index-1)%4)+1}
 question="2021年1月の購入課題を分析するダッシュボードを作って"
 plan={"period":m.period_for_question(question),"panels":[panel(index) for index in range(1,21)]}
 period,sections=m.dashboard_sections_for_plan(question,plan)
 layout=m.dashboard_layout_rows_for_plan(plan["panels"])
-print(json.dumps({"limit":m.MAX_PLAN_BODY_BYTES,"sections":len(sections),"rows":len(layout),"all_full":all(len(row["panel_ids"])==2 and sum(row["shares"])==100 for row in layout)},ensure_ascii=False))
+print(json.dumps({"limit":m.MAX_PLAN_BODY_BYTES,"sections":len(sections),"rows":len(layout),"all_weighted":all(len(row["panel_ids"])==4 and sum(row["shares"])==100 for row in layout)},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
     limit: 98304,
     sections: 20,
-    rows: 10,
-    all_full: true,
+    rows: 5,
+    all_weighted: true,
   });
 });
 
@@ -1474,8 +1827,8 @@ print(json.dumps({
  "adjustable":all(value in html for value in ['id="sidebar-toggle"','aria-label="ナビゲーションを折りたたむ"','id="navigation-resizer"','aria-label="ナビゲーションの幅を変更"','id="inspector-toggle"','aria-label="詳細パネルを折りたたむ"','id="inspector-resizer"','aria-label="詳細パネルの幅を変更"']),
  "views":all(value in html for value in ['id="artifact-dashboard-view"','id="build-studio-view"','id="meeting-report-view"','id="graph-workspace"']),
  "navigation":all(value in html for value in ['id="view-dashboard"','id="view-build"','id="view-report"','id="view-graph"']),
- "conversation":all(value in html for value in ['id="analysis-composer"','id="composer-input"','data-composer-action="consult"','data-composer-action="dashboard"','data-composer-action="insight"','data-composer-action="report"']),
- "artifact_tree":all(value in html for value in ['aria-label="分析成果物"','購入成果改善ダッシュボード','未保存のインサイト','aria-label="分析スレッド"','購入成果を改善する','現在の対話']),
+ "conversation":all(value in html for value in ['id="analysis-composer"','id="composer-input"','data-composer-action="consult"','data-composer-action="dashboard"','data-composer-action="insight"']) and 'data-composer-action="report"' not in html,
+ "artifact_tree":all(value in html for value in ['aria-label="分析成果物"','ダッシュボード','未作成','未保存のインサイト','aria-label="分析スレッド"','新しい分析','現在の対話']),
  "inspector":all(value in html for value in ['id="inspector-empty"','id="inspector-content"','id="inspector-tab-reason"','id="inspector-tab-sql"','id="inspector-tab-data"','id="inspector-tab-provenance"']),
  "artifact_preview":all(value in html for value in ['id="artifact-preview"','id="artifact-preview-host"','単一グラフのインサイト']),
 }))
@@ -1493,7 +1846,7 @@ print(json.dumps({
   });
 });
 
-test('broad analysis requests use paid, stateful AI consultation before paid execution', () => {
+test('explicit consultation and every new insight use stateful AI planning before execution', () => {
   const rendered = python('print(m.HTML)');
   assert.equal(rendered.status, 0, rendered.stderr);
   const script = rendered.stdout.split('<script>').at(-1)?.split('</script>')[0] ?? '';
@@ -1508,17 +1861,37 @@ test('broad analysis requests use paid, stateful AI consultation before paid exe
   assert.ok(script.includes('consultationHistory.slice(-8)'));
   assert.ok(script.includes('stream("/api/consult"'));
   assert.ok(script.includes('function selectAnalysisRecommendation(recommendation)'));
+  assert.ok(script.includes('pendingInsightSpecification=recommendation'));
+  assert.ok(script.includes('analysis_specification:pendingInsightSpecification'));
+  assert.ok(script.includes('selectProfile($("composer-profile").value)'));
+  assert.ok(
+    script.includes(
+      '$("question").addEventListener("input",()=>{pendingInsightSpecification=null})',
+    ),
+  );
+  assert.ok(
+    script.includes(
+      'function beginAnalysisConsultation(question,profile){pendingInsightSpecification=null',
+    ),
+  );
+  assert.ok(
+    script.includes(
+      '$("composer-profile").onchange=()=>{pendingInsightSpecification=null;const profile=$("composer-profile").value;selectProfile(profile);$("composer-input").value=""',
+    ),
+  );
   assert.ok(script.includes('if(action==="consult"){beginAnalysisConsultation'));
+  assert.ok(
+    script.includes(
+      'if(!pendingInsightSpecification||question!==pendingInsightSpecification.execution_prompt){beginAnalysisConsultation',
+    ),
+  );
   assert.ok(script.includes('selectWorkspace("consult");setComposerAction("consult",false)'));
   assert.ok(script.includes('setComposerAction("insight",false)'));
   assert.ok(script.includes('$("composer-input").value=""'));
   assert.ok(!script.includes('const analysisRecommendations='));
   const submit =
     script.match(/function submitComposer\(\)\{.*?\}\nconst originalQueryHandler/s)?.[0] ?? '';
-  assert.ok(
-    submit.indexOf('if(action==="consult"){beginAnalysisConsultation') <
-      submit.indexOf('showCost("graph")'),
-  );
+  assert.ok(submit.indexOf('beginAnalysisConsultation') < submit.indexOf('showCost("graph")'));
 });
 
 test('consultation HTTP boundary accepts bounded history and rejects invalid turns', () => {
@@ -1529,7 +1902,7 @@ class E:
  calls=[]
  def consult(self,question,history,emit,profile="ga4"):
   self.calls.append({"question":question,"history":history,"profile":profile})
-  emit({"type":"consultation","assistant_message":"別の切り口です。","follow_up_question":"どちらを優先しますか？","recommendations":[{"title":"流入チャネル別の購入効率","objective":"成果につながる流入元を探す","metric":"セッション数と購入件数","dimension":"medium","comparison":"チャネル間","chart":"bar","execution_prompt":"2021年1月のセッション数と購入件数を流入チャネル（medium）別に出して","reason":"偏りを判断するため"}],"history_message":"別の切り口です。"})
+  emit({"type":"consultation","assistant_message":"別の切り口です。","follow_up_question":"どちらを優先しますか？","recommendations":[{"title":"流入チャネル別の集客規模","objective":"集客量が偏る流入元を探す","dimensions":["medium"],"measures":["セッション数"],"comparison":"チャネル間","chart":"bar","execution_prompt":"2021年1月のセッション数を流入チャネル（medium）別に出して","reason":"偏りを判断するため","revision":"insight-111111111111"}],"history_message":"別の切り口です。"})
 engine=E();s=m.create_server("127.0.0.1",0,engine);t=threading.Thread(target=s.serve_forever,daemon=True);t.start();base=f"http://127.0.0.1:{s.server_port}"
 def post(history):
  data=json.dumps({"question":"他にない？","profile":"ga4","history":history},ensure_ascii=False).encode()
@@ -1564,18 +1937,47 @@ finally:s.shutdown();s.server_close();t.join()
   });
 });
 
-test('consultation prompt detection is bounded to advice requests', () => {
+test('query routing does not classify natural-language phrases', () => {
+  const result = python(
+    'print(json.dumps({"classifier":hasattr(m,"requires_analysis_consultation")}))',
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), { classifier: false });
+});
+
+test('every single-insight build requires an AI-authored specification', () => {
   const result = python(`
-print(json.dumps({
- "broad":[m.requires_analysis_consultation(value) for value in ["どんな分析をしたらいい？","何を分析すればいい？","おすすめの分析を教えて","どんな分析をしたらいい" + "！" * 1000]],
- "concrete":[m.requires_analysis_consultation(value) for value in ["2021年1月のセッション数を出して","2021年1月のWebサイト回遊を分析して","2024年1月のBitcoin取引の受取アドレス数帯別の取引数を出して"]]
-}))
+import threading
+e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.client=e.bq=object();e.lock=threading.Lock()
+errors=[]
+for profile,question in [("ga4","2021年1月のユーザー数を出して"),("bitcoin","2024年1月の取引数を出して")]:
+ try:e.query(question,lambda _event:None,profile=profile)
+ except m.LiveDemoError as error:errors.append(str(error))
+print(json.dumps({"errors":errors,"selector":hasattr(m,"section_for_question"),"classifier":hasattr(m,"requires_analysis_consultation")},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
-    broad: [true, true, true, true],
-    concrete: [false, false, false],
+    errors: [
+      'AIが作成した分析仕様を選択してからbuildしてください。',
+      'AIが作成した分析仕様を選択してからbuildしてください。',
+    ],
+    selector: false,
+    classifier: false,
   });
+});
+
+test('workspace exposes no fixed insight examples or phrase classifier', () => {
+  const rendered = python('print(m.HTML)');
+  assert.equal(rendered.status, 0, rendered.stderr);
+  const script = rendered.stdout.split('<script>').at(-1)?.split('</script>')[0] ?? '';
+  assert.doesNotMatch(rendered.stdout, /data-q=/);
+  assert.ok(!script.includes('function isConsultationPrompt(question)'));
+  assert.ok(!script.includes('profileDefaults'));
+  assert.ok(!script.includes('action==="consult"?"どんな分析をしたらいい？"'));
+  assert.ok(!script.includes('card.dataset.panelId==="R17"'));
+  assert.ok(!script.includes('card.dataset.panelId==="R9"'));
+  assert.doesNotMatch(rendered.stdout, /購入成果改善ダッシュボード|流入別の購入率/);
+  assert.match(rendered.stdout, /id="dashboard-question"[^>]*><\/textarea>/);
 });
 
 test('workspace pane controls stay viewport-anchored and expose their state visually', () => {
@@ -1677,10 +2079,35 @@ test('dashboard resizes every shared row without free rearrangement', () => {
   assert.doesNotMatch(script, /draggable\s*=|ondragstart|Sortable/);
 });
 
+test('dashboard cards in the same row share height while content stays top-aligned', () => {
+  const rendered = python('print(m.HTML)');
+  assert.equal(rendered.status, 0, rendered.stderr);
+  assert.match(rendered.stdout, /\.dashboard-layout-row\{[^}]*align-items:stretch/);
+  assert.match(
+    rendered.stdout,
+    /\.dashboard-card \.chart\{[^}]*align-items:start[^}]*overflow:visible[^}]*flex:1/,
+  );
+  assert.match(
+    rendered.stdout,
+    /\.dashboard-layout-row>\.dashboard-card \.chart\{[^}]*max-height:460px[^}]*overflow:auto/,
+  );
+  assert.ok(
+    rendered.stdout.indexOf(
+      '.dashboard-layout-row>.dashboard-card .chart{max-height:460px;overflow:auto}',
+    ) <
+      rendered.stdout.indexOf(
+        '@container (max-width:900px){.dashboard-layout-row{grid-template-columns:',
+      ),
+    'the single-column container override must follow the desktop height cap',
+  );
+  assert.match(rendered.stdout, /\.chart-table-scroll\{[^}]*max-height:360px[^}]*overflow:auto/);
+  assert.match(rendered.stdout, /\.chart-table-scroll th,[^}]*overflow-wrap:anywhere/);
+});
+
 test('left navigation stays compact and scrolls long titles only on interaction', () => {
   const rendered = python('print(m.HTML)');
   assert.equal(rendered.status, 0, rendered.stderr);
-  assert.match(rendered.stdout, /class="sidebar-title"><span>購入成果改善ダッシュボード<\/span>/);
+  assert.match(rendered.stdout, /class="sidebar-title"><span>ダッシュボード<\/span>/);
   assert.match(
     rendered.stdout,
     /class="sidebar-chrome"><span class="brand">RepChat<\/span><\/div>/,
@@ -1731,8 +2158,8 @@ test('analysis workspace visual hierarchy protects charts and the main surface',
 html=m.HTML
 print(json.dumps({
  "tokens":all(value in html for value in ["--radius-card:12px","--shadow-card:","--color-background:"]),
- "hierarchy":all(value in html for value in [".dashboard-card:nth-child(1){grid-column:span 6}",".dashboard-card:nth-child(2),.dashboard-card:nth-child(3){grid-column:span 3}"]),
- "overflow":all(value in html for value in ["body{overflow-x:hidden", ".dashboard-card.wide .chart svg,.dashboard-card.full .chart svg{min-width:0}"]),
+ "hierarchy":all(value in html for value in [".dashboard-layout-row>.dashboard-card{grid-column:auto!important;min-height:268px", ".dashboard-layout-row>.dashboard-card{grid-column:1!important;min-height:340px}"]),
+ "overflow":all(value in html for value in ["body{overflow-x:hidden", ".dashboard-card .chart svg{display:block;min-width:0;width:100%;max-width:100%}"]),
  "responsive":all(value in html for value in ["@media(max-width:1180px)","position:fixed","@media(max-width:960px)","@media(max-width:760px)"]),
  "accessible":all(value in html for value in [":focus-visible","prefers-reduced-motion:reduce","outline:3px solid var(--color-focus)"]),
 }))
@@ -1784,7 +2211,7 @@ test('selected workspace title is compact and not repeated above the main conten
   );
   assert.match(
     rendered.stdout,
-    /build:\["購入成果を改善する","AIと目的・KPI・比較軸を相談し、確認した仕様だけをbuildします。","分析スレッド"\]/,
+    /build:\["新しい分析","AIと目的・KPI・比較軸を相談し、確認した仕様だけをbuildします。","分析スレッド"\]/,
   );
   assert.doesNotMatch(rendered.stdout, /id="workspace-back"|id="workspace-forward"/);
 });
@@ -1863,7 +2290,7 @@ test('meeting report owns persistent processing and error state across workspace
   const script = rendered.stdout.split('<script>').at(-1)?.split('</script>')[0] ?? '';
   assert.ok(rendered.stdout.includes('id="report-status"'));
   assert.ok(rendered.stdout.includes('id="report-message"'));
-  assert.ok(!rendered.stdout.includes('id="report-warning"'));
+  assert.ok(!rendered.stdout.includes('generation_warnings'));
   assert.ok(script.includes('let reportWorkspaceState="報告案なし"'));
   assert.ok(script.includes('view==="report"?reportWorkspaceState:copy[view][2]'));
   assert.ok(script.includes('setReportState("エラー",e.message,"notice error")'));
@@ -1945,8 +2372,8 @@ test('chart values use bounded Japanese number formatting without changing raw t
   assert.deepEqual([...values], ['118,380', '895', '57,350.13', '14.57', '49.51', 'organic']);
   assert.ok(script.includes('textContent:chartValue(r.rows[0][0],r.columns[0],true)'));
   assert.ok(script.includes('value.textContent=chartValue(r.rows[0][index],column)'));
-  assert.ok(script.includes('textContent:chartValue(r.rows[0][index],column,true)'));
-  assert.ok(script.includes('textContent=chartValue(x[1],r.columns?.[1]??"")'));
+  assert.ok(script.includes('textContent:chartValue(row[1],r.columns[1],true)'));
+  assert.ok(script.includes('textContent=chartValue(value,columns[1])'));
   assert.ok(
     script.includes('replaceChildren(table(result.columns,result.rows))'),
     'the audit table must retain raw query values',
@@ -2037,30 +2464,36 @@ import threading
 e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL
 e.spec=json.loads((m.HERE/"report.json").read_text());e.metric_definitions=json.loads((m.HERE/"metrics.json").read_text())
 e.client=e.bq=object();e.lock=threading.Lock();e.latest_dashboard=None
-plan={"objective":"2021年1月の購入成果を改善するダッシュボードを作って","objective_summary":"購入成果の課題を判断する","audience":"月次会議","comparison":"月内推移","period":m.period_for_question("2021年1月"),"hypotheses":["導線に課題がある"],"clarifications":[],"answers":{"audience":"月次会議"},"panels":[{"id":panel_id,"reason":"必要"} for panel_id in ["R4","R9","R16","R17"]]}
-rows={"R4":[[895,123456.0]],"R9":[[100,50,20]],"R16":[["2021-01-31",118380,117000.5]],"R17":[["1. 入口: /","2. /shop",5]]}
-columns={"R4":["購入件数","購入金額"],"R9":["閲覧","カート","購入"],"R16":["日付","セッション数","7日移動平均"],"R17":["source","target","sessions"]}
+panels=[
+ {"title":"購入規模","kpi":"購入成果","chart":"table","decision":"購入成果の規模を判断する","reason":"全体規模が必要","execution_prompt":"2021年1月の購入件数と購入金額を集計する","dimensions":[],"measures":["購入件数","購入金額"],"layout_row":1,"layout_weight":1},
+ {"title":"購入ファネル","kpi":"購入導線","chart":"table","decision":"購入までの減少箇所を判断する","reason":"導線診断が必要","execution_prompt":"2021年1月の閲覧とカートと購入を集計する","dimensions":[],"measures":["閲覧","カート","購入"],"layout_row":1,"layout_weight":1},
+ {"title":"日別推移","kpi":"セッション数","chart":"line","decision":"月内変動を判断する","reason":"変動確認が必要","execution_prompt":"2021年1月の日付別セッション数を集計する","dimensions":["日付"],"measures":["セッション数"],"layout_row":2,"layout_weight":1},
+ {"title":"主要回遊","kpi":"回遊数","chart":"sankey","decision":"主要な遷移を判断する","reason":"回遊確認が必要","execution_prompt":"2021年1月のsourceからtargetへのsessionsを集計する","dimensions":["source","target"],"measures":["sessions"],"layout_row":2,"layout_weight":1},
+]
+plan={"objective":"2021年1月の購入成果を改善するダッシュボードを作って","objective_summary":"購入成果の課題を判断する","audience":"月次会議","comparison":"月内推移","period":m.period_for_question("2021年1月"),"hypotheses":["導線に課題がある"],"clarifications":[],"answers":{"audience":"月次会議"},"panels":panels}
+rows={"P1":[[895,123456.0]],"P2":[[100,50,20]],"P3":[["2021-01-31",118380]],"P4":[["1. 入口: /","2. /shop",5]]}
+columns={"P1":["購入件数","購入金額"],"P2":["閲覧","カート","購入"],"P3":["日付","セッション数"],"P4":["source","target","sessions"]}
 def run_section(section,period,emit,context=None,profile="ga4"):
  emit({"type":"sql","sql":"SELECT value FROM source","sql_sha256":"1"*16,**context})
- emit({"type":"result","columns":columns[section["id"]],"rows":rows[section["id"]],"verification":"matched","verification_label":"照合済み","visualization":section["component"],**context})
+ emit({"type":"result","columns":columns[section["id"]],"rows":rows[section["id"]],"verification":"matched","verification_label":"照合済み","visualization":"funnel" if section["id"]=="P2" else section["component"],**context})
  return .1
 e._run_section=run_section;events=[];e.dashboard(plan["objective"],events.append,plan);bundle=e.latest_dashboard
-raw={"executive_summary":{"text":"追加診断が必要です。","panel_ids":["R4"]},"observations":[{"text":"購入件数は895件です。","panel_ids":["R4"]}],"interpretations":[{"text":"変動があります。","uncertainty":"施策履歴がありません。","panel_ids":["R16"]}],"hypotheses":[{"text":"導線に課題がある可能性があります。","validation":"流入別に検証します。","panel_ids":["R9"]}],"actions":[{"text":"導線を確認します。","owner":"マーケティング責任者","urgency":"次回会議まで","expected_impact":"阻害箇所を特定できます。","next_step":"流入別に比較します。","success_metric":"購入件数","panel_ids":["R4"]}],"limitations":["目標値と施策履歴が未登録です。"]}
+raw={"executive_summary":{"text":"追加診断が必要です。","panel_ids":["P1"]},"observations":[{"text":"購入件数は895件です。","panel_ids":["P1"]}],"interpretations":[{"text":"変動があります。","uncertainty":"施策履歴がありません。","panel_ids":["P3"]}],"hypotheses":[{"text":"導線に課題がある可能性があります。","validation":"流入別に検証します。","panel_ids":["P2"]}],"actions":[{"text":"導線を確認します。","owner":"マーケティング責任者","urgency":"次回会議まで","expected_impact":"阻害箇所を特定できます。","next_step":"流入別に比較します。","success_metric":"購入件数","panel_ids":["P1"]}],"limitations":["目標値と施策履歴が未登録です。"]}
 calls=[]
 m.meeting.generate=lambda _client,_model,current:(calls.append(current["build_revision"]) or (m.meeting.normalize_report(raw,current),{"input_tokens":10,"output_tokens":5}))
 report_events=[];e.meeting_report(bundle["build_revision"],report_events.append)
 error=""
 try:e.meeting_report("build-000000000000",lambda _event:None)
 except m.LiveDemoError as caught:error=str(caught)
-funnel=next(panel for panel in bundle["panels"] if panel["id"]=="R9")
-print(json.dumps({"dashboard_complete":events[-1]["build_revision"],"build":bundle["build_revision"],"plan":bundle["analysis_specification"]["revision"],"organization":bundle["organization_context"]["goal"],"metric":"購入件数" in bundle["metric_definitions"]["metrics"],"result_revision":bundle["panels"][0]["result_revision"],"sql":bundle["panels"][0]["sql_sha256"],"funnel_rate":funnel["derived_metrics"][0]["value"],"report_types":[event["type"] for event in report_events],"report_revision":report_events[-1]["report"]["report_revision"],"citation":report_events[-1]["report"]["observations"][0]["evidence_refs"][0],"calls":calls,"error":error},ensure_ascii=False))
+funnel=next(panel for panel in bundle["panels"] if panel["id"]=="P2")
+print(json.dumps({"dashboard_complete":events[-1]["build_revision"],"build":bundle["build_revision"],"plan":bundle["analysis_specification"]["revision"],"organization":bundle["organization_context"]["objective_summary"],"metric":"購入件数" in bundle["metric_definitions"]["metrics"],"result_revision":bundle["panels"][0]["result_revision"],"sql":bundle["panels"][0]["sql_sha256"],"funnel_rate":funnel["derived_metrics"][0]["value"],"report_types":[event["type"] for event in report_events],"report_revision":report_events[-1]["report"]["report_revision"],"citation":report_events[-1]["report"]["observations"][0]["evidence_refs"][0],"calls":calls,"error":error},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
   assert.equal(output.dashboard_complete, output.build);
   assert.match(output.build, /^build-[0-9a-f]{12}$/);
   assert.match(output.plan, /^plan-[0-9a-f]{12}$/);
-  assert.equal(output.organization, '購入成果を伸ばし、訪問者の継続利用を改善する');
+  assert.equal(output.organization, '購入成果の課題を判断する');
   assert.equal(output.metric, true);
   assert.match(output.result_revision, /^result-[0-9a-f]{12}$/);
   assert.equal(output.sql, '1111111111111111');

--- a/tests/spikes/report-generation/run-report.test.ts
+++ b/tests/spikes/report-generation/run-report.test.ts
@@ -31,9 +31,9 @@ ${body}
 `);
 }
 
-test('an exact maintained Japanese question keeps reference verification', () => {
+test('even an exact regression question remains an execution-only user request', () => {
   const result = loadRunReport(`
-sections = module["select_sections"](spec, "2021年1月のセッション数を出して")
+sections = module["sections_for_run"](spec, "2021年1月のセッション数を出して")
 print(json.dumps({
     "count": len(sections),
     "id": sections[0]["id"],
@@ -45,17 +45,17 @@ print(json.dumps({
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
     count: 1,
-    id: 'R1',
+    id: 'Q1',
     text: '2021年1月のセッション数を出して',
-    has_gold: true,
-    verification: 'reference',
+    has_gold: false,
+    verification: 'execution',
   });
 });
 
 test('a new Japanese question becomes one execution-only section', () => {
   const question = '2021年1月の購入ユーザー数をデバイス別に出して';
   const result = loadRunReport(`
-sections = module["select_sections"](spec, ${JSON.stringify(question)})
+sections = module["sections_for_run"](spec, ${JSON.stringify(question)})
 print(json.dumps(sections, ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
@@ -65,26 +65,6 @@ print(json.dumps(sections, ensure_ascii=False))
   assert.equal(sections[0].text, question);
   assert.equal(sections[0].verification, 'execution');
   assert.equal('gold_sql' in sections[0], false);
-});
-
-test('showcase mode selects KPI, funnel, trend, and navigation-flow analyses', () => {
-  const result = loadRunReport(`
-sections = module["select_sections"](spec, None, showcase=True)
-print(json.dumps([{
-    "id": section["id"],
-    "component": section["component"],
-    "verification": section["verification"],
-} for section in sections]))
-`);
-  assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), [
-    { id: 'R4', component: 'kpi_pair', verification: 'reference' },
-    { id: 'R11', component: 'big_value', verification: 'reference' },
-    { id: 'R12', component: 'big_value', verification: 'reference' },
-    { id: 'R9', component: 'funnel', verification: 'reference' },
-    { id: 'R16', component: 'trend', verification: 'reference' },
-    { id: 'R17', component: 'sankey', verification: 'reference' },
-  ]);
 });
 
 test('the navigation-flow reference SQL creates bounded staged Sankey edges', () => {
@@ -133,7 +113,7 @@ test('one-question mode rejects empty and oversized input before cloud access', 
   for (const question of ['', ' '.repeat(3), 'あ'.repeat(501), '1月の\nセッション数']) {
     const result = loadRunReport(`
 try:
-    module["select_sections"](spec, ${JSON.stringify(question)})
+    module["sections_for_run"](spec, ${JSON.stringify(question)})
 except ValueError as error:
     print(str(error))
 else:


### PR DESCRIPTION
## What & why

ライブデモのダッシュボード生成を、固定パネル・固定組織文脈・キーワード分岐・参照SQL一致ショートカットから切り離し、AIが生成した分析仕様だけを実行する経路へ統一します。対応する13種の可視化について、区分軸・指標・行数・レイアウトをプログラム契約で検証し、BigQuery送信前のSQL列検証と1回限りのAI修正、最大4ページのSankey、同一行カードの等高表示まで一貫して処理します。

Refs: #374

## Change classification (ARC-020)

- [ ] Local
- [x] Contract (AI分析仕様、SQL出力列、描画形状の境界)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: 文書差分を退避した単独状態で `make format && make lint && make test && make coverage` が終了コード0。AI計画、追加提案、全13種の形状契約、SQL dry-run前検証・修正、Sankey、チャート描画、固定経路削除を確認。
- Not verified (GR-042): Vertex AI / BigQueryの有料実行は行っていません。

## Documentation (DOC-030)

- [x] Doc-update matrix checked; 文書更新は後続の分割PRで反映します。

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes: 固定提案・考察スキップ・フォールバックを廃止し、AIが利用者要望から分析仕様を考察するという利用者要望に基づきます。

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test && make coverage` green
- [ ] Diff within size limits (GR-020) — 先行7 PRへ分割済み。本PRはプランナー・実行前検証・描画・対応テストを別々にすると中間状態でデモが不整合になるため、整合した契約移行としてまとめています。
- [x] No dependency additions; no guardrail violation
