### PR TITLE
fix(demo): align dashboard card heights

### DIFF
--- a/spikes/report-generation/live_demo.py
+++ b/spikes/report-generation/live_demo.py
@@ -463,23 +463,21 @@ h1{font-size:26px;line-height:1.25;letter-spacing:-.025em}
 .dashboard-grid{gap:14px;margin-top:14px;align-items:stretch;container-type:inline-size}
 .dashboard-card{display:flex;flex-direction:column;grid-column:span 4;min-width:0;min-height:268px;padding:18px 18px 16px;border-color:#dde3ea;border-radius:var(--radius-card);box-shadow:var(--shadow-card);overflow:hidden;transition:border-color 140ms ease,box-shadow 140ms ease,transform 140ms ease}
 .dashboard-card:hover{border-color:#bcc9d5;box-shadow:0 2px 4px #1018280d,0 14px 34px #10182812;transform:translateY(-1px)}
-.dashboard-card:nth-child(1){grid-column:span 6}
-.dashboard-card:nth-child(2),.dashboard-card:nth-child(3){grid-column:span 3}
-.dashboard-card:nth-child(4),.dashboard-card:nth-child(5){grid-column:span 6;min-height:390px}
-.dashboard-card:nth-child(6){grid-column:1/-1;min-height:470px}
 .dashboard-layout-row{grid-column:1/-1;display:grid;align-items:stretch;min-width:0}
-.dashboard-layout-row>.dashboard-card{grid-column:auto!important;min-height:390px;margin:0}
-.dashboard-layout-row:first-child>.dashboard-card{min-height:268px}
-.dashboard-card-resizer{position:relative;z-index:2;min-width:10px;cursor:col-resize;touch-action:none;outline:0}
+.dashboard-layout-row>.dashboard-card{grid-column:auto!important;min-height:268px;margin:0}
+.dashboard-card-resizer{position:relative;z-index:2;align-self:stretch;min-width:10px;cursor:col-resize;touch-action:none;outline:0}
 .dashboard-card-resizer::after{content:"";position:absolute;top:12px;bottom:12px;left:calc(50% - .5px);width:1px;border-radius:999px;background:#dfe4ea;transition:background 120ms ease,box-shadow 120ms ease}
 .dashboard-card-resizer:hover::after,.dashboard-card-resizer:focus-visible::after,.dashboard-card-resizer.dragging::after{background:#4b84b4;box-shadow:0 0 0 3px #4b84b426}
-@container (max-width:900px){.dashboard-layout-row{grid-template-columns:minmax(0,1fr)!important;gap:14px}.dashboard-layout-row>.dashboard-card{grid-column:1!important;min-height:340px}.dashboard-card-resizer{display:none}}
+.dashboard-layout-row>.dashboard-card .chart{max-height:460px;overflow:auto}
+@container (max-width:900px){.dashboard-layout-row{grid-template-columns:minmax(0,1fr)!important;gap:14px}.dashboard-layout-row>.dashboard-card{grid-column:1!important;min-height:340px}.dashboard-layout-row>.dashboard-card .chart{max-height:none;overflow:visible}.dashboard-card-resizer{display:none}}
 .dashboard-card h3{font-size:15px;line-height:1.45;letter-spacing:-.01em}
 .dashboard-card .purpose{min-height:0;margin:9px 0 16px;color:#687386;font-size:11px}
 .panel-state{display:inline-flex;align-items:center;min-height:23px;padding:3px 7px;border-radius:999px;background:var(--color-success-soft);color:var(--color-success);font-size:10px;white-space:nowrap}
-.dashboard-card .chart{min-width:0;flex:1;display:grid;align-items:center;overflow:hidden}
+.dashboard-card .chart{min-width:0;display:grid;align-items:start;overflow:visible;flex:1}
 .dashboard-card .chart svg{display:block;min-width:0;width:100%;max-width:100%}
-.dashboard-card.wide .chart svg,.dashboard-card.full .chart svg{min-width:0}
+.chart-table-scroll{align-self:start;width:100%;max-height:360px;overflow:auto}
+.chart-table-scroll table{width:max-content;min-width:100%;margin-top:0}
+.chart-table-scroll th,.chart-table-scroll td{max-width:320px;overflow-wrap:anywhere;vertical-align:top}
 .metric{align-self:center;padding:20px 6px;font-size:48px;letter-spacing:-.04em}
 .kpi-pair{gap:10px;align-self:center;width:100%}
 .kpi-pair div{padding:17px 16px;border:1px solid #edf0f3;border-radius:9px;background:#f7f9fb}

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -1677,6 +1677,31 @@ test('dashboard resizes every shared row without free rearrangement', () => {
   assert.doesNotMatch(script, /draggable\s*=|ondragstart|Sortable/);
 });
 
+test('dashboard cards in the same row share height while content stays top-aligned', () => {
+  const rendered = python('print(m.HTML)');
+  assert.equal(rendered.status, 0, rendered.stderr);
+  assert.match(rendered.stdout, /\.dashboard-layout-row\{[^}]*align-items:stretch/);
+  assert.match(
+    rendered.stdout,
+    /\.dashboard-card \.chart\{[^}]*align-items:start[^}]*overflow:visible[^}]*flex:1/,
+  );
+  assert.match(
+    rendered.stdout,
+    /\.dashboard-layout-row>\.dashboard-card \.chart\{[^}]*max-height:460px[^}]*overflow:auto/,
+  );
+  assert.ok(
+    rendered.stdout.indexOf(
+      '.dashboard-layout-row>.dashboard-card .chart{max-height:460px;overflow:auto}',
+    ) <
+      rendered.stdout.indexOf(
+        '@container (max-width:900px){.dashboard-layout-row{grid-template-columns:',
+      ),
+    'the single-column container override must follow the desktop height cap',
+  );
+  assert.match(rendered.stdout, /\.chart-table-scroll\{[^}]*max-height:360px[^}]*overflow:auto/);
+  assert.match(rendered.stdout, /\.chart-table-scroll th,[^}]*overflow-wrap:anywhere/);
+});
+
 test('left navigation stays compact and scrolls long titles only on interaction', () => {
   const rendered = python('print(m.HTML)');
   assert.equal(rendered.status, 0, rendered.stderr);
@@ -1731,8 +1756,8 @@ test('analysis workspace visual hierarchy protects charts and the main surface',
 html=m.HTML
 print(json.dumps({
  "tokens":all(value in html for value in ["--radius-card:12px","--shadow-card:","--color-background:"]),
- "hierarchy":all(value in html for value in [".dashboard-card:nth-child(1){grid-column:span 6}",".dashboard-card:nth-child(2),.dashboard-card:nth-child(3){grid-column:span 3}"]),
- "overflow":all(value in html for value in ["body{overflow-x:hidden", ".dashboard-card.wide .chart svg,.dashboard-card.full .chart svg{min-width:0}"]),
+ "hierarchy":all(value in html for value in [".dashboard-layout-row>.dashboard-card{grid-column:auto!important;min-height:268px", ".dashboard-layout-row>.dashboard-card{grid-column:1!important;min-height:340px}"]),
+ "overflow":all(value in html for value in ["body{overflow-x:hidden", ".dashboard-card .chart svg{display:block;min-width:0;width:100%;max-width:100%}"]),
  "responsive":all(value in html for value in ["@media(max-width:1180px)","position:fixed","@media(max-width:960px)","@media(max-width:760px)"]),
  "accessible":all(value in html for value in [":focus-visible","prefers-reduced-motion:reduce","outline:3px solid var(--color-focus)"]),
 }))


### PR DESCRIPTION
## What & why

AIが同じ `layout_row` に配置したダッシュボードカードの高さを揃えます。カード内のグラフと表は上端に揃え、内容が長い場合はカード内部だけをスクロールさせることで、隣のカードを不必要に引き伸ばしません。固定の `nth-child` レイアウト指定も削除します。

Refs: #374

## Change classification (ARC-020)

- [x] Local (ライブデモの表示レイアウト)
- [ ] Contract
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: 残りの作業差分を退避した単独状態で `make format && make lint && make test && make coverage` が終了コード0。同一行のstretch、内容の上端揃え、デスクトップ時の内部スクロール、狭幅時の解除を確認。
- Not verified (GR-042): ブラウザでの手動表示確認は、最新コード統合後のデモ再起動時に行います。

## Documentation (DOC-030)

- [x] Doc-update matrix checked; 挙動変更は既存要件の修正で、文書更新は最終統合PRで反映します。

## AI disclosure

- [x] Authored by AI agent: Codex — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes: 横並びグラフの高さを揃えるという利用者要望に基づきます。

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test && make coverage` green
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No dependency additions; no guardrail violation
