### PR TITLE
refactor(demo): remove fixed dashboard planning

### DIFF
--- a/spikes/report-generation/analysis_planner.py
+++ b/spikes/report-generation/analysis_planner.py
@@ -8,56 +8,7 @@ import json
 import os
 import re
 
-ORGANIZATION_CONTEXT = {
-    "revision": "demo-org-ec-v1",
-    "state": "demo_fixture",
-    "business": "ECサイトで商品を販売する組織",
-    "goal": "購入成果を伸ばし、訪問者の継続利用を改善する",
-    "decision_cycle": "月次マーケティング会議",
-    "prohibited_interpretation": "観測相関を原因または施策効果と断定しない",
-}
-
-PANEL_CATALOG = {
-    "R4": {
-        "title": "購入件数と売上",
-        "kpi": "購入件数、購入金額",
-        "chart": "KPIカード",
-        "decision": "成果の規模を把握し、追加診断が必要か判断する",
-    },
-    "R11": {
-        "title": "リピートユーザー率",
-        "kpi": "2回以上訪問したユーザーの割合",
-        "chart": "KPIカード",
-        "decision": "一度きりの訪問に偏っていないか判断する",
-    },
-    "R12": {
-        "title": "平均エンゲージメント時間",
-        "kpi": "セッションあたり平均エンゲージメント時間",
-        "chart": "KPIカード",
-        "decision": "訪問中に十分な関与があるか判断する",
-    },
-    "R9": {
-        "title": "購入ファネル",
-        "kpi": "商品閲覧、カート追加、購入のセッション数",
-        "chart": "ファネル",
-        "decision": "購入までの減少が大きい段階を絞り込む",
-    },
-    "R16": {
-        "title": "日別セッションと7日移動平均",
-        "kpi": "日別セッション数、7日移動平均",
-        "chart": "2系列折れ線",
-        "decision": "一時的な変動と基調を区別する",
-    },
-    "R17": {
-        "title": "主要なサイト回遊",
-        "kpi": "入口から3ページ目までの主要経路",
-        "chart": "Sankey",
-        "decision": "回遊上の行き止まりや主要導線を診断する",
-    },
-}
-
 CLARIFICATION_FIELDS = ("audience", "comparison", "business_goal")
-DASHBOARD_CHARTS = ("scorecard", "bar", "line", "table", "sankey")
 SUPPORTED_DASHBOARD_CHARTS = (
     "scorecard",
     "kpi_group",
@@ -73,6 +24,7 @@ SUPPORTED_DASHBOARD_CHARTS = (
     "table",
     "sankey",
 )
+DASHBOARD_CHARTS = SUPPORTED_DASHBOARD_CHARTS
 DASHBOARD_ROW_LIMITS = {
     "scorecard": 1,
     "kpi_group": 1,
@@ -111,7 +63,11 @@ DYNAMIC_PANEL_TEXT_FIELDS = (
 )
 DYNAMIC_PANEL_LIST_FIELDS = ("dimensions", "measures")
 DYNAMIC_PANEL_LAYOUT_FIELDS = ("layout_row", "layout_weight")
-DYNAMIC_PANEL_FIELDS = DYNAMIC_PANEL_TEXT_FIELDS
+DYNAMIC_PANEL_FIELDS = (
+    DYNAMIC_PANEL_TEXT_FIELDS
+    + DYNAMIC_PANEL_LIST_FIELDS
+    + DYNAMIC_PANEL_LAYOUT_FIELDS
+)
 
 
 def _positive_count_setting(name: str, default: int) -> int:
@@ -240,16 +196,32 @@ DYNAMIC_PLAN_SCHEMA["properties"]["panels"] = {
         "properties": {
             "title": {"type": "string"},
             "kpi": {"type": "string"},
-            "chart": {
-                "type": "string",
-                "format": "enum",
-                "enum": list(DASHBOARD_CHARTS),
-            },
             "decision": {"type": "string"},
             "reason": {"type": "string"},
             "execution_prompt": {"type": "string"},
+            "visualization": _visualization_response_schema(DASHBOARD_CHARTS),
+            "layout_row": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "表示行番号。1から始めてパネル順に連続させ、同じ行は同じ値にする。1行は最大4件。",
+            },
+            "layout_weight": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100,
+                "description": "同じ表示行にあるパネル間の相対幅。",
+            },
         },
-        "required": list(DYNAMIC_PANEL_FIELDS),
+        "required": [
+            "title",
+            "kpi",
+            "decision",
+            "reason",
+            "execution_prompt",
+            "visualization",
+            "layout_row",
+            "layout_weight",
+        ],
     },
 }
 
@@ -282,48 +254,24 @@ def _response_schema(answers: dict[str, str]) -> dict:
 
 
 def _dashboard_response_schema(
-    answers: dict[str, str], *, revising: bool = False
+    answers: dict[str, str], *, revising: bool = False, seed: str = ""
 ) -> dict:
     """Constrain an initial or revised AI-authored dashboard."""
     schema = _response_schema(answers)
     schema["properties"]["panels"] = copy.deepcopy(
         DYNAMIC_PLAN_SCHEMA["properties"]["panels"]
     )
-    if revising:
-        schema["properties"]["panels"]["minItems"] = 1
-        schema["properties"]["panels"]["maxItems"] = MAX_PANEL_COUNT
-    return schema
-
-
-def planning_request(
-    objective: str, period: dict[str, str], metrics: str, answers: dict[str, str]
-) -> str:
-    """Build a bounded request from declared context, metrics, and panel catalog."""
-    catalog = "\n".join(
-        f"- {panel_id}: {item['title']} / {item['kpi']} / {item['chart']} / {item['decision']}"
-        for panel_id, item in PANEL_CATALOG.items()
+    schema["properties"]["panels"]["items"]["properties"]["visualization"] = (
+        _visualization_response_schema(DASHBOARD_CHARTS, seed=seed)
     )
-    answered = json.dumps(answers, ensure_ascii=False, sort_keys=True)
-    return f"""次の依頼から、月次ECサイト分析ダッシュボードを計画する。
-
-依頼: {objective}
-対象期間: {period['label']}
-読者回答: {answered}
-組織コンテキスト: {json.dumps(ORGANIZATION_CONTEXT, ensure_ascii=False)}
-指標定義:
-{metrics}
-
-利用できるパネル:
-{catalog}
-
-規則:
-- 目的を意思決定へ言い換え、検証可能な仮説を最大3件にする。
-- パネルは目的に必要な4〜6件だけを選び、重複を避ける。
-- KPI・グラフの選択理由をパネルごとに日本語で説明する。
-- 初回は audience / comparison / business_goal から重要な確認を1〜3件だけ質問する。
-- 読者回答にあるfieldは再質問しない。十分ならclarificationsを空にする。
-- 利用できない指標や因果関係を捏造しない。
-"""
+    if revising:
+        # Vertex can reject otherwise valid structured-output schemas as too
+        # complex when a nested array has a long item-count limit. Revisions
+        # can grow to MAX_PANEL_COUNT, so keep that policy in the strict local
+        # normalizer instead of sending minItems/maxItems to the provider.
+        schema["properties"]["panels"].pop("minItems", None)
+        schema["properties"]["panels"].pop("maxItems", None)
+    return schema
 
 
 def dashboard_planning_request(
@@ -356,33 +304,26 @@ def dashboard_planning_request(
         revision_context = f"""これは現在案への追加・変更・削除相談である。
 利用者の変更依頼: {instruction}
 現在の分析仕様: {json.dumps(current, ensure_ascii=False, sort_keys=True)}
-- 明示されていない既存パネルは維持する。
-- 追加依頼なら新しい分析仕様を追加し、既存案を置換しない。
-- 変更・削除依頼なら対象だけを変更し、重複なしの1〜{MAX_PANEL_COUNT}件にする。
+- 変更依頼の意味を解釈し、変更後の分析仕様をpanelsへすべて返す。
+- 利用者が変更または削除を求めていない既存仕様は、意味、順序、文言を維持する。
+- 新しい仕様は既存仕様と重複させず、変更後は重複なしの1〜{MAX_PANEL_COUNT}件にする。
 - 上限{MAX_PANEL_COUNT}件へ達した場合は追加せず、その理由を目的要約へ明記する。"""
     return f"""次の依頼から、月次ECサイト分析ダッシュボードを計画する。
 
 依頼: {objective}
 対象期間: {period['label']}
 読者回答: {answered}
-組織コンテキスト: {json.dumps(ORGANIZATION_CONTEXT, ensure_ascii=False)}
 {revision_context}
 スキーマ・指標定義:
 {metrics}
 
-利用できる可視化形式:
-- scorecard: 1つの成果指標
-- bar: 1つの区分軸と1つの数値
-- line: 日付と1つの数値
-- table: 意思決定に必要な最小限の列
-- sankey: source、target、sessionsで表せる段階付きフロー
-
 規則:
 - 目的を意思決定へ言い換え、検証可能な仮説を最大3件にする。
 - 固定済みの分析候補から選ばず、目的と仮説から分析仕様そのものを新規に考える。
-- 可視化は慣例で決めず、比較、構成比、時系列、偏り、フローのどれを判断するかに合わせて選ぶ。
-- 各パネルにはtitle、kpi、chart、decision、reasonと、SQL生成へ渡す具体的な1行の日本語execution_promptを書く。
-- execution_promptにはSQLを書かない。対象期間、指標、軸、比較、必要な出力列が分かる仕様にする。
+- 各パネルには構造化出力schemaで要求された分析仕様と、SQL生成へ渡す具体的な1行の日本語execution_promptを書く。
+- execution_promptにはSQLを書かない。対象期間、dimensionsとmeasuresの全項目、比較、必要な出力列が分かる仕様にする。
+- 各可視化の結果は最大行数以内で判断できる集計粒度にする。高カーディナリティの区分軸は上位件数と並び順をexecution_promptへ明記する。
+- ページ回遊のsankeyは最大{MAX_SANKEY_PAGES}ページにする。dimensionsは各ページを列挙せず遷移元・遷移先の2件にし、複数ページ分は隣接edgeの複数行としてexecution_promptへ明記する。
 - KPI・グラフの選択理由をパネルごとに日本語で説明する。
 - 初回は audience / comparison / business_goal から重要な確認を1〜3件だけ質問する。
 - 読者回答にあるfieldは再質問しない。十分ならclarificationsを空にする。
@@ -499,17 +440,35 @@ def _normalize_plan_header(
         )
     if len(clarifications) > 3 or (not answers and not clarifications):
         raise PlannerError("初回の確認事項は1〜3件にしてください。")
+    normalized_objective = _text(objective, "目的")
+    objective_summary = _text(raw.get("objective_summary"), "目的要約")
+    audience = _text(raw.get("audience"), "読者")
+    comparison = _text(raw.get("comparison"), "比較軸")
+    organization_context = {
+        "objective": normalized_objective,
+        "objective_summary": objective_summary,
+        "audience": audience,
+        "comparison": comparison,
+        "confirmed_answers": answers,
+    }
+    context_canonical = json.dumps(
+        organization_context, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    organization_context["revision"] = (
+        "context-" + hashlib.sha256(context_canonical.encode()).hexdigest()[:12]
+    )
     return {
         "status": "proposed",
-        "objective": _text(objective, "目的"),
-        "objective_summary": _text(raw.get("objective_summary"), "目的要約"),
-        "audience": _text(raw.get("audience"), "読者"),
-        "comparison": _text(raw.get("comparison"), "比較軸"),
+        "objective": normalized_objective,
+        "objective_summary": objective_summary,
+        "audience": audience,
+        "comparison": comparison,
         "period": period,
         "hypotheses": hypotheses,
         "clarifications": clarifications,
         "answers": answers,
-        "organization_context_revision": ORGANIZATION_CONTEXT["revision"],
+        "organization_context_revision": organization_context["revision"],
+        "organization_context": organization_context,
     }
 
 
@@ -519,47 +478,13 @@ def _revisioned_plan(plan: dict) -> dict:
     return plan
 
 
-def normalize_plan(
-    raw: dict,
-    objective: str,
-    period: dict[str, str],
-    answers: dict[str, str] | None = None,
-    *,
-    complete_purchase_recommendations: bool = False,
-) -> dict:
-    """Validate the fixed-catalog fixture contract used by the current demo."""
-    plan = _normalize_plan_header(raw, objective, period, answers)
-    panel_reasons, seen = {}, set()
-    for item in raw.get("panels", []):
-        panel_id = item.get("id") if isinstance(item, dict) else None
-        if panel_id not in PANEL_CATALOG or panel_id in seen:
-            raise PlannerError("分析計画に未登録または重複したパネルがあります。")
-        seen.add(panel_id)
-        panel_reasons[panel_id] = _text(item.get("reason"), "パネル選択理由")
-    if not 4 <= len(panel_reasons) <= 6:
-        raise PlannerError("分析計画のパネルは4〜6件にしてください。")
-    compact_objective = "".join(objective.split())
-    if (
-        complete_purchase_recommendations
-        and "購入" in compact_objective
-        and "改善" in compact_objective
-        and any(word in compact_objective for word in ("課題", "優先施策"))
-    ):
-        for panel_id, item in PANEL_CATALOG.items():
-            panel_reasons.setdefault(panel_id, f"{item['decision']}ため")
-    plan["panels"] = [
-        {"id": panel_id, **item, "reason": panel_reasons[panel_id]}
-        for panel_id, item in PANEL_CATALOG.items()
-        if panel_id in panel_reasons
-    ]
-    return _revisioned_plan(plan)
-
-
 def normalize_dashboard_plan(
     raw: dict,
     objective: str,
     period: dict[str, str],
     answers: dict[str, str] | None = None,
+    *,
+    allow_layout_gaps: bool = False,
 ) -> dict:
     """Validate model output and produce a deterministic proposed revision."""
     plan = _normalize_plan_header(raw, objective, period, answers)
@@ -570,16 +495,55 @@ def normalize_dashboard_plan(
     for index, item in enumerate(raw_panels, start=1):
         if not isinstance(item, dict):
             raise PlannerError("分析計画のパネルがobjectではありません。")
+        item = _flatten_visualization(item)
         panel = {
             field: _plan_panel_text(
                 item.get(field),
                 "パネル選択理由" if field == "reason" else field,
                 80 if field in {"title", "kpi", "chart"} else 300,
             )
-            for field in DYNAMIC_PANEL_FIELDS
+            for field in DYNAMIC_PANEL_TEXT_FIELDS
         }
         if panel["chart"] not in DASHBOARD_CHARTS:
             raise PlannerError("分析計画の可視化種別が未対応です。")
+        panel["dimensions"] = _panel_terms(
+            item.get("dimensions"),
+            "区分軸",
+            allow_role_duplicates=panel["chart"] == "sankey",
+        )
+        panel["measures"] = _panel_terms(item.get("measures"), "指標", minimum=1)
+        layout_row = item.get("layout_row")
+        layout_weight = item.get("layout_weight")
+        if (
+            isinstance(layout_row, bool)
+            or not isinstance(layout_row, int)
+            or layout_row < 1
+        ):
+            raise PlannerError("分析計画のlayout_rowは1以上の整数にしてください。")
+        if (
+            isinstance(layout_weight, bool)
+            or not isinstance(layout_weight, int)
+            or not 1 <= layout_weight <= 100
+        ):
+            raise PlannerError("分析計画のlayout_weightは1〜100の整数にしてください。")
+        panel["layout_row"] = layout_row
+        panel["layout_weight"] = layout_weight
+        dimensions, measures = panel["dimensions"], panel["measures"]
+        try:
+            _validate_chart_shape(panel["chart"], dimensions, measures)
+        except PlannerError as error:
+            suggestion = panel["execution_prompt"].rstrip("。")
+            if panel["chart"] == "sankey" and measures:
+                if not re.search(r"(?:上位|トップ)\s*\d+", suggestion):
+                    suggestion += "。経路は上位10件に絞って"
+                suggestion += (
+                    f"。3ページ分は遷移元・遷移先の隣接edgeとして表し、"
+                    f"区分軸2件と{measures[0]}1指標で返して"
+                )
+            raise PlannerError(
+                f"{error} 現在案は保持しています。",
+                suggested_instruction=suggestion,
+            ) from error
         prompt = panel["execution_prompt"]
         if re.search(
             r"(?:```|`|\b(?:SELECT|WITH|FROM|GROUP\s+BY)\b)",
@@ -587,36 +551,34 @@ def normalize_dashboard_plan(
             flags=re.IGNORECASE,
         ):
             raise PlannerError("分析計画の実行仕様にはSQLを書けません。")
+        compact_prompt = "".join(prompt.lower().split())
+        missing = [
+            term
+            for term in dimensions + measures
+            if "".join(term.lower().split()) not in compact_prompt
+        ]
+        if missing:
+            raise PlannerError(
+                "分析計画の実行仕様に区分軸・指標がありません: " + "、".join(missing)
+            )
         prompt_key = "".join(prompt.lower().split())
         if prompt_key in seen_prompts:
             raise PlannerError("分析計画に重複した実行仕様があります。")
         seen_prompts.add(prompt_key)
+        panel["max_result_rows"] = DASHBOARD_ROW_LIMITS[panel["chart"]]
         panels.append({"id": f"P{index}", **panel})
+    layout_rows = [panel["layout_row"] for panel in panels]
+    expected_rows = list(range(1, max(layout_rows) + 1))
+    if layout_rows != sorted(layout_rows) or (
+        not allow_layout_gaps and sorted(set(layout_rows)) != expected_rows
+    ):
+        raise PlannerError(
+            "分析計画のlayout_rowは1から始まる連続値をパネル順に指定してください。"
+        )
+    if any(layout_rows.count(row) > 4 for row in expected_rows):
+        raise PlannerError("分析計画の1行あたりのパネルは最大4件にしてください。")
     plan["panels"] = panels
     return _revisioned_plan(plan)
-
-
-def propose(client, model: str, objective: str, period: dict, metrics: str, answers: dict):
-    """Ask Vertex AI for a bounded plan and normalize its response."""
-    from google.genai import types
-    from vertex_usage import token_counts
-
-    response = client.models.generate_content(
-        model=model,
-        contents=planning_request(objective, period, metrics, answers),
-        config=types.GenerateContentConfig(
-            system_instruction="あなたは意思決定から分析仕様を設計する日本語BIプランナー。",
-            response_mime_type="application/json",
-            response_schema=_response_schema(answers),
-        ),
-    )
-    return normalize_plan(
-        json.loads(response.text),
-        objective,
-        period,
-        answers,
-        complete_purchase_recommendations=True,
-    ), token_counts(response.usage_metadata)
 
 
 def propose_dashboard(
@@ -648,26 +610,34 @@ def propose_dashboard(
             system_instruction="あなたは意思決定から分析仕様を設計する日本語BIプランナー。",
             response_mime_type="application/json",
             response_schema=_dashboard_response_schema(
-                answers, revising=current_plan is not None
+                answers,
+                revising=current_plan is not None,
+                seed=f"{objective}\n{instruction or ''}",
             ),
         ),
     )
-    plan = normalize_dashboard_plan(
-        json.loads(response.text), objective, period, answers
-    )
-    add_only = instruction and any(
-        word in instruction for word in ("追加", "他にも", "ほかにも", "増や")
-    ) and not any(
-        word in instruction for word in ("削除", "除外", "減ら", "置換", "入れ替")
-    )
-    if (
-        current_plan is not None
-        and add_only
-        and len(current_plan.get("panels", [])) < MAX_PANEL_COUNT
-        and len(plan["panels"]) <= len(current_plan.get("panels", []))
-    ):
-        raise PlannerError("追加依頼に対して分析パネルが追加されませんでした。")
-    return plan, token_counts(response.usage_metadata)
+    try:
+        response_text = response.text
+    except (AttributeError, ValueError) as error:
+        raise PlannerError(
+            "Vertex AIから分析計画JSONを受け取れませんでした。"
+            "現在案は保持し、自動再実行していません。"
+        ) from error
+    if not isinstance(response_text, str) or not response_text.strip():
+        raise PlannerError(
+            "Vertex AIから分析計画JSONを受け取れませんでした。"
+            "現在案は保持し、自動再実行していません。"
+        )
+    try:
+        raw = json.loads(response_text)
+    except json.JSONDecodeError as error:
+        raise PlannerError(
+            "Vertex AIの分析計画JSONを解釈できませんでした。"
+            "現在案は保持し、自動再実行していません。"
+        ) from error
+    return normalize_dashboard_plan(
+        raw, objective, period, answers
+    ), token_counts(response.usage_metadata)
 
 
 CONSULTATION_CHARTS = SUPPORTED_DASHBOARD_CHARTS
@@ -885,44 +855,6 @@ def propose_consultation(
     ), token_counts(response.usage_metadata)
 
 
-def confirm_plan(plan: dict) -> dict:
-    """Revalidate an edited proposal and freeze a new immutable revision."""
-    answers = plan.get("answers", {})
-    if not isinstance(answers, dict):
-        raise PlannerError("確認事項の回答がobjectではありません。")
-    clarifications = plan.get("clarifications", [])
-    if not isinstance(clarifications, list):
-        raise PlannerError("確認事項が配列ではありません。")
-    for item in clarifications:
-        field = item.get("field") if isinstance(item, dict) else None
-        if field not in CLARIFICATION_FIELDS:
-            diagnostic = json.dumps(field, ensure_ascii=False)
-            raise PlannerError(f"確認事項のfieldが許可範囲外です: {diagnostic}")
-        answer = answers.get(field)
-        if not isinstance(answer, str) or not answer.strip():
-            raise PlannerError(f"確認事項{field}の回答が空です。")
-    raw = {
-        key: plan.get(key)
-        for key in ("objective_summary", "audience", "comparison", "hypotheses")
-    }
-    raw["clarifications"] = []
-    raw["panels"] = [
-        {"id": item.get("id"), "reason": item.get("reason")}
-        for item in plan.get("panels", [])
-    ]
-    confirmed = normalize_plan(
-        raw, plan.get("objective", ""), plan.get("period", {}), answers
-    )
-    if confirmed["clarifications"]:
-        raise PlannerError("未回答の確認事項があります。")
-    confirmed["status"] = "confirmed"
-    canonical = json.dumps(
-        confirmed, ensure_ascii=False, sort_keys=True, separators=(",", ":")
-    )
-    confirmed["revision"] = "plan-" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
-    return confirmed
-
-
 def confirm_dashboard_plan(plan: dict) -> dict:
     """Revalidate an edited AI-authored proposal and freeze its full specification."""
     answers = plan.get("answers", {})
@@ -949,7 +881,11 @@ def confirm_dashboard_plan(plan: dict) -> dict:
         for item in plan.get("panels", [])
     ]
     confirmed = normalize_dashboard_plan(
-        raw, plan.get("objective", ""), plan.get("period", {}), answers
+        raw,
+        plan.get("objective", ""),
+        plan.get("period", {}),
+        answers,
+        allow_layout_gaps=True,
     )
     if confirmed["clarifications"]:
         raise PlannerError("未回答の確認事項があります。")

--- a/spikes/report-generation/live_demo.py
+++ b/spikes/report-generation/live_demo.py
@@ -881,13 +881,8 @@ def dashboard_sections_for_plan(question: str, plan: dict) -> tuple[dict, list[d
 
 
 def confirm_dashboard_analysis_plan(plan: dict) -> dict:
-    """Freeze dynamic plans while preserving the fixed demo fixture contract."""
-    panels = plan.get("panels", []) if isinstance(plan, dict) else []
-    if panels and all(
-        isinstance(panel, dict) and "execution_prompt" in panel for panel in panels
-    ):
-        return planner.confirm_dashboard_plan(plan)
-    return planner.confirm_plan(plan)
+    """Freeze only a complete AI-authored dashboard specification."""
+    return planner.confirm_dashboard_plan(plan)
 
 
 def require_sql_period(sql: str, period: dict[str, str]) -> None:
@@ -1385,7 +1380,7 @@ class LiveQueryEngine:
                     "organization_context_revision": confirmed[
                         "organization_context_revision"
                     ],
-                    "organization_context": planner.ORGANIZATION_CONTEXT,
+                    "organization_context": confirmed["organization_context"],
                     "analysis_specification": {
                         "revision": confirmed["revision"],
                         "objective": confirmed["objective_summary"],

--- a/tests/spikes/report-generation/analysis-planner.test.ts
+++ b/tests/spikes/report-generation/analysis-planner.test.ts
@@ -23,7 +23,7 @@ genai.types=types.SimpleNamespace(GenerateContentConfig=GenerateContentConfig)
 google.genai=genai;sys.modules["google"]=google;sys.modules["google.genai"]=genai
 period={"from":"20210101","to":"20210131","label":"2021年1月"}
 def panel(index,chart="bar"):
- return {"title":f"分析{index}","kpi":f"指標{index}","chart":chart,"decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の定義済み指標{index}を区分別に出して"}
+ return {"title":f"分析{index}","kpi":f"指標{index}","chart":chart,"decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の定義済み指標{index}を区分別に出して","dimensions":["区分"],"measures":[f"定義済み指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
 base={
  "objective_summary":"購入成果の阻害箇所を特定して優先施策を決める",
  "audience":"月次マーケティング会議",
@@ -42,6 +42,7 @@ confirmed=p.confirm_dashboard_plan(second)
 errors=[]
 for changed in [
  {**base,"panels":[]},
+ {**base,"panels":[panel(index) for index in range(1,22)]},
  {**base,"panels":[*base["panels"][:5],base["panels"][0]]},
  {**base,"panels":[*base["panels"][:5],{**panel(6),"execution_prompt":"SELECT * FROM events"}]},
 ]:
@@ -51,7 +52,7 @@ print(json.dumps({
  "first_status":first["status"],"question_count":len(first["clarifications"]),
  "revision_stable":first["revision"]==p.normalize_dashboard_plan(base,first["objective"],period,{})["revision"],
  "confirmed_status":confirmed["status"],"revision_changed":confirmed["revision"]!=first["revision"],
- "context":confirmed["organization_context_revision"],"panel_ids":[item["id"] for item in confirmed["panels"]],
+ "context":confirmed["organization_context_revision"].startswith("context-") and confirmed["organization_context"]["objective"]==first["objective"],"panel_ids":[item["id"] for item in confirmed["panels"]],
  "frozen_prompt":confirmed["panels"][0]["execution_prompt"],
  "errors":errors,
 },ensure_ascii=False))`,
@@ -65,10 +66,11 @@ print(json.dumps({
     revision_stable: true,
     confirmed_status: 'confirmed',
     revision_changed: true,
-    context: 'demo-org-ec-v1',
+    context: true,
     panel_ids: ['P1', 'P2', 'P3', 'P4', 'P5', 'P6'],
     frozen_prompt: '2021年1月の定義済み指標1を区分別に出して',
     errors: [
+      '分析計画のパネルは1〜20件にしてください。',
       '分析計画のパネルは1〜20件にしてください。',
       '分析計画に重複した実行仕様があります。',
       '分析計画の実行仕様にはSQLを書けません。',
@@ -86,18 +88,228 @@ spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)}
 p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
 request=p.dashboard_planning_request("目的",{"label":"2021年1月"},"指標定義",{})
 panels=p._dashboard_response_schema({})["properties"]["panels"]
-print(json.dumps({"context":p.ORGANIZATION_CONTEXT["revision"] in request,"metrics":"指標定義" in request,"new_specs":"分析仕様そのものを新規" in request,"fixed_ids":any(panel_id in request for panel_id in p.PANEL_CATALOG),"count":[panels["minItems"],panels["maxItems"]],"questions":"確認を1〜3件" in request},ensure_ascii=False))`,
+print(json.dumps({"fixed_context":"demo-org-ec-v1" in request,"metrics":"指標定義" in request,"new_specs":"分析仕様そのものを新規" in request,"fixed_ids":any(panel_id in request for panel_id in ["R4","R11","R12","R9","R16","R17"]),"count":[panels["minItems"],panels["maxItems"]],"questions":"確認を1〜3件" in request,"sankey_limit":f"最大{p.MAX_SANKEY_PAGES}ページ" in request},ensure_ascii=False))`,
     ],
     { cwd: ROOT, encoding: 'utf8' },
   );
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
-    context: true,
+    fixed_context: false,
     metrics: true,
     new_specs: true,
     fixed_ids: false,
     count: [6, 6],
     questions: true,
+    sankey_limit: true,
+  });
+});
+
+test('program constraints allow every renderer without exposing a chart catalog in prompts', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+shapes={
+ "kpi_group":([], ["指標A","指標B"]),
+ "grouped_bar":(["区分"], ["指標A","指標B"]),
+ "stacked_bar":(["区分"], ["指標A","指標B"]),
+ "multi_line":(["日付"], ["指標A","指標B"]),
+ "scatter":(["項目"], ["指標A","指標B"]),
+ "bubble":(["項目"], ["指標A","指標B","指標C"]),
+ "funnel":(["段階"], ["指標A"]),
+ "heatmap":(["区分A","区分B"], ["指標A"]),
+}
+accepted=[]
+for chart,(dimensions,measures) in shapes.items():
+ prompt="2021年1月の"+"・".join(dimensions+measures)+"を比較する"
+ item={"title":chart,"objective":"判断する","dimensions":dimensions,"measures":measures,"comparison":"比較","chart":chart,"execution_prompt":prompt,"reason":"判断に必要"}
+ accepted.append(p.confirm_analysis_specification(item)["chart"])
+request=p.dashboard_planning_request("目的",{"label":"2021年1月"},"指標定義",{})
+dashboard_variants=p.DYNAMIC_PLAN_SCHEMA["properties"]["panels"]["items"]["properties"]["visualization"]["anyOf"]
+schema_charts=[variant["properties"]["chart"]["enum"][0] for variant in dashboard_variants]
+consultation=p.consultation_request("目的",[],"指標定義","ga4")
+consultation_variants=p._consultation_schema()["properties"]["recommendations"]["items"]["properties"]["visualization"]["anyOf"]
+consultation_charts=[variant["properties"]["chart"]["enum"][0] for variant in consultation_variants]
+seeded_orders=[]
+for index in range(8):
+ variants=p._dashboard_response_schema({},seed=f"依頼{index}")["properties"]["panels"]["items"]["properties"]["visualization"]["anyOf"]
+ seeded_orders.append([variant["properties"]["chart"]["enum"][0] for variant in variants])
+bar=next(variant for variant in dashboard_variants if variant["properties"]["chart"]["enum"]==["bar"])
+bar_shape={name:[bar["properties"][name]["minItems"],bar["properties"][name]["maxItems"]] for name in ["dimensions","measures"]}
+catalog_markers=[f"- {chart}:" for chart in p.DASHBOARD_CHARTS]
+layout_heuristics=["同時に読む組み合わせ","重要度","表示密度","chart typeだけから幅"]
+print(json.dumps({"accepted":accepted,"charts":list(p.DASHBOARD_CHARTS),"schema_charts":schema_charts,"consultation_charts":consultation_charts,"bar_shape":bar_shape,"seeded_complete":all(set(order)==set(p.DASHBOARD_CHARTS) for order in seeded_orders),"seeded_variety":len({tuple(order) for order in seeded_orders})>1,"seeded_stable":seeded_orders[0]==[variant["properties"]["chart"]["enum"][0] for variant in p._dashboard_response_schema({},seed="依頼0")["properties"]["panels"]["items"]["properties"]["visualization"]["anyOf"]],"dashboard_prompt_has_catalog":any(marker in request for marker in catalog_markers),"consultation_prompt_has_catalog":any(marker in consultation for marker in catalog_markers),"has_prompt_capability_constant":hasattr(p,"CHART_CAPABILITY_PROMPT"),"no_intent_pattern":"比較、構成比、時系列、偏り、フロー" not in request,"no_layout_heuristics":all(value not in request for value in layout_heuristics)},ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.accepted, [
+    'kpi_group',
+    'grouped_bar',
+    'stacked_bar',
+    'multi_line',
+    'scatter',
+    'bubble',
+    'funnel',
+    'heatmap',
+  ]);
+  assert.equal(output.charts.length, 13);
+  assert.deepEqual(output.schema_charts, output.charts);
+  assert.deepEqual(output.consultation_charts, output.charts);
+  assert.deepEqual(output.bar_shape, {
+    dimensions: [1, 1],
+    measures: [1, 1],
+  });
+  assert.equal(output.seeded_complete, true);
+  assert.equal(output.seeded_variety, true);
+  assert.equal(output.seeded_stable, true);
+  assert.equal(output.dashboard_prompt_has_catalog, false);
+  assert.equal(output.consultation_prompt_has_catalog, false);
+  assert.equal(output.has_prompt_capability_constant, false);
+  assert.equal(output.no_intent_pattern, true);
+  assert.equal(output.no_layout_heuristics, true);
+});
+
+test('dashboard plans reject chart shapes that cannot be rendered before build', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+period={"from":"20210101","to":"20210131","label":"2021年1月"}
+def raw(dimensions,measures):return {
+ "objective_summary":"成果を確認する","audience":"責任者","comparison":"月内比較",
+ "hypotheses":["成果に差がある"],"clarifications":[],"panels":[{
+  "title":"購入成果","kpi":"購入成果","chart":"scorecard","decision":"規模を判断する",
+  "reason":"成果確認に必要","execution_prompt":"2021年1月の購入金額と購入件数を集計する",
+  "dimensions":dimensions,"measures":measures,"layout_row":1,"layout_weight":1,
+ }]}
+answers={"audience":"責任者","comparison":"月内比較","business_goal":"成果改善"}
+errors=[]
+for dimensions,measures in [(["デバイス"],["購入金額"]),([], ["購入金額","購入件数"])]:
+ try:p.normalize_dashboard_plan(raw(dimensions,measures),"ダッシュボードを作って",period,answers)
+ except p.PlannerError as error:errors.append(str(error))
+print(json.dumps(errors,ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [
+    'scorecardは区分軸なし・指標1件にしてください。 現在案は保持しています。',
+    'scorecardは区分軸なし・指標1件にしてください。 現在案は保持しています。',
+  ]);
+});
+
+test('invalid Sankey output explains expected counts and returns an AI-authored correction', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+raw={
+ "objective_summary":"サイト回遊を改善する","audience":"責任者","comparison":"経路間比較",
+ "hypotheses":["主要経路に偏りがある"],"clarifications":[],"panels":[{
+  "title":"3ページ回遊","kpi":"セッション数","chart":"sankey","decision":"導線を改善する",
+  "reason":"流量を比較するため",
+  "execution_prompt":"2021年1月の1ページ目・2ページ目・3ページ目ごとのセッション数を集計する",
+  "dimensions":["1ページ目","2ページ目","3ページ目"],"measures":["セッション数"],"layout_row":1,"layout_weight":1
+ }]}
+answers={"audience":"責任者","comparison":"経路間比較","business_goal":"回遊改善"}
+try:p.normalize_dashboard_plan(raw,"3ページのサイト回遊も作成して",{"from":"20210101","to":"20210131","label":"2021年1月"},answers)
+except p.PlannerError as error:
+ print(json.dumps({"message":str(error),"suggestion":error.suggested_instruction},ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.match(output.message, /必要なのは区分軸2件・指標1件/);
+  assert.match(output.message, /AI出力は区分軸3件・指標1件/);
+  assert.match(output.message, /現在案は保持/);
+  assert.match(output.suggestion, /2021年1月/);
+  assert.match(output.suggestion, /上位10件/);
+  assert.match(output.suggestion, /遷移元・遷移先の隣接edge/);
+  assert.match(output.suggestion, /区分軸2件とセッション数1指標/);
+});
+
+test('add-only dashboard revisions preserve accepted panels and append a requested Sankey', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json,sys,types
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+google=types.ModuleType("google");genai=types.ModuleType("google.genai")
+class GenerateContentConfig:
+ def __init__(self,**kwargs):self.__dict__.update(kwargs)
+genai.types=types.SimpleNamespace(GenerateContentConfig=GenerateContentConfig)
+google.genai=genai;sys.modules["google"]=google;sys.modules["google.genai"]=genai
+vertex_usage=types.ModuleType("vertex_usage");vertex_usage.token_counts=lambda _usage:{"input_tokens":1,"output_tokens":1};sys.modules["vertex_usage"]=vertex_usage
+period={"from":"20210101","to":"20210131","label":"2021年1月"}
+def panel(index):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分{index}別に集計する","dimensions":[f"区分{index}"],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
+header={"objective_summary":"成果を判断する","audience":"責任者","comparison":"区分比較","hypotheses":["差がある"],"clarifications":[]}
+answers={"audience":"責任者","comparison":"区分比較","business_goal":"成果改善"}
+current=p.normalize_dashboard_plan({**header,"panels":[panel(i) for i in range(1,7)]},"ダッシュボードを作って",period,answers)
+sankey={"title":"サイト内3ページ回遊","kpi":"セッション数","chart":"sankey","decision":"主要な3ページ回遊を判断する","reason":"ページ間の流量を確認するため","execution_prompt":"2021年1月の遷移元ページから遷移先ページまで3ページのセッション数を多い順に集計する","dimensions":["遷移元ページ","遷移先ページ"],"measures":["セッション数"],"layout_row":4,"layout_weight":1}
+addition={**header,"panels":[panel(i) for i in range(1,7)]+[sankey]}
+observed_schema={}
+class Models:
+ def generate_content(self,**kwargs):
+  observed_schema.update(kwargs["config"].response_schema["properties"]["clarifications"])
+  return types.SimpleNamespace(text=json.dumps(addition,ensure_ascii=False),usage_metadata=object())
+plan,_usage=p.propose_dashboard(types.SimpleNamespace(models=Models()),"test-model",current["objective"],period,"指標定義",answers,current_plan=current,instruction="サイト回遊3ページのサンキーダイアグラムも描いて")
+panel_schema=p._dashboard_response_schema(answers,revising=True)["properties"]["panels"]
+print(json.dumps({"count":len(plan["panels"]),"titles":[item["title"] for item in plan["panels"]],"last_chart":plan["panels"][-1]["chart"],"clarification_zero_bound":observed_schema.get("maxItems")==0,"panel_bounds":[panel_schema.get("minItems"),panel_schema.get("maxItems")]},ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    count: 7,
+    titles: ['分析1', '分析2', '分析3', '分析4', '分析5', '分析6', 'サイト内3ページ回遊'],
+    last_chart: 'sankey',
+    clarification_zero_bound: false,
+    panel_bounds: [null, null],
+  });
+});
+
+test('Sankey permits one page attribute in source and target roles without weakening other charts', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+period={"from":"20210101","to":"20210131","label":"2021年1月"}
+def raw(chart):return {
+ "objective_summary":"サイト内行動を判断する","audience":"責任者","comparison":"回遊比較",
+ "hypotheses":["回遊経路に偏りがある"],"clarifications":[],"panels":[{
+  "title":"3ページ回遊","kpi":"セッション数","chart":chart,"decision":"主要経路を判断する",
+  "reason":"回遊を確認するため","execution_prompt":"2021年1月のページからページへの3段階のセッション数を集計する",
+  "dimensions":["ページ","ページ"],"measures":["セッション数"],"layout_row":1,"layout_weight":1,
+ }]}
+answers={"audience":"責任者","comparison":"回遊比較","business_goal":"エンゲージメント改善"}
+accepted=p.normalize_dashboard_plan(raw("sankey"),"2021年1月のサイト内行動を分析する",period,answers)
+try:p.normalize_dashboard_plan(raw("heatmap"),"2021年1月のサイト内行動を分析する",period,answers)
+except p.PlannerError as error:other_error=str(error)
+print(json.dumps({"dimensions":accepted["panels"][0]["dimensions"],"other_error":other_error},ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    dimensions: ['ページ', 'ページ'],
+    other_error: '分析計画の区分軸に重複があります。',
   });
 });
 
@@ -111,7 +323,7 @@ spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)}
 p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
 initial=p._dashboard_response_schema({})["properties"]["panels"]
 revision=p._dashboard_response_schema({},revising=True)["properties"]["panels"]
-print(json.dumps({"initial":p.INITIAL_PANEL_COUNT,"maximum":p.MAX_PANEL_COUNT,"initial_schema":[initial["minItems"],initial["maxItems"]],"revision_schema":[revision["minItems"],revision["maxItems"]]},ensure_ascii=False))`,
+print(json.dumps({"initial":p.INITIAL_PANEL_COUNT,"maximum":p.MAX_PANEL_COUNT,"initial_schema":[initial["minItems"],initial["maxItems"]],"revision_schema":[revision.get("minItems"),revision.get("maxItems")]},ensure_ascii=False))`,
     ],
     {
       cwd: ROOT,
@@ -128,7 +340,7 @@ print(json.dumps({"initial":p.INITIAL_PANEL_COUNT,"maximum":p.MAX_PANEL_COUNT,"i
     initial: 5,
     maximum: 15,
     initial_schema: [5, 5],
-    revision_schema: [1, 15],
+    revision_schema: [null, null],
   });
   for (const [initial, maximum, error] of [
     ['0', '20', 'ANALYSIS_INITIAL_PANEL_COUNT must be a positive integer'],
@@ -148,6 +360,27 @@ print(json.dumps({"initial":p.INITIAL_PANEL_COUNT,"maximum":p.MAX_PANEL_COUNT,"i
   }
 });
 
+test('planner has no fixed organization context or keyword-based revision mode', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+request=p.dashboard_planning_request("目的",{"label":"2021年1月"},"指標定義",{},current_plan={"objective_summary":"目的","audience":"責任者","comparison":"月内","hypotheses":[],"panels":[]},instruction="既存仕様を維持し、流入別も必要です")
+print(json.dumps({"fixed_context":hasattr(p,"ORGANIZATION_CONTEXT") or "demo-org-ec-v1" in request,"revision_heuristic":hasattr(p,"_is_add_only_instruction"),"returns_complete":"変更後の分析仕様をpanelsへすべて返す" in request},ensure_ascii=False))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    fixed_context: false,
+    revision_heuristic: false,
+    returns_complete: true,
+  });
+});
+
 test('dashboard revisions preserve current specifications and accept add/change/delete instructions', () => {
   const result = spawnSync(
     'python3',
@@ -163,7 +396,7 @@ class GenerateContentConfig:
 genai.types=types.SimpleNamespace(GenerateContentConfig=GenerateContentConfig)
 google.genai=genai;sys.modules["google"]=google;sys.modules["google.genai"]=genai
 period={"from":"20210101","to":"20210131","label":"2021年1月"}
-def panel(index):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分別に出して"}
+def panel(index):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分別に出して","dimensions":["区分"],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
 raw={"objective_summary":"購入課題を判断する","audience":"責任者","comparison":"月内比較","hypotheses":["差がある"],"clarifications":[],"panels":[panel(index) for index in range(1,7)]}
 plan=p.normalize_dashboard_plan(raw,"2021年1月の購入課題を分析するダッシュボードを作って",period,{"audience":"責任者"})
 request=p.dashboard_planning_request(plan["objective"],period,"指標定義",plan["answers"],current_plan=plan,instruction="流入別パネルを追加し、分析2を変更して分析3を削除して")
@@ -176,7 +409,7 @@ class Models:
 try:p.propose_dashboard(types.SimpleNamespace(models=Models()),"test-model",plan["objective"],period,"指標定義",plan["answers"],current_plan=plan,instruction="流入別パネルを追加して")
 except p.PlannerError as error:errors.append(str(error))
 mixed,_usage=p.propose_dashboard(types.SimpleNamespace(models=Models()),"test-model",plan["objective"],period,"指標定義",plan["answers"],current_plan=plan,instruction="流入別を追加して分析3を削除して")
-print(json.dumps({"current_specs":all(value in request for value in ["現在の分析仕様","分析1","2021年1月の指標1を区分別に出して"]),"instruction":"流入別パネルを追加" in request,"operations":all(value in request for value in ["追加・変更・削除相談","明示されていない既存パネルは維持","1〜20件"]),"fixed_ids":any(panel_id in request for panel_id in p.PANEL_CATALOG),"mixed_allowed":len(mixed["panels"])==6,"errors":errors},ensure_ascii=False))`,
+print(json.dumps({"current_specs":all(value in request for value in ["現在の分析仕様","分析1","2021年1月の指標1を区分別に出して"]),"instruction":"流入別パネルを追加" in request,"operations":all(value in request for value in ["追加・変更・削除相談","変更後の分析仕様をpanelsへすべて返す","1〜20件"]),"fixed_ids":any(panel_id in request for panel_id in ["R4","R11","R12","R9","R16","R17"]),"mixed_allowed":len(mixed["panels"])==6,"errors":errors},ensure_ascii=False))`,
     ],
     { cwd: ROOT, encoding: 'utf8' },
   );
@@ -190,7 +423,6 @@ print(json.dumps({"current_specs":all(value in request for value in ["現在の�
     errors: [
       '現在案と変更依頼は一緒に指定してください。',
       '現在案と変更依頼は一緒に指定してください。',
-      '追加依頼に対して分析パネルが追加されませんでした。',
     ],
   });
 });
@@ -283,12 +515,13 @@ class GenerateContentConfig:
 genai.types=types.SimpleNamespace(GenerateContentConfig=GenerateContentConfig)
 google.genai=genai;sys.modules["google"]=google;sys.modules["google.genai"]=genai
 period={"from":"20210101","to":"20210131","label":"2021年1月"}
+def panel(index):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":"目的に必要","execution_prompt":f"2021年1月の指標{index}を1行で出す","dimensions":[],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
 base={
  "objective_summary":"購入成果の阻害箇所を特定して優先施策を決める",
  "audience":"月次マーケティング会議",
  "comparison":"月内の日次推移とファネル段階",
  "hypotheses":["商品閲覧からカート追加への減少が大きい"],
- "panels":[{"id":panel_id,"reason":"目的に必要"} for panel_id in ["R4","R9","R16","R17"]],
+ "panels":[panel(index) for index in range(1,7)],
 }
 responses=[
  {**base,"clarifications":[{"field":"channel","question":"流入は","recommended_answer":"organic"}]},
@@ -318,7 +551,7 @@ answer_sets=[
  {"audience":"月次マーケティング会議","comparison":"前月","business_goal":"購入成果改善"},
 ]
 for answers in answer_sets:
- try:p.propose(client,"test-model","目的",period,"指標定義",answers)
+ try:p.propose_dashboard(client,"test-model","目的",period,"指標定義",answers)
  except p.PlannerError as error:errors.append(str(error))
 print(json.dumps({"calls":calls,"schemas":schemas,"errors":errors},ensure_ascii=False))`,
     ],
@@ -374,7 +607,7 @@ raw={
  "comparison":"月内の日次推移",
  "hypotheses":["購入導線に減少箇所がある"],
  "clarifications":[],
- "panels":[{"id":panel_id,"reason":"目的に必要"} for panel_id in ["R4","R9","R16","R17"]],
+ "panels":[{"title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":"目的に必要","execution_prompt":f"2021年1月の指標{index}を1行で出す","dimensions":[],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1} for index in range(1,7)],
 }
 usage=[
  types.SimpleNamespace(prompt_token_count=10,candidates_token_count=5,thoughts_token_count=7),
@@ -389,9 +622,9 @@ class Models:
 client=types.SimpleNamespace(models=Models())
 period={"from":"20210101","to":"20210131","label":"2021年1月"}
 answers={"audience":"月次マーケティング会議"}
-first=p.propose(client,"test-model","目的",period,"指標定義",answers)[1]
-legacy=p.propose(client,"test-model","目的",period,"指標定義",answers)[1]
-print(json.dumps({"calls":calls,"first":first,"legacy":legacy},ensure_ascii=False))`,
+first=p.propose_dashboard(client,"test-model","目的",period,"指標定義",answers)[1]
+without_thoughts=p.propose_dashboard(client,"test-model","目的",period,"指標定義",answers)[1]
+print(json.dumps({"calls":calls,"first":first,"without_thoughts":without_thoughts},ensure_ascii=False))`,
     ],
     { cwd: ROOT, encoding: 'utf8' },
   );
@@ -399,11 +632,11 @@ print(json.dumps({"calls":calls,"first":first,"legacy":legacy},ensure_ascii=Fals
   assert.deepEqual(JSON.parse(result.stdout), {
     calls: 2,
     first: { input_tokens: 10, output_tokens: 12 },
-    legacy: { input_tokens: 10, output_tokens: 5 },
+    without_thoughts: { input_tokens: 10, output_tokens: 5 },
   });
 });
 
-test('confirmed plan requires a non-empty answer for every displayed clarification', () => {
+test('confirmed dynamic plan requires a non-empty answer for every displayed clarification', () => {
   const result = spawnSync(
     'python3',
     [
@@ -421,12 +654,12 @@ plan={
  "hypotheses":["導線に課題がある"],
  "clarifications":[{"field":"business_goal","question":"優先する目標は","recommended_answer":"購入件数の改善"}],
  "answers":{},
- "panels":[{"id":panel_id,"reason":"必要"} for panel_id in ["R4","R9","R16","R17"]],
+ "panels":[{"title":"購入規模","kpi":"購入件数","chart":"scorecard","decision":"成果規模を判断する","reason":"基準値に必要","execution_prompt":"2021年1月の購入件数を1行で出す","dimensions":[],"measures":["購入件数"],"layout_row":1,"layout_weight":1}],
 }
 missing=""
-try:p.confirm_plan(plan)
+try:p.confirm_dashboard_plan(plan)
 except p.PlannerError as error:missing=str(error)
-accepted=p.confirm_plan({**plan,"answers":{"business_goal":"購入件数の改善"}})
+accepted=p.confirm_dashboard_plan({**plan,"answers":{"business_goal":"購入件数の改善"}})
 print(json.dumps({"missing":missing,"status":accepted["status"],"answers":accepted["answers"]},ensure_ascii=False))`,
     ],
     { cwd: ROOT, encoding: 'utf8' },
@@ -437,4 +670,29 @@ print(json.dumps({"missing":missing,"status":accepted["status"],"answers":accept
     status: 'confirmed',
     answers: { business_goal: '購入件数の改善' },
   });
+});
+
+test('confirming a selected subset preserves AI layout without inventing replacement rows', () => {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `import importlib.util,json
+spec=importlib.util.spec_from_file_location("planner",${JSON.stringify(PLANNER)})
+p=importlib.util.module_from_spec(spec);spec.loader.exec_module(p)
+period={"from":"20210101","to":"20210131","label":"2021年1月"}
+def panel(index,row):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":"目的に必要","execution_prompt":f"2021年1月の指標{index}を1行で出す","dimensions":[],"measures":[f"指標{index}"],"layout_row":row,"layout_weight":index}
+raw={"objective_summary":"成果を判断する","audience":"責任者","comparison":"月内比較","hypotheses":["差がある"],"clarifications":[],"panels":[panel(1,1),panel(2,2),panel(3,3)]}
+plan=p.normalize_dashboard_plan(raw,"ダッシュボードを作って",period,{"audience":"責任者"})
+plan["panels"]=[plan["panels"][0],plan["panels"][2]]
+confirmed=p.confirm_dashboard_plan(plan)
+print(json.dumps([[item["layout_row"],item["layout_weight"]] for item in confirmed["panels"]]))`,
+    ],
+    { cwd: ROOT, encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [
+    [1, 1],
+    [3, 3],
+  ]);
 });

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -1081,15 +1081,15 @@ class E:
 s=m.create_server("127.0.0.1",0,E());t=threading.Thread(target=s.serve_forever,daemon=True);t.start();base=f"http://127.0.0.1:{s.server_port}"
 question="2021年1月のECサイトで購入成果を改善するため、課題の場所と優先施策を判断できるダッシュボードを作って"
 def plan(reason):
- return {"objective":question,"objective_summary":"購入課題を判断する","audience":"月次会議","comparison":"月内推移","period":m.period_for_question(question),"hypotheses":["購入導線に課題がある"],"clarifications":[],"answers":{"audience":"月次会議"},"panels":[{"id":panel_id,"reason":reason} for panel_id in ["R4","R9","R16","R17"]]}
+ return {"objective":question,"objective_summary":"購入課題を判断する","audience":"月次会議","comparison":"月内推移","period":m.period_for_question(question),"hypotheses":["購入導線に課題がある"],"clarifications":[],"answers":{"audience":"月次会議"},"panels":[{"title":f"分析{index}","kpi":"購入金額","chart":"table","decision":"優先施策を判断する","reason":reason,"execution_prompt":f"2021年1月の商品別購入金額を分析{index}として比較する","dimensions":["商品"],"measures":["購入金額"],"layout_row":(index+3)//4,"layout_weight":1} for index in range(1,21)]}
 def request(analysis_plan):
  data=json.dumps({"question":question,"profile":"ga4","analysis_plan":analysis_plan},ensure_ascii=False).encode()
  req=urllib.request.Request(base+"/api/dashboard",data=data,headers={"content-type":"application/json","origin":base},method="POST")
  return data,req
 try:
- bounded,bounded_req=request(plan("理由"*250))
+ bounded,bounded_req=request(plan("理由"*100))
  accepted=json.loads(urllib.request.urlopen(bounded_req).read().decode())["accepted"]
- oversized,oversized_req=request(plan("理由"*9000))
+ oversized,oversized_req=request(plan("理由"*900))
  oversized_status=0
  try:urllib.request.urlopen(oversized_req)
  except urllib.error.HTTPError as error:oversized_status=error.code
@@ -1113,7 +1113,7 @@ class E:
  def plan(self,_question,_answers,emit,analysis_plan=None,revision_instruction=None):emit({"type":"plan","count":len(analysis_plan["panels"]),"instruction":revision_instruction})
 s=m.create_server("127.0.0.1",0,E());t=threading.Thread(target=s.serve_forever,daemon=True);t.start();base=f"http://127.0.0.1:{s.server_port}"
 question="2021年1月の購入課題を分析するダッシュボードを作って"
-def panel(index):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分別に出して"}
+def panel(index):return {"title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分別に出して","dimensions":["区分"],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
 raw={"objective_summary":"購入課題を判断する","audience":"責任者","comparison":"月内比較","hypotheses":["差がある"],"clarifications":[],"panels":[panel(index) for index in range(1,7)]}
 plan=m.planner.normalize_dashboard_plan(raw,question,m.period_for_question(question),{"audience":"責任者"})
 def request(extra):
@@ -1298,7 +1298,7 @@ test('planning calls Vertex only and preserves AI-authored dashboard panels', ()
   const result = python(`
 import threading
 e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.metrics="metrics";e.client=object();e.lock=threading.Lock()
-def panel(index):return {"id":f"P{index}","title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を1行で出して"}
+def panel(index):return {"id":f"P{index}","title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を1行で出して","dimensions":[],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
 raw={"status":"proposed","objective":"2021年1月の購入成果を改善するダッシュボードを作って","objective_summary":"目的","audience":"責任者","comparison":"月内比較","period":m.period_for_question("2021年1月"),"hypotheses":["仮説"],"clarifications":[],"answers":{"audience":"責任者"},"organization_context_revision":"demo-org-ec-v1","panels":[panel(index) for index in range(1,7)],"revision":"plan-test"}
 calls=[]
 m.planner.propose_dashboard=lambda *_args,**_kwargs:(calls.append("vertex") or (raw,{"input_tokens":10,"output_tokens":5}))
@@ -1321,7 +1321,7 @@ test('planning sends the selected current plan and revision instruction back to 
   const result = python(`
 import threading
 e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.metrics="metrics";e.client=object();e.lock=threading.Lock()
-def panel(index):return {"id":f"P{index}","title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分別に出して"}
+def panel(index):return {"id":f"P{index}","title":f"分析{index}","kpi":f"指標{index}","chart":"bar","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の指標{index}を区分別に出して","dimensions":["区分"],"measures":[f"指標{index}"],"layout_row":(index+1)//2,"layout_weight":1}
 raw={"status":"proposed","objective":"2021年1月の購入成果を改善するダッシュボードを作って","objective_summary":"目的","audience":"責任者","comparison":"月内比較","period":m.period_for_question("2021年1月"),"hypotheses":["仮説"],"clarifications":[],"answers":{"audience":"責任者"},"organization_context_revision":"demo-org-ec-v1","panels":[panel(index) for index in range(1,7)],"revision":"plan-test"}
 calls=[]
 def propose(*_args,**kwargs):
@@ -1340,13 +1340,15 @@ print(json.dumps({"calls":calls,"events":[event["type"] for event in events]},en
 
 test('a confirmed dynamic dashboard plan builds its authored specifications', () => {
   const result = python(`
-def panel(title,chart,prompt):return {"title":title,"kpi":"定義済み指標","chart":chart,"decision":"意思決定","reason":"目的に必要","execution_prompt":prompt}
+def panel(title,chart,prompt,row,weight):
+ dimension=[] if chart=="scorecard" else (["日別"] if chart=="line" else ["medium"] if "medium" in prompt else ["デバイス"])
+ return {"title":title,"kpi":"購入件数","chart":chart,"decision":"意思決定","reason":"目的に必要","execution_prompt":prompt,"dimensions":dimension,"measures":["購入件数"],"layout_row":row,"layout_weight":weight}
 question="2021年1月の購入課題を分析するダッシュボードを作って"
 raw={"objective_summary":"購入課題を判断する","audience":"責任者","comparison":"軸間比較","hypotheses":["差がある"],"clarifications":[],"panels":[
- panel("流入別購入","bar","2021年1月の購入件数をmedium別に出して"),
- panel("日別購入","line","2021年1月の日別購入件数を出して"),
- panel("デバイス別購入","bar","2021年1月の購入件数をデバイス別に出して"),
- panel("購入規模","scorecard","2021年1月の購入件数を出して"),
+ panel("流入別購入","bar","2021年1月の購入件数をmedium別に出して",1,1),
+ panel("日別購入","line","2021年1月の日別購入件数を出して",1,3),
+ panel("デバイス別購入","bar","2021年1月の購入件数をデバイス別に出して",2,1),
+ panel("購入規模","scorecard","2021年1月の購入件数を出して",2,1),
 ]}
 plan=m.planner.normalize_dashboard_plan(raw,question,m.period_for_question(question),{"audience":"責任者"})
 confirmed=m.planner.confirm_dashboard_plan(plan)
@@ -2062,30 +2064,36 @@ import threading
 e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL
 e.spec=json.loads((m.HERE/"report.json").read_text());e.metric_definitions=json.loads((m.HERE/"metrics.json").read_text())
 e.client=e.bq=object();e.lock=threading.Lock();e.latest_dashboard=None
-plan={"objective":"2021年1月の購入成果を改善するダッシュボードを作って","objective_summary":"購入成果の課題を判断する","audience":"月次会議","comparison":"月内推移","period":m.period_for_question("2021年1月"),"hypotheses":["導線に課題がある"],"clarifications":[],"answers":{"audience":"月次会議"},"panels":[{"id":panel_id,"reason":"必要"} for panel_id in ["R4","R9","R16","R17"]]}
-rows={"R4":[[895,123456.0]],"R9":[[100,50,20]],"R16":[["2021-01-31",118380,117000.5]],"R17":[["1. 入口: /","2. /shop",5]]}
-columns={"R4":["購入件数","購入金額"],"R9":["閲覧","カート","購入"],"R16":["日付","セッション数","7日移動平均"],"R17":["source","target","sessions"]}
+panels=[
+ {"title":"購入規模","kpi":"購入成果","chart":"table","decision":"購入成果の規模を判断する","reason":"全体規模が必要","execution_prompt":"2021年1月の購入件数と購入金額を集計する","dimensions":[],"measures":["購入件数","購入金額"],"layout_row":1,"layout_weight":1},
+ {"title":"購入ファネル","kpi":"購入導線","chart":"table","decision":"購入までの減少箇所を判断する","reason":"導線診断が必要","execution_prompt":"2021年1月の閲覧とカートと購入を集計する","dimensions":[],"measures":["閲覧","カート","購入"],"layout_row":1,"layout_weight":1},
+ {"title":"日別推移","kpi":"セッション数","chart":"line","decision":"月内変動を判断する","reason":"変動確認が必要","execution_prompt":"2021年1月の日付別セッション数を集計する","dimensions":["日付"],"measures":["セッション数"],"layout_row":2,"layout_weight":1},
+ {"title":"主要回遊","kpi":"回遊数","chart":"sankey","decision":"主要な遷移を判断する","reason":"回遊確認が必要","execution_prompt":"2021年1月のsourceからtargetへのsessionsを集計する","dimensions":["source","target"],"measures":["sessions"],"layout_row":2,"layout_weight":1},
+]
+plan={"objective":"2021年1月の購入成果を改善するダッシュボードを作って","objective_summary":"購入成果の課題を判断する","audience":"月次会議","comparison":"月内推移","period":m.period_for_question("2021年1月"),"hypotheses":["導線に課題がある"],"clarifications":[],"answers":{"audience":"月次会議"},"panels":panels}
+rows={"P1":[[895,123456.0]],"P2":[[100,50,20]],"P3":[["2021-01-31",118380]],"P4":[["1. 入口: /","2. /shop",5]]}
+columns={"P1":["購入件数","購入金額"],"P2":["閲覧","カート","購入"],"P3":["日付","セッション数"],"P4":["source","target","sessions"]}
 def run_section(section,period,emit,context=None,profile="ga4"):
  emit({"type":"sql","sql":"SELECT value FROM source","sql_sha256":"1"*16,**context})
- emit({"type":"result","columns":columns[section["id"]],"rows":rows[section["id"]],"verification":"matched","verification_label":"照合済み","visualization":section["component"],**context})
+ emit({"type":"result","columns":columns[section["id"]],"rows":rows[section["id"]],"verification":"matched","verification_label":"照合済み","visualization":"funnel" if section["id"]=="P2" else section["component"],**context})
  return .1
 e._run_section=run_section;events=[];e.dashboard(plan["objective"],events.append,plan);bundle=e.latest_dashboard
-raw={"executive_summary":{"text":"追加診断が必要です。","panel_ids":["R4"]},"observations":[{"text":"購入件数は895件です。","panel_ids":["R4"]}],"interpretations":[{"text":"変動があります。","uncertainty":"施策履歴がありません。","panel_ids":["R16"]}],"hypotheses":[{"text":"導線に課題がある可能性があります。","validation":"流入別に検証します。","panel_ids":["R9"]}],"actions":[{"text":"導線を確認します。","owner":"マーケティング責任者","urgency":"次回会議まで","expected_impact":"阻害箇所を特定できます。","next_step":"流入別に比較します。","success_metric":"購入件数","panel_ids":["R4"]}],"limitations":["目標値と施策履歴が未登録です。"]}
+raw={"executive_summary":{"text":"追加診断が必要です。","panel_ids":["P1"]},"observations":[{"text":"購入件数は895件です。","panel_ids":["P1"]}],"interpretations":[{"text":"変動があります。","uncertainty":"施策履歴がありません。","panel_ids":["P3"]}],"hypotheses":[{"text":"導線に課題がある可能性があります。","validation":"流入別に検証します。","panel_ids":["P2"]}],"actions":[{"text":"導線を確認します。","owner":"マーケティング責任者","urgency":"次回会議まで","expected_impact":"阻害箇所を特定できます。","next_step":"流入別に比較します。","success_metric":"購入件数","panel_ids":["P1"]}],"limitations":["目標値と施策履歴が未登録です。"]}
 calls=[]
 m.meeting.generate=lambda _client,_model,current:(calls.append(current["build_revision"]) or (m.meeting.normalize_report(raw,current),{"input_tokens":10,"output_tokens":5}))
 report_events=[];e.meeting_report(bundle["build_revision"],report_events.append)
 error=""
 try:e.meeting_report("build-000000000000",lambda _event:None)
 except m.LiveDemoError as caught:error=str(caught)
-funnel=next(panel for panel in bundle["panels"] if panel["id"]=="R9")
-print(json.dumps({"dashboard_complete":events[-1]["build_revision"],"build":bundle["build_revision"],"plan":bundle["analysis_specification"]["revision"],"organization":bundle["organization_context"]["goal"],"metric":"購入件数" in bundle["metric_definitions"]["metrics"],"result_revision":bundle["panels"][0]["result_revision"],"sql":bundle["panels"][0]["sql_sha256"],"funnel_rate":funnel["derived_metrics"][0]["value"],"report_types":[event["type"] for event in report_events],"report_revision":report_events[-1]["report"]["report_revision"],"citation":report_events[-1]["report"]["observations"][0]["evidence_refs"][0],"calls":calls,"error":error},ensure_ascii=False))
+funnel=next(panel for panel in bundle["panels"] if panel["id"]=="P2")
+print(json.dumps({"dashboard_complete":events[-1]["build_revision"],"build":bundle["build_revision"],"plan":bundle["analysis_specification"]["revision"],"organization":bundle["organization_context"]["objective_summary"],"metric":"購入件数" in bundle["metric_definitions"]["metrics"],"result_revision":bundle["panels"][0]["result_revision"],"sql":bundle["panels"][0]["sql_sha256"],"funnel_rate":funnel["derived_metrics"][0]["value"],"report_types":[event["type"] for event in report_events],"report_revision":report_events[-1]["report"]["report_revision"],"citation":report_events[-1]["report"]["observations"][0]["evidence_refs"][0],"calls":calls,"error":error},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
   assert.equal(output.dashboard_complete, output.build);
   assert.match(output.build, /^build-[0-9a-f]{12}$/);
   assert.match(output.plan, /^plan-[0-9a-f]{12}$/);
-  assert.equal(output.organization, '購入成果を伸ばし、訪問者の継続利用を改善する');
+  assert.equal(output.organization, '購入成果の課題を判断する');
   assert.equal(output.metric, true);
   assert.match(output.result_revision, /^result-[0-9a-f]{12}$/);
   assert.equal(output.sql, '1111111111111111');


### PR DESCRIPTION
## Summary
- remove the fixed organization context, panel catalog, and legacy fixed-plan proposal/confirmation paths
- require complete AI-authored dashboard specifications with explicit dimensions, measures, chart shape, and layout metadata
- validate chart shapes, execution prompts, row limits, and layout constraints before build
- preserve an objective-specific organization context in the confirmed build provenance

## Validation
- make format
- make lint
- make test (286 tests)
- make coverage

## GR-020 size justification
This is one atomic contract migration: the old fixed plan and the new AI-authored plan cannot safely coexist because doing so preserves the fallback behavior being removed. The 743 changed lines across 4 files remain below the 800-line hard limit and include the corresponding contract tests.