### PR TITLE
refactor(demo): honor AI dashboard layout

### DIFF
--- a/spikes/report-generation/live_demo.py
+++ b/spikes/report-generation/live_demo.py
@@ -71,22 +71,30 @@ def dashboard_layout_rows_for_plan(panels: list[dict]) -> list[dict]:
     """Lay out AI-authored panels without encoding any analysis topic."""
     if not panels:
         raise LiveDemoError("ダッシュボード計画にパネルがありません。")
+    grouped: dict[int, list[dict]] = {}
+    for panel in panels:
+        row = panel.get("layout_row")
+        weight = panel.get("layout_weight")
+        if (
+            isinstance(row, bool)
+            or not isinstance(row, int)
+            or row < 1
+            or isinstance(weight, bool)
+            or not isinstance(weight, int)
+            or not 1 <= weight <= 100
+        ):
+            raise LiveDemoError("AIが考察したダッシュボード配置がありません。")
+        grouped.setdefault(row, []).append(panel)
+    row_numbers = list(grouped)
+    if row_numbers != sorted(row_numbers) or any(
+        len(group) > 4 for group in grouped.values()
+    ):
+        raise LiveDemoError("AIが考察したダッシュボード行が描画仕様と一致しません。")
     rows: list[dict] = []
-    index = 0
-    weights = {"scorecard": 40, "bar": 60, "line": 60, "table": 60, "sankey": 100}
-    while index < len(panels):
-        panel = panels[index]
-        if panel.get("chart") == "sankey":
-            group = [panel]
-            index += 1
-        else:
-            group = panels[index : index + 2]
-            if len(group) == 2 and group[1].get("chart") == "sankey":
-                group = group[:1]
-            index += len(group)
-        raw_shares = [weights.get(item.get("chart"), 60) for item in group]
-        total = sum(raw_shares)
-        shares = [round(value * 100 / total, 4) for value in raw_shares]
+    for row_number in row_numbers:
+        group = grouped[row_number]
+        total = sum(item["layout_weight"] for item in group)
+        shares = [round(item["layout_weight"] * 100 / total, 4) for item in group]
         shares[-1] = round(100 - sum(shares[:-1]), 4)
         rows.append(
             {

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -1367,8 +1367,8 @@ print(json.dumps({"period":period["label"],"ids":[item["id"] for item in section
       '2021年1月の購入件数を出して',
     ],
     layouts: [
-      { panel_ids: ['P1', 'P2'], shares: [50, 50] },
-      { panel_ids: ['P3', 'P4'], shares: [60, 40] },
+      { panel_ids: ['P1', 'P2'], shares: [25, 75] },
+      { panel_ids: ['P3', 'P4'], shares: [50, 50] },
     ],
   });
 });
@@ -1452,19 +1452,19 @@ print(json.dumps({"initial":m.planner.INITIAL_PANEL_COUNT,"maximum":m.planner.MA
 
 test('an AI-authored dashboard supports twenty panels without hardcoded topics', () => {
   const result = python(`
-def panel(index):return {"id":f"P{index}","title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の定義済み指標{index}を1行で出して"}
+def panel(index):return {"id":f"P{index}","title":f"分析{index}","kpi":f"指標{index}","chart":"scorecard","decision":f"判断{index}","reason":f"理由{index}","execution_prompt":f"2021年1月の定義済み指標{index}を1行で出して","dimensions":[],"measures":[f"定義済み指標{index}"],"layout_row":(index+3)//4,"layout_weight":((index-1)%4)+1}
 question="2021年1月の購入課題を分析するダッシュボードを作って"
 plan={"period":m.period_for_question(question),"panels":[panel(index) for index in range(1,21)]}
 period,sections=m.dashboard_sections_for_plan(question,plan)
 layout=m.dashboard_layout_rows_for_plan(plan["panels"])
-print(json.dumps({"limit":m.MAX_PLAN_BODY_BYTES,"sections":len(sections),"rows":len(layout),"all_full":all(len(row["panel_ids"])==2 and sum(row["shares"])==100 for row in layout)},ensure_ascii=False))
+print(json.dumps({"limit":m.MAX_PLAN_BODY_BYTES,"sections":len(sections),"rows":len(layout),"all_weighted":all(len(row["panel_ids"])==4 and sum(row["shares"])==100 for row in layout)},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
   assert.deepEqual(JSON.parse(result.stdout), {
     limit: 98304,
     sections: 20,
-    rows: 10,
-    all_full: true,
+    rows: 5,
+    all_weighted: true,
   });
 });
 


### PR DESCRIPTION
## Summary
- remove chart-type width weights from dashboard layout
- group cards strictly by the AI-authored layout_row
- normalize each row using only the AI-authored layout_weight
- reject missing or invalid AI layout metadata instead of inventing a fallback

## Validation
- make format
- make lint
- make test (286 tests)
- make coverage

## Size
- 50 changed lines across 2 files (within GR-020)