### PR TITLE
refactor(demo): remove dashboard build fallback

### DIFF
--- a/spikes/report-generation/live_demo.py
+++ b/spikes/report-generation/live_demo.py
@@ -28,45 +28,6 @@ MAX_BODY_BYTES, MAX_PLAN_BODY_BYTES, MAX_RESULT_ROWS = 4096, 98304, 100
 MAX_DASHBOARD_BODY_BYTES = MAX_PLAN_BODY_BYTES
 SAMPLE_FIRST_DAY = date(2020, 11, 1)
 SAMPLE_LAST_DAY = date(2021, 1, 31)
-DASHBOARD_SECTION_IDS = report.SHOWCASE_IDS
-DASHBOARD_PURPOSES = {
-    "R4": "購入成果の規模を最初に確認する",
-    "R11": "単発訪問だけでなく、ユーザーが定着しているかを確認する",
-    "R12": "訪問中に十分な関与が生まれているかを確認する",
-    "R9": "閲覧から購入までのどこで減少しているかを特定する",
-    "R16": "日々の変動と7日間の基調を分けて確認する",
-    "R17": "主要なページ遷移から回遊上の特徴を確認する",
-}
-DASHBOARD_ROW_TEMPLATES = (
-    (("R4", 50), ("R11", 25), ("R12", 25)),
-    (("R9", 40), ("R17", 60)),
-    (("R16", 100),),
-)
-
-
-def dashboard_layout_rows(panel_ids: list[str]) -> list[dict]:
-    """Return complete rows whose shares always consume the available width."""
-    requested = set(panel_ids)
-    known = {panel_id for row in DASHBOARD_ROW_TEMPLATES for panel_id, _ in row}
-    if len(requested) != len(panel_ids) or not requested <= known:
-        raise LiveDemoError("ダッシュボード行へ未登録または重複したパネルがあります。")
-    rows = []
-    covered = set()
-    for template in DASHBOARD_ROW_TEMPLATES:
-        present = [(panel_id, share) for panel_id, share in template if panel_id in requested]
-        if not present:
-            continue
-        total = sum(share for _, share in present)
-        shares = [round(share * 100 / total, 4) for _, share in present]
-        shares[-1] = round(100 - sum(shares[:-1]), 4)
-        row_ids = [panel_id for panel_id, _ in present]
-        rows.append({"panel_ids": row_ids, "shares": shares})
-        covered.update(row_ids)
-    if covered != requested:
-        raise LiveDemoError("ダッシュボード行に配置できないパネルがあります。")
-    return rows
-
-
 def dashboard_layout_rows_for_plan(panels: list[dict]) -> list[dict]:
     """Lay out AI-authored panels without encoding any analysis topic."""
     if not panels:
@@ -806,35 +767,6 @@ def section_for_question(spec: dict, question: str) -> dict:
     }
 
 
-def dashboard_sections(
-    spec: dict, question: str, panel_ids: list[str] | None = None
-) -> tuple[dict[str, str], list[dict]]:
-    """Expand one concrete dashboard request into the validated showcase analyses."""
-    report.select_sections(spec, question)
-    if "ダッシュボード" not in question:
-        raise LiveDemoError("依頼に「ダッシュボード」を含めてください。")
-    period = period_for_question(question)
-    sections = report.select_sections(spec, None, showcase=True)
-    if tuple(section["id"] for section in sections) != DASHBOARD_SECTION_IDS:
-        raise LiveDemoError("ダッシュボード分析定義の構成が一致しません。")
-    if panel_ids is not None:
-        if len(panel_ids) != len(set(panel_ids)) or not 4 <= len(panel_ids) <= 6:
-            raise LiveDemoError("確定した分析パネルは重複なしの4〜6件にしてください。")
-        by_id = {section["id"]: section for section in sections}
-        if any(panel_id not in by_id for panel_id in panel_ids):
-            raise LiveDemoError("確定した分析計画に未登録のパネルがあります。")
-        sections = [by_id[panel_id] for panel_id in panel_ids]
-    month_pattern = re.compile(r"\d{4}年\s*\d{1,2}月")
-    for section in sections:
-        section["text"] = month_pattern.sub(period["label"], section["text"], count=1)
-        section["purpose"] = DASHBOARD_PURPOSES[section["id"]]
-        # Registered reference SQL is fixed to January 2021. Other available
-        # sample months can execute, but cannot be labelled reference-verified.
-        if period["from"] != "20210101" or period["to"] != "20210131":
-            section["verification"] = "execution"
-    return period, sections
-
-
 def dashboard_sections_for_plan(question: str, plan: dict) -> tuple[dict, list[dict]]:
     """Turn AI-authored analysis specifications into guarded generation sections."""
     if "ダッシュボード" not in question:
@@ -886,11 +818,6 @@ def dashboard_sections_for_plan(question: str, plan: dict) -> tuple[dict, list[d
             f"確定した分析パネルは1〜{planner.MAX_PANEL_COUNT}件にしてください。"
         )
     return period, sections
-
-
-def confirm_dashboard_analysis_plan(plan: dict) -> dict:
-    """Freeze only a complete AI-authored dashboard specification."""
-    return planner.confirm_dashboard_plan(plan)
 
 
 def require_sql_period(sql: str, period: dict[str, str]) -> None:
@@ -1286,43 +1213,24 @@ class LiveQueryEngine:
         cancel_event = self._begin_operation(request_id)
         try:
             self.latest_dashboard = None
-            try:
-                confirmed = (
-                    confirm_dashboard_analysis_plan(analysis_plan) if analysis_plan else None
+            if analysis_plan is None:
+                raise LiveDemoError(
+                    "AIが作成した分析仕様を確定してからbuildしてください。"
                 )
+            try:
+                confirmed = planner.confirm_dashboard_plan(analysis_plan)
             except planner.PlannerError as error:
                 raise LiveDemoError(str(error)) from error
-            dynamic_plan = bool(
-                confirmed
-                and all("execution_prompt" in panel for panel in confirmed["panels"])
-            )
-            if dynamic_plan:
-                period, sections = dashboard_sections_for_plan(question, confirmed)
-                layout_rows = dashboard_layout_rows_for_plan(confirmed["panels"])
-            else:
-                panel_ids = (
-                    [panel["id"] for panel in confirmed["panels"]]
-                    if confirmed
-                    else None
-                )
-                period, sections = dashboard_sections(self.spec, question, panel_ids)
-                layout_rows = dashboard_layout_rows(
-                    [section["id"] for section in sections]
-                )
-                if confirmed and confirmed["period"] != period:
-                    raise LiveDemoError(
-                        "確定した分析仕様の対象期間が依頼文と一致しません。"
-                    )
+            period, sections = dashboard_sections_for_plan(question, confirmed)
+            layout_rows = dashboard_layout_rows_for_plan(confirmed["panels"])
             emit(
                 {
                     "type": "dashboard_plan",
                     "period": period["label"],
-                    "plan_revision": confirmed["revision"] if confirmed else "legacy-demo",
-                    "organization_context_revision": (
-                        confirmed["organization_context_revision"]
-                        if confirmed
-                        else "not-attached"
-                    ),
+                    "plan_revision": confirmed["revision"],
+                    "organization_context_revision": confirmed[
+                        "organization_context_revision"
+                    ],
                     "panels": [
                         {
                             "id": section["id"],
@@ -1381,9 +1289,7 @@ class LiveQueryEngine:
                         + hashlib.sha256(result_canonical.encode()).hexdigest()[:12]
                     )
                     evidence_panels.append(evidence)
-            bundle = None
-            if confirmed:
-                bundle = {
+            bundle = {
                     "plan_revision": confirmed["revision"],
                     "organization_context_revision": confirmed[
                         "organization_context_revision"
@@ -1399,18 +1305,18 @@ class LiveQueryEngine:
                     },
                     "metric_definitions": self.metric_definitions,
                     "panels": evidence_panels,
-                }
-                canonical = json.dumps(bundle, ensure_ascii=False, sort_keys=True)
-                bundle["build_revision"] = (
-                    "build-" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
-                )
-                self.latest_dashboard = bundle
+            }
+            canonical = json.dumps(bundle, ensure_ascii=False, sort_keys=True)
+            bundle["build_revision"] = (
+                "build-" + hashlib.sha256(canonical.encode()).hexdigest()[:12]
+            )
+            self.latest_dashboard = bundle
             emit(
                 {
                     "type": "dashboard_complete",
                     "panel_count": len(sections),
                     "cost_jpy": round(total_cost, 3),
-                    "build_revision": bundle["build_revision"] if bundle else None,
+                    "build_revision": bundle["build_revision"],
                 }
             )
         finally:
@@ -1760,23 +1666,10 @@ class LiveDemoHandler(BaseHTTPRequestHandler):
             elif self.path == "/api/dashboard":
                 if profile != "ga4":
                     raise ValueError("dashboard mode currently supports only ga4")
-                confirmed = (
-                    confirm_dashboard_analysis_plan(analysis_plan)
-                    if analysis_plan
-                    else None
-                )
-                if confirmed and all(
-                    "execution_prompt" in panel for panel in confirmed["panels"]
-                ):
-                    dashboard_sections_for_plan(question, confirmed)
-                else:
-                    dashboard_sections(
-                        self.engine.spec,
-                        question,
-                        [panel["id"] for panel in confirmed["panels"]]
-                        if confirmed
-                        else None,
-                    )
+                if analysis_plan is None:
+                    raise ValueError("analysis_plan is required")
+                confirmed = planner.confirm_dashboard_plan(analysis_plan)
+                dashboard_sections_for_plan(question, confirmed)
             elif requires_analysis_consultation(question):
                 raise ValueError(
                     "分析内容が具体化されていません。相談から分析候補を選び、"

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -720,96 +720,6 @@ print(json.dumps({"values":values,"errors":errors},ensure_ascii=False))
   });
 });
 
-test('one dashboard request expands to the six validated analyses for its month', () => {
-  const result = python(`
-spec=json.loads((m.HERE/"report.json").read_text())
-period,sections=m.dashboard_sections(spec,"2020年12月のECサイト分析ダッシュボードを作って")
-error=""
-try:
- m.dashboard_sections(spec,"2021年1月のECサイト分析をして")
-except m.LiveDemoError as caught:
- error=str(caught)
-print(json.dumps({"period":period,"ids":[s["id"] for s in sections],"requested_month":all(period["label"] in s["text"] for s in sections),"verification":[s["verification"] for s in sections],"purposes":[bool(s["purpose"]) for s in sections],"error":error},ensure_ascii=False))
-`);
-  assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), {
-    period: { from: '20201201', to: '20201231', label: '2020年12月' },
-    ids: ['R4', 'R11', 'R12', 'R9', 'R16', 'R17'],
-    requested_month: true,
-    verification: Array(6).fill('execution'),
-    purposes: Array(6).fill(true),
-    error: '依頼に「ダッシュボード」を含めてください。',
-  });
-});
-
-test('dashboard layout normalizes incomplete and single-card rows to the full width', () => {
-  const result = python(`
-layouts=m.dashboard_layout_rows(["R4","R11","R9","R16"])
-print(json.dumps(layouts,ensure_ascii=False))
-`);
-  assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), [
-    { panel_ids: ['R4', 'R11'], shares: [66.6667, 33.3333] },
-    { panel_ids: ['R9'], shares: [100] },
-    { panel_ids: ['R16'], shares: [100] },
-  ]);
-});
-
-test('dashboard engine streams six generated panels without paid dependencies', () => {
-  const result = python(`
-import threading
-from datetime import date
-e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL
-e.spec=json.loads((m.HERE/"report.json").read_text());e.rules="";e.client=e.bq=object();e.lock=threading.Lock()
-generated=[];executed=[]
-results={
- "R4": ([(895,57350)],["purchases","revenue"]),
- "R11": ([(14.56,)],["repeat_rate"]),
- "R12": ([(49.51,)],["engagement_seconds"]),
- "R9": ([(23105,4537,1115)],["viewed","carted","purchased"]),
- "R16": ([(date(2020,12,1),100,90.0)],["day","sessions","moving_average"]),
- "R17": ([("1. 入口: /","2. /shop",20)],["source","target","sessions"]),
-}
-def generate(_client,_model,section,period,_rules):
- generated.append([section["id"],period["label"]])
- order="ORDER BY value DESC, value, value, value LIMIT 12" if section["id"]=="R17" else "LIMIT 1"
- sql=f"SELECT 1 AS value FROM \`bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*\` WHERE _TABLE_SUFFIX BETWEEN '20201201' AND '20201231' {order} /* {section['id']} */"
- return ({"sql":sql,"reason":"理由","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
-def execute(_bq,sql,**_kwargs):
- section_id=next(section_id for section_id in m.DASHBOARD_SECTION_IDS if f"/* {section_id} */" in sql)
- executed.append(section_id)
- return (results[section_id],None)
-m.report.generate=generate;m.report.exec_bq=execute
-events=[]
-e.dashboard("2020年12月のECサイト分析ダッシュボードを作って",events.append)
-panel_results=[event for event in events if event["type"]=="result"]
-print(json.dumps({"first":events[0]["type"],"last":events[-1]["type"],"layout":events[0]["layout_rows"],"generated":generated,"executed":executed,"result_ids":[event["panel_id"] for event in panel_results],"visualizations":[event["visualization"] for event in panel_results],"first_columns":panel_results[0]["columns"],"count":events[-1]["panel_count"]},ensure_ascii=False))
-`);
-  assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), {
-    first: 'dashboard_plan',
-    last: 'dashboard_complete',
-    layout: [
-      { panel_ids: ['R4', 'R11', 'R12'], shares: [50, 25, 25] },
-      { panel_ids: ['R9', 'R17'], shares: [40, 60] },
-      { panel_ids: ['R16'], shares: [100] },
-    ],
-    generated: [
-      ['R4', '2020年12月'],
-      ['R11', '2020年12月'],
-      ['R12', '2020年12月'],
-      ['R9', '2020年12月'],
-      ['R16', '2020年12月'],
-      ['R17', '2020年12月'],
-    ],
-    executed: ['R4', 'R11', 'R12', 'R9', 'R16', 'R17'],
-    result_ids: ['R4', 'R11', 'R12', 'R9', 'R16', 'R17'],
-    visualizations: ['kpi_pair', 'scalar', 'scalar', 'funnel', 'trend', 'sankey'],
-    first_columns: ['購入件数', '購入金額'],
-    count: 6,
-  });
-});
-
 test('dashboard result-shape validation fails closed before rendering', () => {
   const result = python(`
 errors=[]
@@ -1014,7 +924,10 @@ try:
  page=urllib.request.urlopen(base+"/").read().decode()
  req=urllib.request.Request(base+"/api/query",data=json.dumps({"question":"2021年1月のセッション数を出して"}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
  value=json.loads(urllib.request.urlopen(req).read().decode())["rows"][0][0]
- dashboard_req=urllib.request.Request(base+"/api/dashboard",data=json.dumps({"question":"2021年1月のECサイト分析ダッシュボードを作って"}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
+ dashboard_question="2021年1月のECサイト分析ダッシュボードを作って"
+ dashboard_raw={"objective_summary":"成果を判断する","audience":"責任者","comparison":"月内比較","hypotheses":["差がある"],"clarifications":[],"panels":[{"title":"購入規模","kpi":"購入件数","chart":"scorecard","decision":"規模を判断する","reason":"基準値が必要","execution_prompt":"2021年1月の購入件数を集計する","dimensions":[],"measures":["購入件数"],"layout_row":1,"layout_weight":1}]}
+ dashboard_plan=m.planner.normalize_dashboard_plan(dashboard_raw,dashboard_question,m.period_for_question(dashboard_question),{"audience":"責任者","comparison":"月内比較","business_goal":"成果改善"})
+ dashboard_req=urllib.request.Request(base+"/api/dashboard",data=json.dumps({"question":dashboard_question,"analysis_plan":dashboard_plan},ensure_ascii=False).encode(),headers={"content-type":"application/json","origin":base},method="POST")
  dashboard_count=json.loads(urllib.request.urlopen(dashboard_req).read().decode())["panel_count"]
  report_req=urllib.request.Request(base+"/api/report",data=json.dumps({"question":"会議報告案を作って","build_revision":"build-111111111111"}).encode(),headers={"content-type":"application/json","origin":base},method="POST")
  report_revision=json.loads(urllib.request.urlopen(report_req).read().decode())["build_revision"]
@@ -1314,6 +1227,30 @@ print(json.dumps({"calls":calls,"events":[event["type"] for event in events],"id
     ids: ['P1', 'P2', 'P3', 'P4', 'P5', 'P6'],
     period: '2021年1月',
     confirmed: 'confirmed',
+  });
+});
+
+test('dashboard build has no fixed-catalog fallback without an AI-authored plan', () => {
+  const result = python(`
+import inspect,threading
+e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.spec=json.loads((m.HERE/"report.json").read_text());e.rules="";e.client=e.bq=object();e.lock=threading.Lock();e.latest_dashboard=None
+m.report.generate=lambda *_args,**_kwargs:({"sql":"","reason":"unused","undefined_terms":["unused"]},{"input_tokens":1,"output_tokens":1})
+events=[];error=""
+try:e.dashboard("2021年1月のECサイト分析ダッシュボードを作って",events.append)
+except m.LiveDemoError as caught:error=str(caught)
+removed=all(not hasattr(m,name) for name in ["DASHBOARD_PURPOSES","DASHBOARD_ROW_TEMPLATES","dashboard_sections","dashboard_layout_rows","confirm_dashboard_analysis_plan"])
+planner_removed=all(not hasattr(m.planner,name) for name in ["PANEL_CATALOG","planning_request","normalize_plan","propose","confirm_plan"])
+layout_source=inspect.getsource(m.dashboard_layout_rows_for_plan)
+layout_is_ai_authored=all(value not in layout_source for value in ["panel.get('chart')","full_width_charts","weights ="])
+print(json.dumps({"error":error,"events":[event["type"] for event in events],"removed":removed,"planner_removed":planner_removed,"layout_is_ai_authored":layout_is_ai_authored},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    error: 'AIが作成した分析仕様を確定してからbuildしてください。',
+    events: [],
+    removed: true,
+    planner_removed: true,
+    layout_is_ai_authored: true,
   });
 });
 


### PR DESCRIPTION
## Summary
- delete DASHBOARD_PURPOSES, DASHBOARD_ROW_TEMPLATES, and the fixed showcase dashboard expansion
- remove the fixed six-panel build path and its hard-coded layout
- require a confirmed AI-authored plan at both the HTTP boundary and dashboard engine
- fail before SQL generation when no AI-authored plan is provided

## Validation
- make format
- make lint
- make test (284 tests)
- make coverage

## Size
- 272 changed lines across 2 files (within GR-020)