### PR TITLE
feat(demo): preflight AI dashboard SQL

### DIFF
--- a/spikes/report-generation/live_demo.py
+++ b/spikes/report-generation/live_demo.py
@@ -926,6 +926,176 @@ def require_sql_period(sql: str, period: dict[str, str]) -> None:
         )
 
 
+def _top_level_select_expressions(sql: str) -> tuple[list[str], str]:
+    """Return the final SELECT expressions and its top-level suffix."""
+    structure = re.sub(
+        r"'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\"|`(?:``|[^`])*`|--[^\n]*|/\*[\s\S]*?\*/",
+        lambda match: " " * len(match.group(0)),
+        sql,
+    )
+    depth = 0
+    depths = []
+    for char in structure:
+        depths.append(depth)
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth = max(0, depth - 1)
+    tokens = [
+        (match.group(0).upper(), match.start(), match.end())
+        for match in re.finditer(r"\b[A-Za-z_][A-Za-z0-9_]*\b", structure)
+        if depths[match.start()] == 0
+    ]
+    selects = [token for token in tokens if token[0] == "SELECT"]
+    if not selects:
+        raise LiveDemoError("生成SQLの最終SELECTを解析できないためBigQueryへ送信しません。")
+    select = selects[-1]
+    following = [token for token in tokens if token[1] > select[2]]
+    boundary = next(
+        (token for token in following if token[0] in {"FROM", "UNION"}),
+        ("END", len(sql), len(sql)),
+    )
+    clause = sql[select[2] : boundary[1]]
+    expressions, start, nested = [], 0, 0
+    for index, char in enumerate(structure[select[2] : boundary[1]]):
+        if char == "(":
+            nested += 1
+        elif char == ")":
+            nested = max(0, nested - 1)
+        elif char == "," and nested == 0:
+            expressions.append(clause[start:index].strip())
+            start = index + 1
+    expressions.append(clause[start:].strip())
+    suffix_chars, nested = [], 0
+    for char in structure[boundary[1] :]:
+        if char == "(":
+            nested += 1
+            suffix_chars.append(" ")
+        elif char == ")":
+            nested = max(0, nested - 1)
+            suffix_chars.append(" ")
+        else:
+            suffix_chars.append(char if nested == 0 else " ")
+    return [expression for expression in expressions if expression], "".join(suffix_chars)
+
+
+def validate_generated_dashboard_sql(section: dict, sql: str) -> None:
+    """Reject SQL that cannot satisfy the confirmed renderer before BigQuery runs."""
+    planned = section.get("planned_visualization")
+    expected = section.get("source_columns")
+    if not planned or not expected:
+        return
+    expressions, suffix = _top_level_select_expressions(sql)
+    aliases = []
+    for expression in expressions:
+        match = re.search(r"\bAS\s+([A-Za-z_][A-Za-z0-9_]*)\s*$", expression, re.I)
+        aliases.append(match.group(1).lower() if match else "")
+    if (
+        len(aliases) != len(expected)
+        or any(not alias for alias in aliases)
+        or len(set(aliases)) != len(aliases)
+    ):
+        observed = "、".join(alias or "別名なし" for alias in aliases)
+        raise LiveDemoError(
+            f"{section['title']}のSQL出力列（{observed}）は、{planned}に必要な"
+            f"{len(expected)}列の一意なASCII別名を満たさないためBigQueryへ送信しません。"
+        )
+    nonnull_columns = section.get("nonnull_metric_columns", [])
+    unsafe_columns = []
+    for column in nonnull_columns:
+        index = expected.index(column)
+        expression = re.sub(
+            r"\bAS\s+[A-Za-z_][A-Za-z0-9_]*\s*$", "", expressions[index], flags=re.I
+        ).strip()
+        if not re.match(
+            r"^(?:(?:COUNT|COUNTIF|COALESCE|IFNULL)\s*\(|"
+            r"(?:CAST|SAFE_CAST)\s*\(\s*(?:COUNT|COUNTIF)\s*\()",
+            expression,
+            re.I,
+        ):
+            unsafe_columns.append(column)
+    if unsafe_columns:
+        raise LiveDemoError(
+            f"{section['title']}のSQL指標列（{'、'.join(unsafe_columns)}）がNULLを"
+            "返し得るためBigQueryへ送信しません。COUNT/COUNTIFを使うか、"
+            "最終SELECT式全体をCOALESCEまたはIFNULLで包んでください。"
+        )
+    max_rows = section.get("max_result_rows")
+    if planned not in {"scorecard", "kpi_group"} and isinstance(max_rows, int):
+        limit = re.search(r"\bLIMIT\s+([0-9]+)\b", suffix, re.I)
+        if (
+            not re.search(r"\bORDER\s+BY\b", suffix, re.I)
+            or not limit
+            or not 1 <= int(limit.group(1)) <= max_rows
+        ):
+            raise LiveDemoError(
+                f"{section['title']}のSQLに{planned}用のORDER BYとLIMIT "
+                f"{max_rows}以下がないためBigQueryへ送信しません。"
+            )
+    if planned in {"scorecard", "kpi_group"}:
+        aggregate_pattern = re.compile(
+            r"\b(?:COUNT|COUNTIF|SUM|AVG|MIN|MAX|ANY_VALUE|LOGICAL_AND|LOGICAL_OR|APPROX_[A-Z_]+)\s*\(",
+            re.I,
+        )
+        has_aggregate = all(aggregate_pattern.search(expression) for expression in expressions)
+        if (
+            not has_aggregate
+            or re.search(r"\bGROUP\s+BY\b", suffix, re.I)
+            or any(re.search(r"\bOVER\s*\(", expression, re.I) for expression in expressions)
+        ):
+            raise LiveDemoError(
+                f"{section['title']}のSQLが{planned}用の単一集計行になっていないため"
+                "BigQueryへ送信しません。"
+            )
+
+
+def validate_dashboard_dry_run_schema(section: dict, schema: list[tuple[str, str]]) -> None:
+    """Check BigQuery's cost-free dry-run schema against the confirmed renderer."""
+    planned = section.get("planned_visualization")
+    expected = section.get("source_columns")
+    if not planned or not expected:
+        return
+    names = [name.lower() for name, _field_type in schema]
+    types = [field_type.upper() for _name, field_type in schema]
+    numeric = {"INTEGER", "INT64", "FLOAT", "FLOAT64", "NUMERIC", "BIGNUMERIC"}
+    valid = len(names) == len(expected) and all(names) and len(set(names)) == len(names)
+    if planned == "scorecard":
+        valid = valid and types[0] in numeric
+    elif planned == "kpi_group":
+        valid = valid and all(field_type in numeric for field_type in types)
+    elif planned == "bar":
+        valid = valid and types[1] in numeric
+    elif planned in {"grouped_bar", "stacked_bar"}:
+        valid = valid and all(field_type in numeric for field_type in types[1:])
+    elif planned == "line":
+        valid = valid and types[0] in {"DATE", "DATETIME", "TIMESTAMP"} and types[1] in numeric
+    elif planned == "multi_line":
+        valid = (
+            valid
+            and types[0] in {"DATE", "DATETIME", "TIMESTAMP"}
+            and all(field_type in numeric for field_type in types[1:])
+        )
+    elif planned in {"scatter", "bubble"}:
+        valid = valid and all(field_type in numeric for field_type in types[1:])
+    elif planned == "funnel":
+        valid = valid and types[1] in numeric
+    elif planned == "heatmap":
+        valid = valid and types[2] in numeric
+    elif planned == "sankey":
+        valid = valid and types[:2] == ["STRING", "STRING"] and types[2] in numeric
+    elif planned == "table":
+        dimension_count = section.get("dimension_count", 0)
+        valid = valid and all(
+            field_type in numeric for field_type in types[dimension_count:]
+        )
+    if not valid:
+        observed = "、".join(f"{name}:{field_type}" for name, field_type in schema)
+        raise LiveDemoError(
+            f"{section['title']}のdry run出力（{observed}）が{planned}の描画仕様と"
+            "一致しないためBigQueryを実行しません。"
+        )
+
+
 def require_deterministic_navigation_order(sql: str, navigation_depth: int = 3) -> None:
     """Require a stable top-12 journey order before executing navigation SQL."""
 
@@ -1555,6 +1725,94 @@ class LiveQueryEngine:
                         )
         except ValueError as error:
             raise LiveDemoError(str(error)) from error
+        if section.get("source_columns"):
+            send(
+                {
+                    "type": "stage",
+                    "stage": "validate",
+                    "message": "描画仕様とBigQuery dry runの出力schemaを照合中です。",
+                }
+            )
+            analysis_request = (
+                bitcoin.generation_request(section, period)
+                if profile == "bitcoin"
+                else report.generation_request(section, period)
+            )
+            repair_used = False
+            while True:
+                diagnostic = ""
+                try:
+                    validate_generated_dashboard_sql(section, normalized)
+                except LiveDemoError as validation_error:
+                    diagnostic = str(validation_error)
+                if not diagnostic:
+                    dry_schema, dry_error = report.inspect_bq_schema(
+                        self.bq, normalized, allowed_dataset=allowed_dataset
+                    )
+                    if dry_error:
+                        if not report.repairable_dry_run_error(dry_error):
+                            raise LiveDemoError(
+                                f"BigQuery dry runに失敗しました: {dry_error}"
+                            )
+                        diagnostic = dry_error
+                    else:
+                        assert dry_schema is not None
+                        try:
+                            validate_dashboard_dry_run_schema(section, dry_schema)
+                        except LiveDemoError as validation_error:
+                            diagnostic = str(validation_error)
+                if not diagnostic:
+                    break
+                if repair_used:
+                    raise LiveDemoError(
+                        "SQL担当AIで1回修正しましたが、実行前診断を解消できなかったため"
+                        f"実行しません: {diagnostic}"
+                    )
+                send(
+                    {
+                        "type": "stage",
+                        "stage": "repair",
+                        "message": "実行前診断をもとにSQLを1回修正中です。",
+                    }
+                )
+                repaired, repair_usage = report.repair(
+                    self.client,
+                    self.model,
+                    analysis_request,
+                    normalized,
+                    diagnostic,
+                    self.bitcoin_rules if profile == "bitcoin" else self.rules,
+                )
+                cost += (
+                    repair_usage["input_tokens"] * report.PRICING[self.model][0]
+                    + repair_usage["output_tokens"] * report.PRICING[self.model][1]
+                ) / 1e6 * report.USD_JPY
+                repaired_sql = (repaired.get("sql") or "").strip()
+                if not repaired_sql:
+                    reason = (repaired.get("reason") or "").strip()
+                    detail = f" 理由: {reason}" if reason else ""
+                    raise LiveDemoError(
+                        "SQL担当AIが実行前診断を解消できなかったため実行しません。"
+                        + detail
+                    )
+                normalized, validation_error = report.validate_sql(
+                    repaired_sql, allowed_dataset
+                )
+                if validation_error:
+                    raise LiveDemoError(
+                        f"修正SQLを安全検査で拒否しました: {validation_error}"
+                    )
+                assert normalized is not None
+                try:
+                    if profile == "bitcoin":
+                        normalized = bitcoin.quote_reserved_hash_identifiers(normalized)
+                        bitcoin.require_sql_period(normalized, period)
+                    else:
+                        require_sql_period(normalized, period)
+                except ValueError as repair_error:
+                    raise LiveDemoError(str(repair_error)) from repair_error
+                answer = repaired
+                repair_used = True
         send(
             {
                 "type": "sql",

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -1343,6 +1343,83 @@ print(json.dumps({"contracts":contracts,"max_pages":m.planned_analysis_section({
   assert.ok(Object.values(output.contracts).every((contract: any) => contract.limit > 0));
 });
 
+test('dashboard SQL and dry-run schema are checked against the AI chart contract', () => {
+  const result = python(`
+panel={"id":"P1","title":"イベント別比較","chart":"grouped_bar","decision":"判断","execution_prompt":"2021年1月を比較","dimensions":["イベント"],"measures":["時間","人数"]}
+section=m.planned_analysis_section(panel)
+tick=chr(96);table=tick+"bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*"+tick
+safe="SELECT event_name AS category, COALESCE(SUM(engagement_time),0) AS metric_1, COUNT(DISTINCT user_pseudo_id) AS metric_2 FROM "+table+" GROUP BY category ORDER BY metric_1 DESC LIMIT 20"
+m.validate_generated_dashboard_sql(section,safe)
+m.validate_dashboard_dry_run_schema(section,[("category","STRING"),("metric_1","INT64"),("metric_2","INT64")])
+errors=[]
+for sql in [
+ "SELECT event_name, COALESCE(SUM(engagement_time),0) AS metric_1, COUNT(*) AS metric_2 FROM "+table+" GROUP BY event_name ORDER BY metric_1 DESC LIMIT 20",
+ "SELECT event_name AS category, SUM(engagement_time) AS metric_1, COUNT(*) AS metric_2 FROM "+table+" GROUP BY category ORDER BY metric_1 DESC LIMIT 20",
+ "SELECT event_name AS category, COALESCE(SUM(engagement_time),0) AS metric_1, COUNT(*) AS metric_2 FROM "+table+" GROUP BY category",
+]:
+ try:m.validate_generated_dashboard_sql(section,sql)
+ except m.LiveDemoError as error:errors.append(str(error))
+try:m.validate_dashboard_dry_run_schema(section,[("category","STRING"),("metric_1","STRING"),("metric_2","INT64")])
+except m.LiveDemoError as error:errors.append(str(error))
+print(json.dumps({"safe":True,"errors":errors},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.safe, true);
+  assert.equal(output.errors.length, 4);
+  assert.match(output.errors[0], /別名なし/);
+  assert.match(output.errors[1], /NULLを返し得る/);
+  assert.match(output.errors[2], /ORDER BYとLIMIT 20以下/);
+  assert.match(output.errors[3], /dry run出力/);
+});
+
+test('dashboard dry-run mismatch is repaired once and still stops before paid execution', () => {
+  const result = python(`
+e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.rules="rules";e.client=e.bq=object()
+section=m.planned_analysis_section({"id":"P1","title":"購入規模","chart":"scorecard","decision":"判断","execution_prompt":"2021年1月の購入件数","dimensions":[],"measures":["購入件数"]})
+tick=chr(96);sql="SELECT COUNT(*) AS metric_value FROM "+tick+"bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*"+tick+" WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131'"
+m.report.generate=lambda *_args,**_kwargs:({"sql":sql,"reason":"集計","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
+repairs=[]
+m.report.repair=lambda *_args,**_kwargs:(repairs.append(True) or ({"sql":sql,"reason":"型を修正できない","undefined_terms":[]},{"input_tokens":1,"output_tokens":1}))
+m.report.inspect_bq_schema=lambda *_args,**_kwargs:([("metric_value","STRING")],None)
+executions=[];m.report.exec_bq=lambda *_args,**_kwargs:(executions.append(True) or (([],[]),None))
+try:e._run_section(section,{"from":"20210101","to":"20210131","label":"2021年1月"},lambda _event:None,{"panel_id":"P1"})
+except m.LiveDemoError as error:message=str(error)
+print(json.dumps({"message":message,"repairs":len(repairs),"executions":executions},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(JSON.parse(result.stdout).message, /1回修正しましたが/);
+  assert.equal(JSON.parse(result.stdout).repairs, 1);
+  assert.deepEqual(JSON.parse(result.stdout).executions, []);
+});
+
+test('a compiler dry-run diagnostic is repaired before paid execution', () => {
+  const result = python(`
+e=object.__new__(m.LiveQueryEngine);e.model=m.report.DEFAULT_MODEL;e.rules="rules";e.client=e.bq=object()
+section=m.planned_analysis_section({"id":"P1","title":"購入規模","chart":"scorecard","decision":"判断","execution_prompt":"2021年1月の購入件数","dimensions":[],"measures":["購入件数"]})
+tick=chr(96);table=tick+"bigquery-public-data.ga4_obfuscated_sample_ecommerce.events_*"+tick
+initial="SELECT COUNT(*) AS metric_value FROM "+table+" WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131'"
+repaired="WITH base AS (SELECT user_pseudo_id FROM "+table+" WHERE _TABLE_SUFFIX BETWEEN '20210101' AND '20210131') SELECT COUNT(*) AS metric_value FROM base"
+m.report.generate=lambda *_args,**_kwargs:({"sql":initial,"reason":"初回","undefined_terms":[]},{"input_tokens":1,"output_tokens":1})
+diagnostics=[]
+m.report.repair=lambda _client,_model,_request,_sql,diagnostic,_rules:(diagnostics.append(diagnostic) or ({"sql":repaired,"reason":"CTEへ修正","undefined_terms":[]},{"input_tokens":1,"output_tokens":1}))
+dry_runs=[]
+def inspect(_bq,sql,**_kwargs):
+ dry_runs.append(sql)
+ return (None,"bq dry-run error: BadRequest: Correlated subqueries are not supported") if len(dry_runs)==1 else ([("metric_value","INT64")],None)
+m.report.inspect_bq_schema=inspect
+executed=[];m.report.exec_bq=lambda _bq,sql,**_kwargs:(executed.append(sql) or (([(12,)], ["metric_value"]),None))
+events=[];e._run_section(section,{"from":"20210101","to":"20210131","label":"2021年1月"},events.append,{"panel_id":"P1"})
+print(json.dumps({"diagnostics":diagnostics,"dry_runs":dry_runs,"executed":executed,"stages":[event.get("stage") for event in events if event["type"]=="stage"]},ensure_ascii=False))
+`);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.match(output.diagnostics[0], /Correlated subqueries/);
+  assert.equal(output.dry_runs.length, 2);
+  assert.deepEqual(output.executed, [output.dry_runs[1]]);
+  assert.deepEqual(output.stages, ['generate', 'validate', 'repair', 'execute']);
+});
+
 test('an AI-authored table remains a table even when its result could be plotted', () => {
   const result = python(`
 section={"title":"流入別の比較表","component":"table","planned_visualization":"table"}


### PR DESCRIPTION
## Summary
- validate AI-generated SQL aliases, metric nullability, ordering, and row limits against the confirmed chart contract
- compare BigQuery dry-run schema with the renderer contract before paid execution
- give compiler/shape diagnostics back to the SQL role for one bounded repair, then fail closed

## Validation
- make format
- make lint
- make test
- make coverage

Part of #374