### PR TITLE
fix(demo): bound dashboard provider schema

### DIFF
--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -19,7 +19,7 @@ updated: 2026-08-15
 | デモ実行状態 | [PR #411](https://github.com/Yukihide-Mitsuoka/repchat/pull/411)はmerge済み。18 chart分岐へ定義済み指標enumを複製してschemaが6,898 bytesから9,319 bytesへ増えた原因を固定応答で再現し、PR #412では指標検証をserver側へ移した。実Vertex AI・BigQueryは再実行していない |
 | 直近完了 | `make format`、`make lint`、`make test-unit`、`make test`は2026-08-15に成功。修正前コードに対する再現テストは9,319 bytesのschemaで失敗し、修正後は成功した |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
-| AIができること | PR #412のCIとreview指摘へ対応する。merge後は無料の固定応答確認まで行える。有料Vertex AI・BigQueryはオーナー承認なしに実行しない |
+| AIができること | PR #412のCI 24件は2026-08-15に成功済み。review指摘へ対応し、merge後は無料の固定応答確認まで行える。有料Vertex AI・BigQueryはオーナー承認なしに実行しない |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |
 | 完了時 | PR #412をmergeし、費用承認が得られた場合だけVertex AIのdashboard相談を1回確認する。その後はIssue #160の証拠を`proceed` / `revise` / `reject`に分類する |
 
@@ -87,7 +87,7 @@ positioningとroadmapを再評価します。
 
 ## 次にやる順序（2026-08-15）
 
-1. **現在:** [PR #412](https://github.com/Yukihide-Mitsuoka/repchat/pull/412)のCIとreviewを完了する。修正前コードで失敗する再現テスト、server側の未定義指標拒否、固定テスト・format・lint・全テストは確認済み。
+1. **現在:** [PR #412](https://github.com/Yukihide-Mitsuoka/repchat/pull/412)はCI 24件が成功済み。reviewを完了してmergeする。修正前コードで失敗する再現テスト、server側の未定義指標拒否、固定テスト・format・lint・全テストは確認済み。
 2. **merge後:** ローカルデモを最新mainから再起動し、無料の固定応答でschema、現在案保持、未定義指標の修正文案を確認する。
 3. **オーナー承認後:** Vertex AIだけを使うdashboard相談を1回確認する。提案を実行する場合は、別の費用確認を経てSQL生成・BigQueryを1件だけ実行する。
 4. **並行するオーナー作業:** [#160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)の参加者を選定して日程を決める。デモ阻害を解消後に5分デモを行い、`proceed` / `revise` / `reject`へ分類する。

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -19,7 +19,7 @@ updated: 2026-08-15
 | デモ実行状態 | [PR #411](https://github.com/Yukihide-Mitsuoka/repchat/pull/411)はmerge済み。18 chart分岐へ定義済み指標enumを複製してschemaが6,898 bytesから9,319 bytesへ増えた原因を固定応答で再現し、PR #412では指標検証をserver側へ移した。実Vertex AI・BigQueryは再実行していない |
 | 直近完了 | `make format`、`make lint`、`make test-unit`、`make test`は2026-08-15に成功。修正前コードに対する再現テストは9,319 bytesのschemaで失敗し、修正後は成功した |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
-| AIができること | PR #412のCI 24件は2026-08-15に成功済み。review指摘へ対応し、merge後は無料の固定応答確認まで行える。有料Vertex AI・BigQueryはオーナー承認なしに実行しない |
+| AIができること | PR #412の必須CIは2026-08-15に成功済み。review指摘へ対応し、merge後は無料の固定応答確認まで行える。有料Vertex AI・BigQueryはオーナー承認なしに実行しない |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |
 | 完了時 | PR #412をmergeし、費用承認が得られた場合だけVertex AIのdashboard相談を1回確認する。その後はIssue #160の証拠を`proceed` / `revise` / `reject`に分類する |
 
@@ -87,7 +87,7 @@ positioningとroadmapを再評価します。
 
 ## 次にやる順序（2026-08-15）
 
-1. **現在:** [PR #412](https://github.com/Yukihide-Mitsuoka/repchat/pull/412)はCI 24件が成功済み。reviewを完了してmergeする。修正前コードで失敗する再現テスト、server側の未定義指標拒否、固定テスト・format・lint・全テストは確認済み。
+1. **現在:** [PR #412](https://github.com/Yukihide-Mitsuoka/repchat/pull/412)は必須CIが成功済み。reviewを完了してmergeする。修正前コードで失敗する再現テスト、server側の未定義指標拒否、固定テスト・format・lint・全テストは確認済み。
 2. **merge後:** ローカルデモを最新mainから再起動し、無料の固定応答でschema、現在案保持、未定義指標の修正文案を確認する。
 3. **オーナー承認後:** Vertex AIだけを使うdashboard相談を1回確認する。提案を実行する場合は、別の費用確認を経てSQL生成・BigQueryを1件だけ実行する。
 4. **並行するオーナー作業:** [#160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)の参加者を選定して日程を決める。デモ阻害を解消後に5分デモを行い、`proceed` / `revise` / `reject`へ分類する。

--- a/docs/development-handoff.md
+++ b/docs/development-handoff.md
@@ -2,7 +2,7 @@
 id: development-handoff
 title: 開発引き継ぎ
 status: active
-updated: 2026-08-12
+updated: 2026-08-15
 ---
 
 # 開発引き継ぎ
@@ -15,13 +15,13 @@ updated: 2026-08-12
 
 | 項目 | 現在地 |
 |------|--------|
-| 作業 | [Issue #374](https://github.com/Yukihide-Mitsuoka/repchat/issues/374) — dashboard plannerの固定6分析依存を外し、AIが作った任意の分析仕様をreview、freeze、SQL生成、描画まで保持する |
-| デモ実行状態 | [PR #375](https://github.com/Yukihide-Mitsuoka/repchat/pull/375)と[PR #376](https://github.com/Yukihide-Mitsuoka/repchat/pull/376)の単一分析相談はmerge済み。Issue #374は固定応答で検証し、実Vertex AIとBigQueryは再実行していない |
-| 直近完了 | [Issue #373](https://github.com/Yukihide-Mitsuoka/repchat/issues/373)の状態付きAI相談、[PR #372](https://github.com/Yukihide-Mitsuoka/repchat/pull/372)の共有可能なdashboard layout revision要件、[PR #365](https://github.com/Yukihide-Mitsuoka/repchat/pull/365)のdashboard閲覧モードはmerge済み |
+| 作業 | [Issue #410](https://github.com/Yukihide-Mitsuoka/repchat/issues/410)の可視化拡張後に発生したdashboard plannerのprovider schema回帰を、[PR #412](https://github.com/Yukihide-Mitsuoka/repchat/pull/412)で修正する |
+| デモ実行状態 | [PR #411](https://github.com/Yukihide-Mitsuoka/repchat/pull/411)はmerge済み。18 chart分岐へ定義済み指標enumを複製してschemaが6,898 bytesから9,319 bytesへ増えた原因を固定応答で再現し、PR #412では指標検証をserver側へ移した。実Vertex AI・BigQueryは再実行していない |
+| 直近完了 | `make format`、`make lint`、`make test-unit`、`make test`は2026-08-15に成功。修正前コードに対する再現テストは9,319 bytesのschemaで失敗し、修正後は成功した |
 | オーナー作業 | 日本の小規模代理店またはソフトウェアベンダーから参加者を1名以上選定し、日程を決める |
-| AIができること | Issue #374のtest、format、lint、reviewを完了し、固定候補一覧が通常plannerへ渡らず、動的分析仕様がfreeze後のSQL生成とlayoutまで保持されることを固定応答で確認する。有料Vertex AI・BigQueryはオーナー承認なしに実行しない |
+| AIができること | PR #412のCIとreview指摘へ対応する。merge後は無料の固定応答確認まで行える。有料Vertex AI・BigQueryはオーナー承認なしに実行しない |
 | 停止条件 | Issue #160の実施結果を`proceed` / `revise` / `reject`に分類するまで製品実装を開始しない。GitHub App、artifact pipeline、#179以降の製品UXを先行実装しない |
-| 完了時 | 証拠を`proceed` / `revise` / `reject`に分類し、Issue #160と[status](status.md)を更新する。方向が変わる場合だけpositioning、ADR、decision logを更新する |
+| 完了時 | PR #412をmergeし、費用承認が得られた場合だけVertex AIのdashboard相談を1回確認する。その後はIssue #160の証拠を`proceed` / `revise` / `reject`に分類する |
 
 ## 最初に読む順序
 
@@ -85,11 +85,11 @@ strict validatorを維持し、生成経路だけで妥当な項目を保持、�
 `#160`が`revise`または`reject`の場合は、上表の製品タスクへ進まず、観測結果に基づいて
 positioningとroadmapを再評価します。
 
-## 次にやる順序（2026-08-12）
+## 次にやる順序（2026-08-15）
 
-1. **現在:** [Issue #374](https://github.com/Yukihide-Mitsuoka/repchat/issues/374)で、AIが作る任意のdashboard分析仕様をreview、追加・変更・削除、freeze、SQL生成、描画まで保持することを固定応答で検証する。実Vertex AI・BigQueryは実行しない。
-2. **UI確認後:** ローカルデモを最新修正から再起動し、現在案を保った再提案、件数境界、可視化別layout、結果形状不一致の拒否を確認する。
-3. **オーナー承認後:** Vertex AIだけを使う相談を「どんな分析をしたらいい？」→「他にない？」の2 turnで確認し、既出案の固定反復ではないことを評価する。提案を実行する場合は、別の費用確認を経てSQL生成・BigQueryを1件だけ実行する。
+1. **現在:** [PR #412](https://github.com/Yukihide-Mitsuoka/repchat/pull/412)のCIとreviewを完了する。修正前コードで失敗する再現テスト、server側の未定義指標拒否、固定テスト・format・lint・全テストは確認済み。
+2. **merge後:** ローカルデモを最新mainから再起動し、無料の固定応答でschema、現在案保持、未定義指標の修正文案を確認する。
+3. **オーナー承認後:** Vertex AIだけを使うdashboard相談を1回確認する。提案を実行する場合は、別の費用確認を経てSQL生成・BigQueryを1件だけ実行する。
 4. **並行するオーナー作業:** [#160](https://github.com/Yukihide-Mitsuoka/repchat/issues/160)の参加者を選定して日程を決める。デモ阻害を解消後に5分デモを行い、`proceed` / `revise` / `reject`へ分類する。
 5. **未完の検証:** [#188](https://github.com/Yukihide-Mitsuoka/repchat/issues/188)はBitcoin 1種類の縦切りと予約語修正まで完了したが、実値照合、独立レビュー、未知・非公開相当2種類の評価が残る。
 6. **製品化前提が整った後:** [#179](https://github.com/Yukihide-Mitsuoka/repchat/issues/179)の閲覧／SQL来歴UX、[#180](https://github.com/Yukihide-Mitsuoka/repchat/issues/180)の非同期・再開可能なbuild、[#181](https://github.com/Yukihide-Mitsuoka/repchat/issues/181)の承認・監査付き報告、[#251](https://github.com/Yukihide-Mitsuoka/repchat/issues/251)の配布artifact定義を各Issueの受入条件で進める。会議パック後の決定・アクション永続化は[会議意思決定ループ要件](requirements/meeting-decision-loop.md)の開始条件に従う。現在mainにある#180/#181はローカル未検証プロトタイプであり、Issue完了ではない。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,18 +19,18 @@ RepChatの開発方向と実施順序を示します。詳細なスコープと�
 2026-08-15時点では、未解消の不具合と検証阻害を先に解消し、その後に以下の順で依頼を選びます。
 各Issueが受入条件の正本であり、この表は開始順序と依存関係だけを管理します。
 
-| 優先 | 段階 | 依頼候補 | 開始条件 |
-|---:|---|---|---|
-| 1 | 検証ゲート | [#160 デザインパートナー検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/160) | 現在。オーナーが参加者を選定し、5分デモ後に`proceed` / `revise` / `reject`を確定する |
-| 2 | 基盤品質 | [#188 未知のnested schema検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/188) | 評価設計は並行可能。製品能力として扱うのは独立レビュー、実値照合、未知・非公開相当2種類の評価に合格した後 |
-| 2 | 製品UX | [#179 ダッシュボード閲覧とSQL来歴の分離](https://github.com/Yukihide-Mitsuoka/repchat/issues/179) | #160=`proceed`。#188とは独立に開始し、閲覧面と監査面のinteraction・認可境界を先に確定する |
-| 3 | 分析契約 | [#180 対話による分析仕様確定](https://github.com/Yukihide-Mitsuoka/repchat/issues/180) | #179のinteractionと#188のschema品質境界が確定した後 |
-| 4 | 保存・共有 | [#371 レイアウトrevisionの保存と共有](https://github.com/Yukihide-Mitsuoka/repchat/issues/371) | #179/#180のdashboard・panel・layout revision契約が確定し、共有需要をdesign partnerで確認した後 |
-| 5 | 意思決定支援 | [#181 根拠付き経営報告とアクション](https://github.com/Yukihide-Mitsuoka/repchat/issues/181) | #180の統制された生成・公開経路と、SQL・結果・根拠のrevision追跡が安定した後 |
-| 6 | 外部連携 | [#345 Action Package API](https://github.com/Yukihide-Mitsuoka/repchat/issues/345) | #181の承認済みaction revisionが安定し、最初の外部consumerを確認した後 |
-| 条件付き | 品質向上 | [#380 AI考察後の根拠付きパネル補強](https://github.com/Yukihide-Mitsuoka/repchat/issues/380) | AI-only plannerのbaselineが代表シナリオで安定し、補強による改善を同一評価セットで比較できる場合だけ |
-| 着手直前 | 本番化 | [#194 課金・認証方式](https://github.com/Yukihide-Mitsuoka/repchat/issues/194) | 課金または本番オンボーディングへ着手する直前。オーナー判断なしにAIが方式を選ばない |
-| リリース前 | リリース | [#251 検証可能なrelease artifact](https://github.com/Yukihide-Mitsuoka/repchat/issues/251) | 配布対象とconsumerを確定し、`make build`またはpublish jobが不変artifactを生成できる時点 |
+| 優先 | 段階 | 依頼候補 | 目的 | 開始・完了条件 |
+|---:|---|---|---|---|
+| 1 | 検証ゲート | [#160 デザインパートナー検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/160) | 現在のAI提案・SQL・dashboardが実利用者の意思決定に使えるか判定する | 現在。オーナーが参加者を選定し、5分デモ後に`proceed` / `revise` / `reject`を確定する |
+| 2 | 基盤品質 | [#188 未知のnested schema検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/188) | GA4・Bitcoinの固定例や固定SQLに依存せず、未知schemaから分析・SQL・描画できる境界を測る | 評価設計は並行可能。独立レビュー、実値照合、未知・非公開相当2種類の反復評価に合格するまで製品能力として扱わない |
+| 2 | 製品UX | [#179 ダッシュボード閲覧とSQL来歴の分離](https://github.com/Yukihide-Mitsuoka/repchat/issues/179) | 一般閲覧面と、SQL・定義・検証・data lineageを確認する監査面を分離する | #160=`proceed`。#188とは独立に開始し、interaction・deep link・認可境界を先に確定する |
+| 3 | 分析契約 | [#180 対話による分析仕様確定](https://github.com/Yukihide-Mitsuoka/repchat/issues/180) | 対話、immutable specification revision、承認、非同期build、再開、公開を製品契約にする | #179のinteractionと#188のschema品質境界が確定した後 |
+| 4 | 保存・共有 | [#371 レイアウトrevisionの保存と共有](https://github.com/Yukihide-Mitsuoka/repchat/issues/371) | AI配置と利用者の幅調整を構造化revisionとして保存・公開し、共有相手に再現する | #179/#180のdashboard・panel・layout revision契約が確定し、共有需要をdesign partnerで確認した後 |
+| 5 | 意思決定支援 | [#181 根拠付き経営報告とアクション](https://github.com/Yukihide-Mitsuoka/repchat/issues/181) | 根拠へ追跡できる判断、施策、担当、成功指標、検証方法を生成し、人間の承認後だけ配布する | #180の統制された生成・公開経路と、SQL・結果・根拠のrevision追跡が安定した後 |
+| 6 | 外部連携 | [#345 Action Package API](https://github.com/Yukihide-Mitsuoka/repchat/issues/345) | 承認済み施策をprovider非依存のJSON packageとして外部systemへ渡し、権限・credential・監査を分析処理から分離する | #181の承認済みaction revisionが安定し、最初の外部consumerを確認した後 |
+| 条件付き | 品質向上 | [#380 AI考察後の根拠付きパネル補強](https://github.com/Yukihide-Mitsuoka/repchat/issues/380) | AI-only計画の後に根拠付き補強候補を任意提示し、固定パネル置換や自動fallbackを行わず品質差を測る | AI-only plannerのbaselineが代表シナリオで安定し、同一評価セットで改善と失敗例を比較できる場合だけ |
+| 着手直前 | 本番化 | [#194 課金・認証方式](https://github.com/Yukihide-Mitsuoka/repchat/issues/194) | 閲覧者・作成者・管理者の課金区分、初期認証方式、利用者管理主体をオーナー判断で確定する | 課金または本番オンボーディングへ着手する直前。オーナー判断なしにAIが方式を選ばない |
+| リリース前 | リリース | [#251 検証可能なrelease artifact](https://github.com/Yukihide-Mitsuoka/repchat/issues/251) | 実行コード、設定、依存関係、検査結果を同じ不変artifactとprovenanceへ結び付ける | 配布対象とconsumerを確定し、`make build`またはpublish jobがattestation対象を生成できる時点 |
 
 同順位の#179と#188は独立した依頼として並行できます。#160が`revise`または`reject`の場合は、
 優先3以降へ進まず、観測結果からpositioningと本ロードマップを再評価します。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
 ---
 id: project-roadmap
 title: プロジェクトロードマップ
-updated: 2026-08-12
-last_reviewed: 2026-08-12
+updated: 2026-08-15
+last_reviewed: 2026-08-15
 ---
 
 # プロジェクトロードマップ
@@ -13,6 +13,38 @@ RepChatの開発方向と実施順序を示します。詳細なスコープと�
 **現時点で何が出来ているか**は[実装状況サマリー](status.md)を参照してください。
 
 更新契機は、フェーズ完了、優先順位変更、スコープ追加・削除です（DOC-040）。
+
+## 次の依頼を選ぶ優先順位
+
+2026-08-15時点では、未解消の不具合と検証阻害を先に解消し、その後に以下の順で依頼を選びます。
+各Issueが受入条件の正本であり、この表は開始順序と依存関係だけを管理します。
+
+| 優先 | 段階 | 依頼候補 | 開始条件 |
+|---:|---|---|---|
+| 1 | 検証ゲート | [#160 デザインパートナー検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/160) | 現在。オーナーが参加者を選定し、5分デモ後に`proceed` / `revise` / `reject`を確定する |
+| 2 | 基盤品質 | [#188 未知のnested schema検証](https://github.com/Yukihide-Mitsuoka/repchat/issues/188) | 評価設計は並行可能。製品能力として扱うのは独立レビュー、実値照合、未知・非公開相当2種類の評価に合格した後 |
+| 2 | 製品UX | [#179 ダッシュボード閲覧とSQL来歴の分離](https://github.com/Yukihide-Mitsuoka/repchat/issues/179) | #160=`proceed`。#188とは独立に開始し、閲覧面と監査面のinteraction・認可境界を先に確定する |
+| 3 | 分析契約 | [#180 対話による分析仕様確定](https://github.com/Yukihide-Mitsuoka/repchat/issues/180) | #179のinteractionと#188のschema品質境界が確定した後 |
+| 4 | 保存・共有 | [#371 レイアウトrevisionの保存と共有](https://github.com/Yukihide-Mitsuoka/repchat/issues/371) | #179/#180のdashboard・panel・layout revision契約が確定し、共有需要をdesign partnerで確認した後 |
+| 5 | 意思決定支援 | [#181 根拠付き経営報告とアクション](https://github.com/Yukihide-Mitsuoka/repchat/issues/181) | #180の統制された生成・公開経路と、SQL・結果・根拠のrevision追跡が安定した後 |
+| 6 | 外部連携 | [#345 Action Package API](https://github.com/Yukihide-Mitsuoka/repchat/issues/345) | #181の承認済みaction revisionが安定し、最初の外部consumerを確認した後 |
+| 条件付き | 品質向上 | [#380 AI考察後の根拠付きパネル補強](https://github.com/Yukihide-Mitsuoka/repchat/issues/380) | AI-only plannerのbaselineが代表シナリオで安定し、補強による改善を同一評価セットで比較できる場合だけ |
+| 着手直前 | 本番化 | [#194 課金・認証方式](https://github.com/Yukihide-Mitsuoka/repchat/issues/194) | 課金または本番オンボーディングへ着手する直前。オーナー判断なしにAIが方式を選ばない |
+| リリース前 | リリース | [#251 検証可能なrelease artifact](https://github.com/Yukihide-Mitsuoka/repchat/issues/251) | 配布対象とconsumerを確定し、`make build`またはpublish jobが不変artifactを生成できる時点 |
+
+同順位の#179と#188は独立した依頼として並行できます。#160が`revise`または`reject`の場合は、
+優先3以降へ進まず、観測結果からpositioningと本ロードマップを再評価します。
+
+## 残課題
+
+将来機能と重複しない、現行経路の品質・検証課題は次のとおりです。
+
+| 優先 | 課題 | 次の完了条件 |
+|---:|---|---|
+| 0 | [#410](https://github.com/Yukihide-Mitsuoka/repchat/issues/410)の可視化拡張後、dashboard plannerのstructured-output schemaがproviderに拒否される | 再現テストで指標enumの重複展開を固定し、定義済み指標の検証をserver側へ移して、固定テスト・format・lint・全テストを通す。実Vertex AI・BigQueryは費用承認なしに再実行しない |
+| 保守時 | [#315 `make doctor` wrapper timeout](https://github.com/Yukihide-Mitsuoka/repchat/issues/315) | 外部I/Oまたは待機条件を特定し、timeout延長や再試行ではなく無外部I/Oの再現テストと原因修正を行う |
+| 再発時 | [#169 serve round-trip flake](https://github.com/Yukihide-Mitsuoka/repchat/issues/169) | 4件同時失敗時の未省略例外を取得し、listener割当・cleanup・並列実行の原因を確定して再現テストを追加する |
+| 費用承認後 | #374/#410で拡張したAI分析計画の実サービス確認 | 固定応答テスト後にVertex AIだけを1回確認し、SQL生成・BigQuery buildは別の費用確認後に1件だけ実行する |
 
 ## 完了：Phase 1の技術基盤と実環境検証
 

--- a/docs/troubleshooting/live-demo.md
+++ b/docs/troubleshooting/live-demo.md
@@ -12,7 +12,8 @@ BigQueryを再実行する前に、画面のエラーと生成済みSQLを確認
 
 ## ダッシュボード相談で「生成または実行に失敗しました。端末ログを確認してください。」と表示される
 
-**Affects:** PR #411の可視化拡張後に、定義済み指標を含むdashboard plannerを実Vertex AIへ送る場合。
+**Affects:** PR #411の可視化拡張後からPR #412の修正前までに、定義済み指標を含むdashboard plannerを
+実Vertex AIへ送る場合。
 
 **Cause:** 18種類の可視化を表す`anyOf`の各分岐へ、同じ定義済み指標enumを複製していました。
 指標7件のGA4契約ではstructured-output schemaが6,898 bytesから9,319 bytesへ増え、providerが
@@ -26,7 +27,8 @@ AI応答の`measures`はserver側で定義済み指標と照合し、未定義�
 含まれた場合にserver側が拒否することを確認します。修正版での実Vertex AI確認は、画面の費用を改めて
 承認した場合だけ1回実行してください。
 
-**Refs:** [Issue #410](https://github.com/Yukihide-Mitsuoka/repchat/issues/410)
+**Refs:** [Issue #410](https://github.com/Yukihide-Mitsuoka/repchat/issues/410)、
+[PR #412](https://github.com/Yukihide-Mitsuoka/repchat/pull/412)
 
 ## 「Google Cloudの認証期限が切れています」で停止する
 

--- a/docs/troubleshooting/live-demo.md
+++ b/docs/troubleshooting/live-demo.md
@@ -2,13 +2,31 @@
 id: troubleshooting-live-demo
 title: ライブデモのトラブルシューティング
 status: active
-updated: 2026-08-10
+updated: 2026-08-15
 ---
 
 # ライブデモのトラブルシューティング
 
 この文書は、`make demo-live`が結果の描画を停止した場合の確認方法を示します。実Vertex AIまたは
 BigQueryを再実行する前に、画面のエラーと生成済みSQLを確認してください。
+
+## ダッシュボード相談で「生成または実行に失敗しました。端末ログを確認してください。」と表示される
+
+**Affects:** PR #411の可視化拡張後に、定義済み指標を含むdashboard plannerを実Vertex AIへ送る場合。
+
+**Cause:** 18種類の可視化を表す`anyOf`の各分岐へ、同じ定義済み指標enumを複製していました。
+指標7件のGA4契約ではstructured-output schemaが6,898 bytesから9,319 bytesへ増え、providerが
+複雑すぎるschemaとして分析計画の生成前に拒否しました。BigQueryは実行されていません。
+
+**Fix:** 可視化ごとのschemaはchartと結果形状だけを制約し、定義済み指標はschema内に1回だけ説明します。
+AI応答の`measures`はserver側で定義済み指標と照合し、未定義指標があれば現在案を保持して再提案文を
+表示します。追加のVertex AI呼出しは自動実行しません。
+
+**Prevention:** 固定応答回帰テストで、可視化分岐へ指標enumを複製しないことと、provider応答に未定義指標が
+含まれた場合にserver側が拒否することを確認します。修正版での実Vertex AI確認は、画面の費用を改めて
+承認した場合だけ1回実行してください。
+
+**Refs:** [Issue #410](https://github.com/Yukihide-Mitsuoka/repchat/issues/410)
 
 ## 「Google Cloudの認証期限が切れています」で停止する
 

--- a/spikes/report-generation/analysis_planner.py
+++ b/spikes/report-generation/analysis_planner.py
@@ -131,7 +131,7 @@ def _defined_metric_names(metrics: str) -> tuple[str, ...]:
 
 
 def _visualization_response_schema(
-    charts: tuple[str, ...], *, seed: str = "", metric_names: tuple[str, ...] = ()
+    charts: tuple[str, ...], *, seed: str = ""
 ) -> dict:
     """Constrain chart and result shape together without prompt heuristics."""
     variants = []
@@ -139,14 +139,6 @@ def _visualization_response_schema(
         min_dimensions, max_dimensions, min_measures, max_measures = (
             CHART_SHAPE_CONTRACTS[chart]
         )
-        measure_items = {"type": "string"}
-        if metric_names:
-            measure_items.update(
-                {
-                    "format": "enum",
-                    "enum": list(_neutral_chart_order(metric_names, seed)),
-                }
-            )
         variants.append(
             {
                 "type": "object",
@@ -166,7 +158,7 @@ def _visualization_response_schema(
                         "type": "array",
                         "minItems": min_measures,
                         "maxItems": max_measures,
-                        "items": measure_items,
+                        "items": {"type": "string"},
                     },
                 },
                 "required": ["chart", "dimensions", "measures"],
@@ -296,10 +288,13 @@ def _dashboard_response_schema(
         DYNAMIC_PLAN_SCHEMA["properties"]["panels"]
     )
     schema["properties"]["panels"]["items"]["properties"]["visualization"] = (
-        _visualization_response_schema(
-            DASHBOARD_CHARTS, seed=seed, metric_names=metric_names
-        )
+        _visualization_response_schema(DASHBOARD_CHARTS, seed=seed)
     )
+    if metric_names:
+        schema["properties"]["panels"]["description"] = (
+            "measuresは次の定義済み指標名だけを使う: "
+            + "、".join(_neutral_chart_order(metric_names, seed))
+        )
     if revising:
         # Vertex can reject otherwise valid structured-output schemas as too
         # complex when a nested array has a long item-count limit. Revisions
@@ -522,6 +517,7 @@ def normalize_dashboard_plan(
     answers: dict[str, str] | None = None,
     *,
     allow_layout_gaps: bool = False,
+    allowed_metrics: tuple[str, ...] = (),
 ) -> dict:
     """Validate model output and produce a deterministic proposed revision."""
     plan = _normalize_plan_header(raw, objective, period, answers)
@@ -549,6 +545,20 @@ def normalize_dashboard_plan(
             allow_role_duplicates=panel["chart"] == "sankey",
         )
         panel["measures"] = _panel_terms(item.get("measures"), "指標", minimum=1)
+        undefined_metrics = [
+            measure
+            for measure in panel["measures"]
+            if allowed_metrics and measure not in allowed_metrics
+        ]
+        if undefined_metrics:
+            raise PlannerError(
+                "AIが指標定義にない指標を生成しました: "
+                + "、".join(undefined_metrics)
+                + "。現在案は保持し、自動再実行していません。",
+                suggested_instruction="指標は定義済みの「"
+                + "」「".join(allowed_metrics)
+                + "」だけを使って再提案して",
+            )
         layout_row = item.get("layout_row")
         layout_weight = item.get("layout_weight")
         if (
@@ -633,6 +643,7 @@ def propose_dashboard(
     from google.genai import types
     from vertex_usage import token_counts
 
+    metric_names = _defined_metric_names(metrics)
     response = client.models.generate_content(
         model=model,
         contents=dashboard_planning_request(
@@ -650,7 +661,7 @@ def propose_dashboard(
                 answers,
                 revising=current_plan is not None,
                 seed=f"{objective}\n{instruction or ''}",
-                metric_names=_defined_metric_names(metrics),
+                metric_names=metric_names,
             ),
         ),
     )
@@ -674,7 +685,7 @@ def propose_dashboard(
             "現在案は保持し、自動再実行していません。"
         ) from error
     return normalize_dashboard_plan(
-        raw, objective, period, answers
+        raw, objective, period, answers, allowed_metrics=metric_names
     ), token_counts(response.usage_metadata)
 
 

--- a/tests/spikes/report-generation/analysis-planner-chart-contract.test.ts
+++ b/tests/spikes/report-generation/analysis-planner-chart-contract.test.ts
@@ -68,21 +68,35 @@ print(json.dumps({"same":first==second,"different":first!=other,"complete":set(f
   });
 });
 
-test('dashboard measures are constrained to defined metrics without fixing analysis content', () => {
+test('defined metrics are validated after generation without expanding every chart schema', () => {
   const result = python(`
 metrics='''指標定義:\n- 指標「セッション数」 = COUNT(*)\n- 指標「購入金額」 = SUM(value)\n- 軸「日付」 = event_date'''
 names=p._defined_metric_names(metrics)
 schema=p._dashboard_response_schema({},seed="依頼A",metric_names=names)
 variants=schema["properties"]["panels"]["items"]["properties"]["visualization"]["anyOf"]
-enums=[item["properties"]["measures"]["items"]["enum"] for item in variants]
-print(json.dumps({"names":names,"same":all(set(values)==set(names) for values in enums),"unknown":any("目標達成度" in values for values in enums)},ensure_ascii=False))
+measure_enums=[item["properties"]["measures"]["items"].get("enum") for item in variants]
+raw={
+ "objective_summary":"目的を確認する","audience":"責任者","comparison":"月内比較",
+ "hypotheses":["指標を比較する"],
+ "clarifications":[{"field":"audience","question":"主な読者は誰ですか","recommended_answer":"責任者"}],
+ "panels":[{
+  "title":"未定義指標","kpi":"目標達成度","chart":"scorecard",
+  "decision":"目標達成度を判断する","reason":"判断に必要",
+  "execution_prompt":"2021年1月の目標達成度を集計する",
+  "dimensions":[],"measures":["目標達成度"],"layout_row":1,"layout_weight":100
+ }]
+}
+error=""
+try:
+ p.normalize_dashboard_plan(raw,"2021年1月のダッシュボードを作る",{"from":"20210101","to":"20210131","label":"2021年1月"},{},allowed_metrics=names)
+except Exception as caught:error=f"{type(caught).__name__}: {caught}"
+print(json.dumps({"schema_bytes":len(json.dumps(schema,ensure_ascii=False,separators=(",",":" )).encode()),"measure_enums":measure_enums,"error":error},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), {
-    names: ['セッション数', '購入金額'],
-    same: true,
-    unknown: false,
-  });
+  const output = JSON.parse(result.stdout);
+  assert.ok(output.schema_bytes < 8000, output.schema_bytes);
+  assert.ok(output.measure_enums.every((value: unknown) => value === null));
+  assert.match(output.error, /指標定義にない指標.*目標達成度/);
 });
 
 test('answered clarification schema avoids the provider-invalid zero item bound', () => {

--- a/tests/spikes/report-generation/analysis-planner-chart-contract.test.ts
+++ b/tests/spikes/report-generation/analysis-planner-chart-contract.test.ts
@@ -70,11 +70,25 @@ print(json.dumps({"same":first==second,"different":first!=other,"complete":set(f
 
 test('defined metrics are validated after generation without expanding every chart schema', () => {
   const result = python(`
-metrics='''指標定義:\n- 指標「セッション数」 = COUNT(*)\n- 指標「購入金額」 = SUM(value)\n- 軸「日付」 = event_date'''
+import sys,types
+google=types.ModuleType("google");genai=types.ModuleType("google.genai")
+class GenerateContentConfig:
+ def __init__(self,**kwargs):self.__dict__.update(kwargs)
+genai.types=types.SimpleNamespace(GenerateContentConfig=GenerateContentConfig)
+google.genai=genai;sys.modules["google"]=google;sys.modules["google.genai"]=genai
+vertex_usage=types.ModuleType("vertex_usage")
+vertex_usage.token_counts=lambda _usage:{"input_tokens":1,"output_tokens":1}
+sys.modules["vertex_usage"]=vertex_usage
+metrics='''指標定義:
+- 指標「セッション数」 = COUNT(*)
+- 指標「ユーザー数」 = COUNT(DISTINCT user_pseudo_id)
+- 指標「閲覧数」 = COUNTIF(event_name = "page_view")
+- 指標「商品閲覧数」 = COUNTIF(event_name = "view_item")
+- 指標「カート追加数」 = COUNTIF(event_name = "add_to_cart")
+- 指標「購入件数」 = COUNTIF(event_name = "purchase")
+- 指標「購入金額」 = SUM(ecommerce.purchase_revenue)
+- 軸「日付」 = event_date'''
 names=p._defined_metric_names(metrics)
-schema=p._dashboard_response_schema({},seed="依頼A",metric_names=names)
-variants=schema["properties"]["panels"]["items"]["properties"]["visualization"]["anyOf"]
-measure_enums=[item["properties"]["measures"]["items"].get("enum") for item in variants]
 raw={
  "objective_summary":"目的を確認する","audience":"責任者","comparison":"月内比較",
  "hypotheses":["指標を比較する"],
@@ -86,10 +100,18 @@ raw={
   "dimensions":[],"measures":["目標達成度"],"layout_row":1,"layout_weight":100
  }]
 }
+captured={}
+class Models:
+ def generate_content(self,**kwargs):
+  captured["schema"]=kwargs["config"].response_schema
+  return types.SimpleNamespace(text=json.dumps(raw,ensure_ascii=False),usage_metadata=object())
 error=""
 try:
- p.normalize_dashboard_plan(raw,"2021年1月のダッシュボードを作る",{"from":"20210101","to":"20210131","label":"2021年1月"},{},allowed_metrics=names)
+ p.propose_dashboard(types.SimpleNamespace(models=Models()),"test-model","2021年1月のダッシュボードを作る",{"from":"20210101","to":"20210131","label":"2021年1月"},metrics,{})
 except Exception as caught:error=f"{type(caught).__name__}: {caught}"
+schema=captured["schema"]
+variants=schema["properties"]["panels"]["items"]["properties"]["visualization"]["anyOf"]
+measure_enums=[item["properties"]["measures"]["items"].get("enum") for item in variants]
 print(json.dumps({"schema_bytes":len(json.dumps(schema,ensure_ascii=False,separators=(",",":" )).encode()),"measure_enums":measure_enums,"error":error},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);

--- a/tests/spikes/report-generation/analysis-planner-chart-contract.test.ts
+++ b/tests/spikes/report-generation/analysis-planner-chart-contract.test.ts
@@ -100,25 +100,46 @@ raw={
   "dimensions":[],"measures":["目標達成度"],"layout_row":1,"layout_weight":100
  }]
 }
+valid={**raw,"panels":[{
+ "title":"定義済み指標","kpi":"セッション数","chart":"scorecard",
+ "decision":"セッション数を判断する","reason":"判断に必要",
+ "execution_prompt":"2021年1月のセッション数を集計する",
+ "dimensions":[],"measures":["セッション数"],"layout_row":1,"layout_weight":100
+}]}
 captured={}
 class Models:
+ def __init__(self):self.responses=[raw,valid]
  def generate_content(self,**kwargs):
   captured["schema"]=kwargs["config"].response_schema
-  return types.SimpleNamespace(text=json.dumps(raw,ensure_ascii=False),usage_metadata=object())
+  return types.SimpleNamespace(text=json.dumps(self.responses.pop(0),ensure_ascii=False),usage_metadata=object())
+client=types.SimpleNamespace(models=Models())
 error=""
+suggestion=""
 try:
- p.propose_dashboard(types.SimpleNamespace(models=Models()),"test-model","2021年1月のダッシュボードを作る",{"from":"20210101","to":"20210131","label":"2021年1月"},metrics,{})
-except Exception as caught:error=f"{type(caught).__name__}: {caught}"
+ p.propose_dashboard(client,"test-model","2021年1月のダッシュボードを作る",{"from":"20210101","to":"20210131","label":"2021年1月"},metrics,{})
+except Exception as caught:
+ error=f"{type(caught).__name__}: {caught}"
+ suggestion=getattr(caught,"suggested_instruction","")
+accepted,_usage=p.propose_dashboard(client,"test-model","2021年1月のダッシュボードを作る",{"from":"20210101","to":"20210131","label":"2021年1月"},metrics,{})
 schema=captured["schema"]
 variants=schema["properties"]["panels"]["items"]["properties"]["visualization"]["anyOf"]
 measure_enums=[item["properties"]["measures"]["items"].get("enum") for item in variants]
-print(json.dumps({"schema_bytes":len(json.dumps(schema,ensure_ascii=False,separators=(",",":" )).encode()),"measure_enums":measure_enums,"error":error},ensure_ascii=False))
+schema_json=json.dumps(schema,ensure_ascii=False,separators=(",",":"))
+description=schema["properties"]["panels"]["description"]
+description_metrics=description.removeprefix("measuresは次の定義済み指標名だけを使う: ").split("、")
+print(json.dumps({"schema_bytes":len(schema_json.encode()),"names":names,"description_metrics":description_metrics,"measure_enums":measure_enums,"error":error,"suggestion":suggestion,"accepted":accepted["panels"][0]["measures"]},ensure_ascii=False))
 `);
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
   assert.ok(output.schema_bytes < 8000, output.schema_bytes);
+  assert.deepEqual(new Set(output.description_metrics), new Set(output.names));
+  assert.equal(output.description_metrics.length, output.names.length);
   assert.ok(output.measure_enums.every((value: unknown) => value === null));
   assert.match(output.error, /指標定義にない指標.*目標達成度/);
+  assert.match(output.suggestion, /セッション数/);
+  assert.match(output.suggestion, /購入金額/);
+  assert.match(output.suggestion, /だけを使って再提案/);
+  assert.deepEqual(output.accepted, ['セッション数']);
 });
 
 test('answered clarification schema avoids the provider-invalid zero item bound', () => {


### PR DESCRIPTION
## What & why

PR #411 repeated the complete defined-metric enum in each of 18 visualization schema branches. With the seven GA4 metrics, the provider schema grew from 6,898 to 9,319 bytes and Vertex AI rejected it before generating a dashboard plan. This change keeps chart/result-shape constraints in the provider schema, validates generated measures against the defined metrics on the server, and consolidates the next-work priority and remaining quality tasks in the roadmap.

Refs: #410

## Change classification (ARC-020)

- [x] Local (inside one module, contract unchanged)
- [ ] Contract (MODULE.md public API / event changed — consumers updated in this PR)
- [ ] Architectural (ADR required — link: )

## Breaking change?

- [x] No
- [ ] Yes — commit carries `!` + `BREAKING CHANGE:` footer; migration notes:

## Testing (GR-021 / TST-002)

- How verified: failing-first commit `cfc8f96` fails against the pre-fix planner with a 9,319-byte schema; after the fix, `make format`, `make lint`, `make test-unit`, and `make test` all exit 0. The regression also verifies that an undefined generated metric is rejected locally without an automatic paid retry.
- Not verified (be honest — GR-042): paid Vertex AI and BigQuery execution were not repeated. The provider-side call requires a separate cost approval; BigQuery is not needed to validate this schema fix.

## Documentation (DOC-030)

- [x] Doc-update matrix checked; updated: `docs/troubleshooting/live-demo.md`, `docs/roadmap.md`, `docs/development-handoff.md`

## AI disclosure

- [x] Authored by AI agent: Fugu worker agent — self-review against `.ai/review-checklist.md` completed
- [ ] Authored by human
- Prompts/context notes (optional, helps reviewers): Kept the provider schema responsible for renderer shape only; moved metric allowlisting to the existing local normalization boundary.

## Self-review checklist (WF-090)

- [x] `make format && make lint && make test` green — output reported above
- [x] Diff within size limits (GR-020) and contains no unrelated changes
- [x] No guardrail violated (`.ai/guardrails.md`)
