### PR TITLE
fix(demo): balance chart layout and ground report numbers

### DIFF
--- a/spikes/report-generation/chart_renderer.js
+++ b/spikes/report-generation/chart_renderer.js
@@ -31,10 +31,11 @@ function standardChartUnit(column) {
   return metricAxisTitle(column);
 }
 
-function standardChartGrid(horizontal = false) {
-  return horizontal
-    ? { left: 156, right: 34, top: 56, bottom: 58, containLabel: true }
+function standardChartGrid(horizontal = false, spacing = {}) {
+  const base = horizontal
+    ? { left: 156, right: 34, top: 70, bottom: 70, containLabel: true }
     : { left: 76, right: 28, top: 56, bottom: 70, containLabel: true };
+  return { ...base, ...spacing };
 }
 
 function standardChartTooltipFormatter(params) {
@@ -60,10 +61,10 @@ function standardChartCategoryAxis(data, axisLabel = {}) {
   };
 }
 
-function standardChartValueAxis(column, position = 'left', offset = 0) {
+function standardChartValueAxis(column, position = 'left', offset = 0, nameOverride) {
   return {
     type: 'value',
-    name: standardChartUnit(column),
+    name: nameOverride ?? standardChartUnit(column),
     nameLocation: 'middle',
     nameGap: position === 'left' || position === 'right' ? 48 : 34,
     nameTextStyle: { fontSize: 11, color: '#475467' },
@@ -93,15 +94,25 @@ function standardBarOption(result, mode) {
   const categories = result.rows.map((row) => String(row[0] ?? ''));
   const units = metricColumns.map((column) => metricUnit(column) || column);
   const unitIndexes = new Map();
-  units.forEach((unit) => {
-    if (!unitIndexes.has(unit)) unitIndexes.set(unit, unitIndexes.size);
+  const unitColumns = [];
+  units.forEach((unit, index) => {
+    if (!unitIndexes.has(unit)) {
+      unitIndexes.set(unit, unitIndexes.size);
+      unitColumns.push({ unit, column: metricColumns[index] });
+    }
   });
-  const multipleUnits = mode === 'grouped' && unitIndexes.size > 1;
-  const axes = multipleUnits
-    ? metricColumns.map((column, index) =>
-        standardChartValueAxis(column, index % 2 === 0 ? 'bottom' : 'top', Math.floor(index / 2) * 24),
-      )
-    : [standardChartValueAxis(metricColumns[0])];
+  const multipleUnits = unitColumns.length > 1;
+  const bottomAxisCount = multipleUnits ? Math.ceil(unitColumns.length / 2) : 1;
+  const topAxisCount = multipleUnits ? Math.floor(unitColumns.length / 2) : 0;
+  const axes = unitColumns.map(({ unit, column }, index) =>
+    standardChartValueAxis(
+      column,
+      index % 2 === 0 ? 'bottom' : 'top',
+      Math.floor(index / 2) * 28,
+      unit || standardChartUnit(column),
+    ),
+  );
+  const canStack = mode === 'stacked' && !multipleUnits;
   const series = metricColumns.map((column, seriesIndex) => {
     const axisIndex = multipleUnits ? unitIndexes.get(units[seriesIndex]) : 0;
     const values = result.rows.map((row) => standardChartNumber(row[seriesIndex + 1]));
@@ -111,38 +122,37 @@ function standardBarOption(result, mode) {
       data: values,
       yAxisIndex: multipleUnits ? axisIndex : undefined,
       xAxisIndex: multipleUnits ? axisIndex : undefined,
-      stack: mode === 'stacked' ? 'total' : undefined,
+      stack: canStack ? 'total' : undefined,
       barMaxWidth: mode === 'grouped' ? 24 : 34,
+      barGap: '30%',
+      barCategoryGap: '28%',
       emphasis: { focus: 'series' },
       label: {
         show: true,
-        position: mode === 'stacked' ? 'inside' : 'right',
+        position: canStack ? 'inside' : 'right',
+        distance: 8,
         formatter: (params) => standardChartFormat(params.value, column),
-        color: mode === 'stacked' ? '#fff' : '#344054',
-        textBorderColor: mode === 'stacked' ? '#344054' : undefined,
-        textBorderWidth: mode === 'stacked' ? 2 : 0,
+        color: canStack ? '#fff' : '#344054',
+        textBorderColor: canStack ? '#344054' : undefined,
+        textBorderWidth: canStack ? 2 : 0,
       },
+      labelLayout: { hideOverlap: true, moveOverlap: 'shiftY' },
     };
   });
   const option = standardChartBase({ horizontal: true, legend: metricColumns.length > 1 });
-  option.grid = standardChartGrid(true);
-  option.xAxis = multipleUnits
-    ? axes.map((axis, index) => ({ ...axis, gridIndex: 0, position: index % 2 === 0 ? 'bottom' : 'top' }))
-    : axes;
+  option.grid = standardChartGrid(true, {
+    top: 62 + topAxisCount * 32,
+    bottom: 62 + bottomAxisCount * 32,
+  });
+  option.xAxis = axes.map((axis) => ({ ...axis, gridIndex: 0 }));
   option.yAxis = standardChartCategoryAxis(categories, {
     width: 132,
     overflow: 'truncate',
     formatter: (value) => standardChartLabel(value, 30),
   });
-  if (multipleUnits) {
-    option.xAxis = metricColumns.map((column, index) => ({
-      ...standardChartValueAxis(column, index % 2 === 0 ? 'bottom' : 'top', Math.floor(index / 2) * 24),
-      gridIndex: 0,
-    }));
-  }
   option.series = series.map((item, index) => ({
     ...item,
-    xAxisIndex: multipleUnits ? index : 0,
+    xAxisIndex: multipleUnits ? unitIndexes.get(units[index]) : 0,
     yAxisIndex: 0,
   }));
   return option;
@@ -330,7 +340,9 @@ function standardChartOption(result) {
 
 function standardChartHeight(result) {
   if (result.visualization === 'bar' || result.visualization === 'grouped_bar' || result.visualization === 'stacked_bar') {
-    return Math.max(300, result.rows.length * (result.visualization === 'grouped_bar' ? 48 : 38) + 120);
+    const units = new Set(result.columns.slice(1).map((column) => metricUnit(column) || column));
+    const axisSpace = units.size > 1 ? 64 : 0;
+    return Math.max(300, result.rows.length * (result.visualization === 'grouped_bar' ? 48 : 38) + 120 + axisSpace);
   }
   if (result.visualization === 'sankey') return 440;
   if (result.visualization === 'calendar_heatmap') return 280;

--- a/spikes/report-generation/live_demo.py
+++ b/spikes/report-generation/live_demo.py
@@ -465,6 +465,9 @@ h1{font-size:26px;line-height:1.25;letter-spacing:-.025em}
 .dashboard-card-resizer:hover::after,.dashboard-card-resizer:focus-visible::after,.dashboard-card-resizer.dragging::after{background:#4b84b4;box-shadow:0 0 0 3px #4b84b426}
 .dashboard-layout-row>.dashboard-card .chart{max-height:460px;overflow:auto}
 @container (max-width:900px){.dashboard-layout-row{grid-template-columns:minmax(0,1fr)!important;gap:14px}.dashboard-layout-row>.dashboard-card{grid-column:1!important;min-height:340px}.dashboard-layout-row>.dashboard-card .chart{max-height:none;overflow:visible}.dashboard-card-resizer{display:none}}
+.dashboard-layout-row>.dashboard-card .chart{display:flex;flex:1;min-height:0;overflow:hidden}
+.dashboard-layout-row>.dashboard-card .echart-root{flex:1 1 auto;height:100%!important;min-height:300px}
+@container (max-width:900px){.dashboard-layout-row>.dashboard-card .chart{overflow:visible}.dashboard-layout-row>.dashboard-card .echart-root{height:auto!important;min-height:260px}}
 .dashboard-card h3{font-size:15px;line-height:1.45;letter-spacing:-.01em}
 .dashboard-card .purpose{min-height:0;margin:9px 0 16px;color:#687386;font-size:11px}
 .panel-state{display:inline-flex;align-items:center;min-height:23px;padding:3px 7px;border-radius:999px;background:var(--color-success-soft);color:var(--color-success);font-size:10px;white-space:nowrap}

--- a/spikes/report-generation/meeting_report.py
+++ b/spikes/report-generation/meeting_report.py
@@ -141,6 +141,13 @@ class ReportError(ValueError):
 
 def report_request(bundle: dict) -> str:
     """Build a Japanese reporting request from one immutable evidence bundle."""
+    indexed = _evidence_index(bundle)
+    allowed_numbers = "、".join(
+        sorted(
+            _evidence_numbers(indexed, list(indexed)),
+            key=lambda value: (Decimal(value.replace(",", "")), value),
+        )
+    )
     return f"""次の確定済みダッシュボードだけを根拠に、月次会議の報告案を書く。
 
 分析仕様revision: {bundle['plan_revision']}
@@ -150,10 +157,12 @@ build revision: {bundle['build_revision']}
 確定済み分析仕様: {json.dumps(bundle['analysis_specification'], ensure_ascii=False)}
 指標定義: {json.dumps(bundle['metric_definitions'], ensure_ascii=False)}
 根拠パネル: {json.dumps(bundle['panels'], ensure_ascii=False)}
+根拠パネルに存在する許可数値（この一覧にない数値は使用禁止）: {allowed_numbers}
 
 規則:
 - 観測、解釈、未検証の仮説、推奨アクションを混ぜない。
-- 数値は根拠パネルの生値、その値を最大小数2桁へ丸めた値、またはderived_metricsに記録された値だけを使い、必ずpanel_idsを付ける。
+- 数値は根拠パネルの生値、その値を小数点以下2桁まで丸めた値、またはderived_metricsに記録された値だけを使い、必ずpanel_idsを付ける。丸めは小数点以下だけに限定し、204を200にするような整数の概算・有効数字化は行わない。
+- 数値を使わずに説明できる場合は定性的に書き、根拠にない閾値・目標値・概数を補わない。
 - 相関を因果と断定せず、解釈には不確実性を、仮説には検証方法を付ける。
 - アクションには期待効果、担当、緊急度、次の一歩、成功指標を付ける。
 - 目標値、事業事情、サンプルサイズを推測しない。不足はlimitationsへ書く。

--- a/tests/spikes/report-generation/live-demo.test.ts
+++ b/tests/spikes/report-generation/live-demo.test.ts
@@ -1470,6 +1470,18 @@ test('standard chart renderer creates ECharts options for every supported chart'
   assert.equal(parsed.donut.series[0].type, 'pie');
   assert.equal(parsed.funnel.series[0].sort, 'none');
   assert.equal(parsed.sankey.series[0].type, 'sankey');
+
+  const grouped = vm.runInNewContext(
+    `${source};standardChartOption({visualization:'grouped_bar',columns:['channel','new_sessions','repeat_sessions','purchases'],rows:[['organic',100,20,3]]})`,
+    {
+      metricUnit: (column: string) => (column.includes('sessions') ? 'セッション' : '件'),
+      metricAxisTitle: (column: string) => column,
+    },
+  ) as Record<string, any>;
+  assert.equal(grouped.xAxis.length, 2, '同じ単位の系列は共有軸にまとめる');
+  assert.equal(JSON.stringify(grouped.series.map((series: any) => series.xAxisIndex)), '[0,0,1]');
+  assert.equal(grouped.series[0].labelLayout.hideOverlap, true);
+  assert.ok(grouped.grid.top > 70 && grouped.grid.bottom > 70);
 });
 
 test('live dashboard loads the standard chart library and renderer', () => {
@@ -1920,6 +1932,14 @@ test('dashboard cards in the same row share height while content stays top-align
   assert.match(
     rendered.stdout,
     /\.dashboard-layout-row>\.dashboard-card \.chart\{[^}]*max-height:460px[^}]*overflow:auto/,
+  );
+  assert.match(
+    rendered.stdout,
+    /\.dashboard-layout-row>\.dashboard-card \.chart\{display:flex;flex:1;min-height:0;overflow:hidden\}/,
+  );
+  assert.match(
+    rendered.stdout,
+    /\.dashboard-layout-row>\.dashboard-card \.echart-root\{flex:1 1 auto;height:100%!important;min-height:300px\}/,
   );
   assert.ok(
     rendered.stdout.indexOf(

--- a/tests/spikes/report-generation/meeting-report.test.ts
+++ b/tests/spikes/report-generation/meeting-report.test.ts
@@ -184,6 +184,8 @@ print(json.dumps({
  "specification":"月内推移" in request,
  "metrics":"取引IDの異なり数" in request,
  "evidence":"result-222222222222" in request,
+ "allowlist":"根拠パネルに存在する許可数値（この一覧にない数値は使用禁止）" in request,
+ "rounding":"204を200にするような整数の概算" in request,
  "impact":"expected_impact" in required,
  "no_warehouse":"BigQuery" not in request,
 },ensure_ascii=False))`);
@@ -193,6 +195,8 @@ print(json.dumps({
     specification: true,
     metrics: true,
     evidence: true,
+    allowlist: true,
+    rounding: true,
     impact: true,
     no_warehouse: true,
   });


### PR DESCRIPTION
## 概要
- 同一単位の棒グラフ系列で軸を共有し、複数単位の軸間隔と値ラベル重なりを改善
- 横並びダッシュボードカードのECharts領域を行高に追従させ、グラフと説明領域のバランスを改善
- 会議報告の数値概算を禁止し、根拠パネル由来の許可数値一覧を生成AIへ提示

## 検証
- `make format && make lint`
- `node --test 'tests/**/*.test.ts'`（285 passed）\n\n## 対応する事象\n- 横棒グラフの軸・凡例・値ラベルの重なり\n- 横並びカードのグラフ領域の高さ不一致\n- 会議報告で根拠にない数値（例: 200）が生成される問題\n\nPRサイズ: 79 additions / 31 deletions